### PR TITLE
Retain 'parents' ivar in GTCommit

### DIFF
--- a/Classes/GTCommit.m
+++ b/Classes/GTCommit.m
@@ -172,9 +172,15 @@
 			[rents addObject:(GTCommit *)[GTObject objectInRepo:self.repo withObject:(git_object *)parent]];
 		}
 		
-		parents = [NSArray arrayWithArray:rents];
+		parents = [[NSArray arrayWithArray:rents] retain];
 	}
 	return parents;
+}
+
+- (void)dealloc
+{
+    [parents release];
+    [super dealloc];
 }
 
 @end


### PR DESCRIPTION
In `GTCommit`, the `-parents` getter sets the `parents` ivar to an autoreleased instance of `NSArray`. I've made it so that the ivar is retained, preventing EXC_BAD_ACCESS when trying to access the `parents` property.
