### PR TITLE
Clean up a file left behind in testCreateTag.

### DIFF
--- a/Tests/GTTagTest.m
+++ b/Tests/GTTagTest.m
@@ -88,6 +88,9 @@
 	GHAssertEqualStrings(@"commit", tag.targetType, nil);
 
 	rm_loose(newSha);
+	NSFileManager *m = [[[NSFileManager alloc] init] autorelease];
+	NSURL *tagPath = [[NSURL fileURLWithPath:TEST_REPO_PATH()] URLByAppendingPathComponent:@"refs/tags/a_new_tag"];
+	[m removeItemAtURL:tagPath error:&error];
 }
 
 @end


### PR DESCRIPTION
If this file is not removed, several tests will fail if you run the tests more than once.
