### PR TITLE
Use GTObjectType where appropriate

### DIFF
--- a/Classes/GTBlob.m
+++ b/Classes/GTBlob.m
@@ -57,7 +57,7 @@
 	
 	if((self = [super init])) {
 		self.repo = theRepo;
-		self.object = [GTObject getNewObjectInRepo:self.repo.repo type:GIT_OBJ_BLOB error:error];
+		self.object = [GTObject getNewObjectInRepo:self.repo.repo type:GTObjectTypeBlob error:error];
 		if(self.object == nil)return nil;
 	}
 	return self;

--- a/Classes/GTCommit.m
+++ b/Classes/GTCommit.m
@@ -70,7 +70,7 @@
 	
 	if((self = [super init])) {
 		self.repo = theRepo;
-		self.object = [GTObject getNewObjectInRepo:self.repo.repo type:GIT_OBJ_COMMIT error:error];
+		self.object = [GTObject getNewObjectInRepo:self.repo.repo type:GTObjectTypeCommit error:error];
 		if(self.object == nil)return nil;
 	}
 	return self;

--- a/Classes/GTObject.h
+++ b/Classes/GTObject.h
@@ -31,16 +31,16 @@
 
 
 typedef enum {
-	GTObjectTypeAny = -2,			/**< Object can be any of the following */
-	GTObjectTypeBad = -1,			/**< Object is invalid. */
-	GTObjectTypeExt1 = 0,			/**< Reserved for future use. */
-	GTObjectTypeCommit = 1,		/**< A commit object. */
-	GTObjectTypeTree = 2,			/**< A tree (directory listing) object. */
-	GTObjectTypeBlob = 3,			/**< A file revision object. */
-	GTObjectTypeTag = 4,			/**< An annotated tag object. */
-	GTObjectTypeExt2 = 5,			/**< Reserved for future use. */
-	GTObjectTypeOffsetDelta = 6,	/**< A delta, base is given by an offset. */
-	GTObjectTypeRefDelta = 7,		/**< A delta, base is given by object id. */
+	GTObjectTypeAny = GIT_OBJ_ANY,				/**< Object can be any of the following */
+	GTObjectTypeBad = GIT_OBJ_BAD,				/**< Object is invalid. */
+	GTObjectTypeExt1 = GIT_OBJ__EXT1,			/**< Reserved for future use. */
+	GTObjectTypeCommit = GIT_OBJ_COMMIT,		/**< A commit object. */
+	GTObjectTypeTree = GIT_OBJ_TREE,			/**< A tree (directory listing) object. */
+	GTObjectTypeBlob = GIT_OBJ_BLOB,			/**< A file revision object. */
+	GTObjectTypeTag = GIT_OBJ_TAG,				/**< An annotated tag object. */
+	GTObjectTypeExt2 = GIT_OBJ__EXT2,			/**< Reserved for future use. */
+	GTObjectTypeOffsetDelta = GIT_OBJ_OFS_DELTA,/**< A delta, base is given by an offset. */
+	GTObjectTypeRefDelta = GIT_OBJ_REF_DELTA,	/**< A delta, base is given by object id. */
 } GTObjectType;
 
 @class GTRepository;

--- a/Tests/GTBlobTest.m
+++ b/Tests/GTBlobTest.m
@@ -89,7 +89,7 @@
 	NSError *error = nil;
 	char bytes[] = "100644 example_helper.rb\00\xD3\xD5\xED\x9D A4_\x00 40000 examples";
 	NSData *content = [NSData dataWithBytes:bytes length:sizeof(bytes)];
-	GTRawObject *obj = [GTRawObject rawObjectWithType:GIT_OBJ_BLOB data:content];
+	GTRawObject *obj = [GTRawObject rawObjectWithType:GTObjectTypeBlob data:content];
 
 	NSString *newSha = [repo write:obj error:&error];
 

--- a/Tests/GTRepositoryPackTest.m
+++ b/Tests/GTRepositoryPackTest.m
@@ -56,7 +56,7 @@
 	GTRawObject *obj = [repo read:@"41bc8c69075bbdb46c5c6f0566cc8cc5b46e8bd9" error:&error];
 	
 	GHAssertEquals(230, (int)[obj.data length], nil);
-	GHAssertEquals(GIT_OBJ_COMMIT, obj.type, nil);
+	GHAssertEquals(GTObjectTypeCommit, obj.type, nil);
 }
 
 @end

--- a/Tests/GTRepositoryTest.m
+++ b/Tests/GTRepositoryTest.m
@@ -45,7 +45,7 @@
 	NSError *error = nil;
 	repo = [GTRepository repoByOpeningRepositoryInDirectory:[NSURL URLWithString:TEST_REPO_PATH()] error:&error];
 
-	obj = [[[GTRawObject alloc] initWithType:GIT_OBJ_BLOB string:@"my test data\n"] autorelease];
+	obj = [[[GTRawObject alloc] initWithType:GTObjectTypeBlob string:@"my test data\n"] autorelease];
 }
 
 - (void)testCreateRepositoryInDirectory {
@@ -95,7 +95,7 @@
 	GHAssertNotNil(rawObj, nil);
 	GHAssertEqualStrings(@"tree 181037049a54a1eb5fab404658a3a250b44335d7", [[rawObj dataAsUTF8String] substringToIndex:45], nil);
 	GHAssertEquals((int)[rawObj.data length], 172, nil);
-	GHAssertEquals(rawObj.type, GIT_OBJ_COMMIT, nil);
+	GHAssertEquals(rawObj.type, GTObjectTypeCommit, nil);
 }
 
 - (void)testReadingFailsOnUnknownObjects {


### PR DESCRIPTION
And since GTObjectType and git_otype are used as synonyms, I've defined them as such.
