### PR TITLE
Fix for Xcode mem warnings

### DIFF
--- a/Classes/GTRawObject.h
+++ b/Classes/GTRawObject.h
@@ -43,6 +43,9 @@
 - (id)initWithType:(GTObjectType)theType string:(NSString *)string;
 + (id)rawObjectWithType:(GTObjectType)theType string:(NSString *)string;
 
+- (id)initWithRawObject:(const git_rawobj *)obj;
++ (id)rawObjectWithRawObject:(const git_rawobj *)obj;
+
 // Helper to return the data of this raw object as a utf8 string
 - (NSString *)dataAsUTF8String;
 

--- a/Classes/GTRawObject.m
+++ b/Classes/GTRawObject.m
@@ -71,6 +71,19 @@
 	return [[[self alloc] initWithType:theType string:string] autorelease];
 }
 
+- (id)initWithRawObject:(const git_rawobj *)obj {
+    
+    if((self = [super init])) {
+        self.type = obj->type;
+        self.data = [NSData dataWithBytes:obj->data length:obj->len];
+    }
+    return self;
+}
++ (id)rawObjectWithRawObject:(const git_rawobj *)obj {
+    
+    return [[[self alloc] initWithRawObject:obj] autorelease];
+}
+
 - (NSString *)dataAsUTF8String {
 	
 	if(!self.data) return nil;

--- a/Classes/GTReference.m
+++ b/Classes/GTReference.m
@@ -160,7 +160,7 @@
 		return nil;
 	}
 	
-	NSMutableArray *references = [[NSMutableArray arrayWithCapacity:array.count] autorelease];
+	NSMutableArray *references = [NSMutableArray arrayWithCapacity:array.count];
 	for(int i=0; i< array.count; i++) {
 		[references addObject:[NSString stringForUTF8String:array.strings[i]]];
 	}

--- a/Classes/GTRepository.m
+++ b/Classes/GTRepository.m
@@ -225,11 +225,6 @@
 	return git_odb_exists(odb, &oid) ? YES : NO;
 }
 
-- (GTRawObject *)newRawObject:(const git_rawobj *)obj {
-	
-	return [GTRawObject rawObjectWithType:obj->type data:[NSData dataWithBytes:obj->data length:obj->len]];
-}
-
 - (GTRawObject *)rawRead:(const git_oid *)oid error:(NSError **)error {
 	
 	git_odb *odb;
@@ -243,7 +238,7 @@
 		return nil;
 	}
 	
-	GTRawObject *rawObj = [self newRawObject:&obj];
+	GTRawObject *rawObj = [GTRawObject rawObjectWithRawObject:&obj];
 	git_rawobj_close(&obj);
 	
 	return rawObj;


### PR DESCRIPTION
I've moved the creation of a GTRawObject from a git_rawobj struct to the GTRawObject class. Renamed it because methods starting with "new" by convention should return an object that needs to be released by the caller.
