### PR TITLE
Massive method rename

### DIFF
--- a/Classes/GTBlob.h
+++ b/Classes/GTBlob.h
@@ -39,18 +39,19 @@
 // 
 // These call the associated createInRepo: methods, but then lookup the newly 
 // created blob in the repo and return it
-+ (GTBlob *)blobInRepo:(GTRepository *)theRepo content:(NSString *)content error:(NSError **)error;
-+ (GTBlob *)blobInRepo:(GTRepository *)theRepo data:(NSData *)data error:(NSError **)error;
-+ (GTBlob *)blobInRepo:(GTRepository *)theRepo file:(NSURL *)file error:(NSError **)error;
++ (GTBlob *)blobInRepository:(GTRepository *)theRepo content:(NSString *)content error:(NSError **)error;
++ (GTBlob *)blobInRepository:(GTRepository *)theRepo data:(NSData *)data error:(NSError **)error;
++ (GTBlob *)blobInRepository:(GTRepository *)theRepo file:(NSURL *)file error:(NSError **)error;
 
 // Create a blob in the specified repository
 //
 // returns the sha1 of the created blob or nil if an error occurred
-+ (NSString *)createInRepo:(GTRepository *)theRepo content:(NSString *)content error:(NSError **)error;
-+ (NSString *)createInRepo:(GTRepository *)theRepo data:(NSData *)data error:(NSError **)error;
-+ (NSString *)createInRepo:(GTRepository *)theRepo file:(NSURL *)file error:(NSError **)error;
++ (NSString *)shaByCreatingBlobInRepository:(GTRepository *)theRepo content:(NSString *)content error:(NSError **)error;
++ (NSString *)shaByCreatingBlobInRepository:(GTRepository *)theRepo data:(NSData *)data error:(NSError **)error;
++ (NSString *)shaByCreatingBlobInRepository:(GTRepository *)theRepo file:(NSURL *)file error:(NSError **)error;
 
 - (NSInteger)size;
 - (NSString *)content;
+- (NSData *)data;
 
 @end

--- a/Classes/GTBlob.m
+++ b/Classes/GTBlob.m
@@ -38,31 +38,31 @@
 
 - (git_blob *)blob {
 	
-	return (git_blob *)self.object;
+	return (git_blob *)self.obj;
 }
 
 #pragma mark -
 #pragma mark API
 
-+ (GTBlob *)blobInRepo:(GTRepository *)theRepo content:(NSString *)content error:(NSError **)error {
++ (GTBlob *)blobInRepository:(GTRepository *)theRepo content:(NSString *)content error:(NSError **)error {
 	
-	NSString *sha = [GTBlob createInRepo:theRepo content:content error:error];
-	return sha ? (GTBlob *)[theRepo lookupBySha:sha type:GTObjectTypeBlob error:error] : nil;
+	NSString *sha = [GTBlob shaByCreatingBlobInRepository:theRepo content:content error:error];
+	return sha ? (GTBlob *)[theRepo lookupObjectBySha:sha type:GTObjectTypeBlob error:error] : nil;
 }
 
-+ (GTBlob *)blobInRepo:(GTRepository *)theRepo data:(NSData *)data error:(NSError **)error {
++ (GTBlob *)blobInRepository:(GTRepository *)theRepo data:(NSData *)data error:(NSError **)error {
 	
-	NSString *sha = [GTBlob createInRepo:theRepo data:data error:error];
-	return sha ? (GTBlob *)[theRepo lookupBySha:sha type:GTObjectTypeBlob error:error] : nil;
+	NSString *sha = [GTBlob shaByCreatingBlobInRepository:theRepo data:data error:error];
+	return sha ? (GTBlob *)[theRepo lookupObjectBySha:sha type:GTObjectTypeBlob error:error] : nil;
 }
 
-+ (GTBlob *)blobInRepo:(GTRepository *)theRepo file:(NSURL *)file error:(NSError **)error {
++ (GTBlob *)blobInRepository:(GTRepository *)theRepo file:(NSURL *)file error:(NSError **)error {
 	
-	NSString *sha = [GTBlob createInRepo:theRepo file:file error:error];
-	return sha ? (GTBlob *)[theRepo lookupBySha:sha type:GTObjectTypeBlob error:error] : nil;
+	NSString *sha = [GTBlob shaByCreatingBlobInRepository:theRepo file:file error:error];
+	return sha ? (GTBlob *)[theRepo lookupObjectBySha:sha type:GTObjectTypeBlob error:error] : nil;
 }
 
-+ (NSString *)createInRepo:(GTRepository *)theRepo content:(NSString *)content error:(NSError **)error {
++ (NSString *)shaByCreatingBlobInRepository:(GTRepository *)theRepo content:(NSString *)content error:(NSError **)error {
 	
 	git_oid oid;
 	int gitError = git_blob_create_frombuffer(&oid, theRepo.repo, [NSString utf8StringForString:content], content.length);
@@ -75,7 +75,7 @@
 	return [GTLib convertOidToSha:&oid];
 }
 
-+ (NSString *)createInRepo:(GTRepository *)theRepo data:(NSData *)data error:(NSError **)error {
++ (NSString *)shaByCreatingBlobInRepository:(GTRepository *)theRepo data:(NSData *)data error:(NSError **)error {
 	
 	git_oid oid;
 	int gitError = git_blob_create_frombuffer(&oid, theRepo.repo, [data bytes], data.length);
@@ -88,7 +88,7 @@
 	return [GTLib convertOidToSha:&oid];
 }
 
-+ (NSString *)createInRepo:(GTRepository *)theRepo file:(NSURL *)file error:(NSError **)error {
++ (NSString *)shaByCreatingBlobInRepository:(GTRepository *)theRepo file:(NSURL *)file error:(NSError **)error {
 	
 	git_oid oid;
 	int gitError = git_blob_create_fromfile(&oid, theRepo.repo, [NSString utf8StringForString:[file path]]);
@@ -112,6 +112,13 @@
 	if(s == 0) return @"";
 	
 	return [NSString stringForUTF8String:git_blob_rawcontent(self.blob)];
+}
+
+- (NSData *)data {
+    NSInteger s = [self size];
+    if (s == 0) return [NSData data];
+    
+    return [NSData dataWithBytes:git_blob_rawcontent(self.blob) length:s];
 }
 
 @end

--- a/Classes/GTBranch.h
+++ b/Classes/GTBranch.h
@@ -23,16 +23,24 @@
 //  THE SOFTWARE.
 //
 
+#import "GTObject.h"
+
 @class GTCommit;
 @class GTReference;
 @class GTRepository;
 
-@interface GTBranch : NSObject {}
+typedef enum {
+    GTBranchTypeLocal = 1,
+    GTBranchTypeRemote
+} GTBranchType;
+
+@interface GTBranch : NSObject <GTObject> {}
 
 @property (nonatomic, readonly) NSString *name;
 @property (nonatomic, readonly) NSString *shortName;
 @property (nonatomic, readonly) NSString *sha;
 @property (nonatomic, readonly) NSString *remoteName;
+@property (nonatomic, readonly) GTBranchType branchType;
 @property (nonatomic, readonly, assign) GTRepository *repository;
 @property (nonatomic, readonly, retain) GTReference *reference;
 @property (nonatomic, retain) GTBranch *remoteBranch;
@@ -61,30 +69,27 @@
 // error(out) - will be filled if an error occurs
 //
 // returns an NSArray of GTBranch objects or nil if an error occurred
-+ (NSArray *)listAllLocalBranchesInRepository:(GTRepository *)repo error:(NSError **)error;
++ (NSArray *)branchesInRepository:(GTRepository *)repo error:(NSError **)error;
 
 // List all remote branches in a repository
 //
 // error(out) - will be filled if an error occurs
 //
 // returns an NSArray of GTBranch objects or nil if an error occurred
-+ (NSArray *)listAllRemoteBranchesInRepository:(GTRepository *)repo error:(NSError **)error;
++ (NSArray *)remoteBranchesInRepository:(GTRepository *)repo error:(NSError **)error;
 
 // List all branches in a repository with the given prefix.
 //
 // error(out) - will be filled if an error occurs
 //
 // returns an NSArray of GTBranch objects or nil if an error occurred
-+ (NSArray *)listAllBranchesInRepository:(GTRepository *)repo withPrefix:(NSString *)prefix error:(NSError **)error;
++ (NSArray *)branchesInRepository:(GTRepository *)repo withPrefix:(NSString *)prefix error:(NSError **)error;
 
 // Count all commits in this branch
 //
 // error(out) - will be filled if an error occurs
 //
 // returns number of commits in the branch or NSNotFound if an error occurred
-- (NSInteger)numberOfCommitsAndReturnError:(NSError **)error;
-
-- (BOOL)isRemote;
-- (BOOL)isLocal;
+- (NSInteger)numberOfCommitsWithError:(NSError **)error;
 
 @end

--- a/Classes/GTCommit.h
+++ b/Classes/GTCommit.h
@@ -41,28 +41,28 @@
 @property (nonatomic, readonly) GTSignature *committer;
 @property (nonatomic, readonly) NSArray *parents;
 
-+ (GTCommit *)commitInRepo:(GTRepository *)theRepo
-			updateRefNamed:(NSString *)refName
-					author:(GTSignature *)authorSig
-				 committer:(GTSignature *)committerSig
-				   message:(NSString *)newMessage
-					  tree:(GTTree *)theTree 
-				   parents:(NSArray *)theParents 
-					 error:(NSError **)error;
++ (GTCommit *)commitInRepository:(GTRepository *)theRepo
+                  updateRefNamed:(NSString *)refName
+                          author:(GTSignature *)authorSig
+                       committer:(GTSignature *)committerSig
+                         message:(NSString *)newMessage
+                            tree:(GTTree *)theTree 
+                         parents:(NSArray *)theParents 
+                           error:(NSError **)error;
 
-+ (NSString *)createCommitInRepo:(GTRepository *)theRepo
-				  updateRefNamed:(NSString *)refName
-						  author:(GTSignature *)authorSig
-					   committer:(GTSignature *)committerSig
-						 message:(NSString *)newMessage
-							tree:(GTTree *)theTree 
-						 parents:(NSArray *)theParents 
-						   error:(NSError **)error;
++ (NSString *)shaByCreatingCommitInRepository:(GTRepository *)theRepo
+                               updateRefNamed:(NSString *)refName
+                                       author:(GTSignature *)authorSig
+                                    committer:(GTSignature *)committerSig
+                                      message:(NSString *)newMessage
+                                         tree:(GTTree *)theTree 
+                                      parents:(NSArray *)theParents 
+                                        error:(NSError **)error;
 
 - (NSString *)message;
-- (NSString *)messageShort;
+- (NSString *)shortMessage;
 - (NSString *)messageDetails;
-- (NSDate *)time;
+- (NSDate *)commitDate;
 - (GTTree *)tree;
 
 @end

--- a/Classes/GTIndex.h
+++ b/Classes/GTIndex.h
@@ -43,14 +43,14 @@
 + (id)indexWithPath:(NSURL *)localFileUrl error:(NSError **)error;
 
 - (id)initWithGitIndex:(git_index *)theIndex;
-+ (id)indexWithIndex:(git_index *)theIndex;
++ (id)indexWithGitIndex:(git_index *)theIndex;
 
 // Refresh the index from the datastore
 //
 // error(out) - will be filled if an error occurs
 //
 // returns YES if refresh was successful
-- (BOOL)refreshAndReturnError:(NSError **)error;
+- (BOOL)refreshWithError:(NSError **)error;
 
 // Clear the contents (all entry objects) of the index. This happens in memory.
 // Changes can be written to the datastore by calling writeAndReturnError:
@@ -69,6 +69,6 @@
 // error(out) - will be filled if an error occurs
 //
 // returns YES if the write was successful.
-- (BOOL)writeAndReturnError:(NSError **)error;
+- (BOOL)writeWithError:(NSError **)error;
 
 @end

--- a/Classes/GTIndex.m
+++ b/Classes/GTIndex.m
@@ -76,7 +76,7 @@
 	}
 	return self;
 }
-+ (id)indexWithIndex:(git_index *)theIndex {
++ (id)indexWithGitIndex:(git_index *)theIndex {
 	
 	return [[[self alloc] initWithGitIndex:theIndex] autorelease];
 }
@@ -86,7 +86,7 @@
 	return git_index_entrycount(self.index);
 }
 
-- (BOOL)refreshAndReturnError:(NSError **)error {
+- (BOOL)refreshWithError:(NSError **)error {
 	
 	int gitError = git_index_read(self.index);
 	if(gitError != GIT_SUCCESS) {
@@ -135,7 +135,7 @@
 	return YES;
 }
 
-- (BOOL)writeAndReturnError:(NSError **)error {
+- (BOOL)writeWithError:(NSError **)error {
 	
 	int gitError = git_index_write(self.index);
 	if(gitError != GIT_SUCCESS) {

--- a/Classes/GTIndexEntry.h
+++ b/Classes/GTIndexEntry.h
@@ -34,8 +34,8 @@
 
 @property (nonatomic, assign) git_index_entry *entry;
 @property (nonatomic, assign) NSString *path;
-@property (nonatomic, assign) NSDate *mTime;
-@property (nonatomic, assign) NSDate *cTime;
+@property (nonatomic, assign) NSDate *modificationDate;
+@property (nonatomic, assign) NSDate *creationDate;
 @property (nonatomic, assign) long long fileSize;
 @property (nonatomic, assign) NSUInteger dev;
 @property (nonatomic, assign) NSUInteger ino;

--- a/Classes/GTIndexEntry.m
+++ b/Classes/GTIndexEntry.m
@@ -47,8 +47,8 @@
 
 @synthesize entry;
 @synthesize path;
-@synthesize mTime;
-@synthesize cTime;
+@synthesize modificationDate;
+@synthesize creationDate;
 @synthesize fileSize;
 @synthesize dev;
 @synthesize ino;
@@ -108,24 +108,24 @@
 	return YES;
 }
 
-- (NSDate *)mTime {
+- (NSDate *)modificationDate {
 	
 	double time = self.entry->mtime.seconds + (self.entry->mtime.nanoseconds/1000);
 	return [NSDate dateWithTimeIntervalSince1970:time];
 }
-- (void)setMTime:(NSDate *)time {
+- (void)setModificationDate:(NSDate *)time {
 	
 	NSTimeInterval t = [time timeIntervalSince1970];
 	self.entry->mtime.seconds = (int)t;
 	self.entry->mtime.nanoseconds = 1000 * (t - (int)t);
 }
 
-- (NSDate *)cTime {
+- (NSDate *)creationDate {
 	
 	double time = self.entry->ctime.seconds + (self.entry->ctime.nanoseconds/1000);
 	return [NSDate dateWithTimeIntervalSince1970:time];
 }
-- (void)setCTime:(NSDate *)time {
+- (void)setCreationDate:(NSDate *)time {
 	
 	NSTimeInterval t = [time timeIntervalSince1970];
 	self.entry->ctime.seconds = (int)t;

--- a/Classes/GTObject.h
+++ b/Classes/GTObject.h
@@ -46,17 +46,24 @@ typedef enum {
 @class GTRepository;
 @class GTOdbObject;
 
-@interface GTObject : NSObject {}
+@protocol GTObject <NSObject>
 
-@property (nonatomic, readonly) git_object *object;
+@required
+- (GTRepository *)repository;
+
+@end
+
+@interface GTObject : NSObject <GTObject> {}
+
+@property (nonatomic, readonly) git_object *obj;
 @property (nonatomic, readonly) NSString *type;
 @property (nonatomic, readonly) NSString *sha;
 @property (nonatomic, readonly) NSString *shortSha;
-@property (nonatomic, assign) GTRepository *repo;
+@property (nonatomic, assign) GTRepository *repository;
 
 // Convenience initializers
-- (id)initInRepo:(GTRepository *)theRepo withObject:(git_object *)theObject;
-+ (id)objectInRepo:(GTRepository *)theRepo withObject:(git_object *)theObject;
+- (id)initWithObj:(git_object *)theObject inRepository:(GTRepository *)theRepo;
++ (id)objectWithObj:(git_object *)theObject inRepository:(GTRepository *)theRepo;
 
 // Read the raw object from the datastore
 //

--- a/Classes/GTObject.m
+++ b/Classes/GTObject.m
@@ -46,7 +46,7 @@ static NSString * const GTTagClassName = @"GTTag";
 
 - (void)dealloc {
 	
-	self.repo = nil;
+	self.repository = nil;
 	[super dealloc];
 }
 
@@ -59,26 +59,26 @@ static NSString * const GTTagClassName = @"GTTag";
 	
 	if(![otherObject isKindOfClass:[GTObject class]]) return NO;
 	
-	return 0 == git_oid_cmp(git_object_id(self.object), git_object_id(((GTObject *)otherObject).object)) ? YES : NO;
+	return 0 == git_oid_cmp(git_object_id(self.obj), git_object_id(((GTObject *)otherObject).obj)) ? YES : NO;
 }
 
 #pragma mark -
 #pragma mark API 
 
-@synthesize object;
+@synthesize obj;
 @synthesize type;
 @synthesize sha;
-@synthesize repo;
+@synthesize repository;
 
-- (id)initInRepo:(GTRepository *)theRepo withObject:(git_object *)theObject {
+- (id)initWithObj:(git_object *)theObject inRepository:(GTRepository *)theRepo {
 	
 	if((self = [super init])) {
-		self.repo = theRepo;
-		object = theObject;
+		self.repository = theRepo;
+		obj = theObject;
 	}
 	return self;
 }
-+ (id)objectInRepo:(GTRepository *)theRepo withObject:(git_object *)theObject {
++ (id)objectWithObj:(git_object *)theObject inRepository:(GTRepository *)theRepo {
 	
 	NSString *klass;
 	git_otype t = git_object_type(theObject);
@@ -100,17 +100,17 @@ static NSString * const GTTagClassName = @"GTTag";
 			break;
 	}
 	
-	return [[[NSClassFromString(klass) alloc] initInRepo:theRepo withObject:theObject] autorelease];
+    return [[[NSClassFromString(klass) alloc] initWithObj:theObject inRepository:theRepo] autorelease];
 }
 
 - (NSString *)type {
 	
-	return [NSString stringForUTF8String:git_object_type2string(git_object_type(self.object))];
+	return [NSString stringForUTF8String:git_object_type2string(git_object_type(self.obj))];
 }
 
 - (NSString *)sha {
 	
-	return [GTLib convertOidToSha:git_object_id(self.object)];
+	return [GTLib convertOidToSha:git_object_id(self.obj)];
 }
 
 - (NSString *)shortSha {
@@ -120,7 +120,7 @@ static NSString * const GTTagClassName = @"GTTag";
 
 - (GTOdbObject *)readRawAndReturnError:(NSError **)error {
 	
-	return [self.repo rawRead:git_object_id(self.object) error:error];
+	return [self.repository rawRead:git_object_id(self.obj) error:error];
 }
 
 @end

--- a/Classes/GTOdbObject.h
+++ b/Classes/GTOdbObject.h
@@ -16,7 +16,7 @@
 - (id)initWithObject:(git_odb_object *)object;
 + (id)objectWithObject:(git_odb_object *)object;
 
-- (NSString *)hash;
+- (NSString *)shaHash;
 - (GTObjectType)type;
 - (NSUInteger)length;
 - (NSData *)data;

--- a/Classes/GTOdbObject.m
+++ b/Classes/GTOdbObject.m
@@ -34,7 +34,7 @@
 	return [[[self alloc] initWithObject:object] autorelease];
 }
 
-- (NSString *)hash {
+- (NSString *)shaHash {
 	
 	return [GTLib convertOidToSha:git_odb_object_id(self.odbObject)];
 }

--- a/Classes/GTReference.h
+++ b/Classes/GTReference.h
@@ -24,6 +24,7 @@
 //
 
 #import <git2.h>
+#import "GTObject.h"
 
 typedef enum {
 	GTReferenceTypesOid = GIT_REF_OID,				/** A reference which points at an object id */
@@ -35,22 +36,22 @@ typedef enum {
 
 @class GTRepository;
 
-@interface GTReference : NSObject {}
+@interface GTReference : NSObject <GTObject> {}
 
 @property (nonatomic, assign) git_reference *ref;
-@property (nonatomic, assign) GTRepository *repo;
+@property (nonatomic, assign) GTRepository *repository;
 @property (nonatomic, readonly) NSString *type;
 @property (nonatomic, readonly) const git_oid *oid;
 
 // Convenience initializers
-+ (id)referenceByLookingUpRef:(NSString *)refName inRepo:(GTRepository *)theRepo error:(NSError **)error;
-- (id)initByLookingUpRef:(NSString *)refName inRepo:(GTRepository *)theRepo error:(NSError **)error;
++ (id)referenceByLookingUpReferencedNamed:(NSString *)refName inRepository:(GTRepository *)theRepo error:(NSError **)error;
+- (id)initByLookingUpReferenceNamed:(NSString *)refName inRepository:(GTRepository *)theRepo error:(NSError **)error;
 
-+ (id)referenceByCreatingRef:(NSString *)refName fromRef:(NSString *)target inRepo:(GTRepository *)theRepo error:(NSError **)error;
-- (id)initByCreatingRef:(NSString *)refName fromRef:(NSString *)target inRepo:(GTRepository *)theRepo error:(NSError **)error;
++ (id)referenceByCreatingReferenceNamed:(NSString *)refName fromReferenceTarget:(NSString *)target inRepository:(GTRepository *)theRepo error:(NSError **)error;
+- (id)initByCreatingReferenceNamed:(NSString *)refName fromReferenceTarget:(NSString *)target inRepository:(GTRepository *)theRepo error:(NSError **)error;
 
-+ (id)referenceByResolvingRef:(GTReference *)symbolicRef error:(NSError **)error;
-- (id)initByResolvingRef:(GTReference *)symbolicRef error:(NSError **)error;
++ (id)referenceByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error;
+- (id)initByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error;
 
 // List references in a repository
 // 
@@ -60,7 +61,7 @@ typedef enum {
 // 
 // returns an array of NSStrings holding the names of the references
 // returns nil if an error occurred and fills the error parameter
-+ (NSArray *)listReferenceNamesInRepo:(GTRepository *)theRepo types:(GTReferenceTypes)types error:(NSError **)error;
++ (NSArray *)referenceNamesInRepository:(GTRepository *)theRepo types:(GTReferenceTypes)types error:(NSError **)error;
 
 // List all references in a repository
 //
@@ -71,7 +72,7 @@ typedef enum {
 // 
 // returns an array of NSStrings holding the names of the references
 // returns nil if an error occurred and fills the error parameter
-+ (NSArray *)listAllReferenceNamesInRepo:(GTRepository *)theRepo error:(NSError **)error;
++ (NSArray *)referenceNamesInRepository:(GTRepository *)theRepo error:(NSError **)error;
 
 - (NSString *)target;
 - (BOOL)setTarget:(NSString *)newTarget error:(NSError **)error;
@@ -83,20 +84,20 @@ typedef enum {
 // error(out) - will be filled if an error occurs
 //
 // returns YES if the pack was successful
-- (BOOL)packAllAndReturnError:(NSError **)error;
+- (BOOL)packAllWithError:(NSError **)error;
 
 // Delete this reference
 //
 // error(out) - will be filled if an error occurs
 //
 // returns YES if the delete was successful
-- (BOOL)deleteAndReturnError:(NSError **)error;
+- (BOOL)deleteWithError:(NSError **)error;
 
 // Resolve this reference as a symbolic ref
 //
 // error(out) - will be filled if an error occurs
 //
 // returns the peeled GTReference or nil if an error occurred.
-- (GTReference *)resolveAndReturnError:(NSError **)error;
+- (GTReference *)resolvedReferenceWithError:(NSError **)error;
 
 @end

--- a/Classes/GTReference.m
+++ b/Classes/GTReference.m
@@ -34,7 +34,7 @@
 
 - (void)dealloc {
 	
-	self.repo = nil;
+	self.repository = nil;
 	[super dealloc];
 }
 
@@ -47,14 +47,14 @@
 #pragma mark API
 
 @synthesize ref;
-@synthesize repo;
+@synthesize repository;
 @synthesize type;
 
-- (id)initByLookingUpRef:(NSString *)refName inRepo:(GTRepository *)theRepo error:(NSError **)error {
+- (id)initByLookingUpReferenceNamed:(NSString *)refName inRepository:(GTRepository *)theRepo error:(NSError **)error {
 	
 	if((self = [super init])) {
-		self.repo = theRepo;
-		int gitError = git_reference_lookup(&ref, self.repo.repo, [NSString utf8StringForString:refName]);
+		self.repository = theRepo;
+		int gitError = git_reference_lookup(&ref, self.repository.repo, [NSString utf8StringForString:refName]);
 		if(gitError != GIT_SUCCESS) {
 			if(error != NULL)
 				*error = [NSError gitErrorForLookupRef:gitError];
@@ -63,28 +63,28 @@
 	}
 	return self;
 }
-+ (id)referenceByLookingUpRef:(NSString *)refName inRepo:(GTRepository *)theRepo error:(NSError **)error {
++ (id)referenceByLookingUpReferencedNamed:(NSString *)refName inRepository:(GTRepository *)theRepo error:(NSError **)error {
 	
-	return [[[self alloc] initByLookingUpRef:refName inRepo:theRepo error:error] autorelease];
+	return [[[self alloc] initByLookingUpReferenceNamed:refName inRepository:theRepo error:error] autorelease];
 }
 
-- (id)initByCreatingRef:(NSString *)refName fromRef:(NSString *)theTarget inRepo:(GTRepository *)theRepo error:(NSError **)error {
+- (id)initByCreatingReferenceNamed:(NSString *)refName fromReferenceTarget:(NSString *)theTarget inRepository:(GTRepository *)theRepo error:(NSError **)error {
 	
 	if((self = [super init])) {
 		
 		git_oid oid;
 		int gitError;
 		
-		self.repo = theRepo;
+		self.repository = theRepo;
 		if (git_oid_mkstr(&oid, [NSString utf8StringForString:theTarget]) == GIT_SUCCESS) {
 			gitError = git_reference_create_oid(&ref, 
-												self.repo.repo, 
+												self.repository.repo, 
 												[NSString utf8StringForString:refName], 
 												&oid);
 		}
 		else {
 			gitError = git_reference_create_symbolic(&ref, 
-													 self.repo.repo, 
+													 self.repository.repo, 
 													 [NSString utf8StringForString:refName], 
 													 [NSString utf8StringForString:theTarget]);
 		}
@@ -97,12 +97,12 @@
 	}
 	return self;
 }
-+ (id)referenceByCreatingRef:(NSString *)refName fromRef:(NSString *)target inRepo:(GTRepository *)theRepo error:(NSError **)error {
++ (id)referenceByCreatingReferenceNamed:(NSString *)refName fromReferenceTarget:(NSString *)target inRepository:(GTRepository *)theRepo error:(NSError **)error {
 		
-	return [[[self alloc] initByCreatingRef:refName fromRef:target inRepo:theRepo error:error] autorelease];
+	return [[[self alloc] initByCreatingReferenceNamed:refName fromReferenceTarget:target inRepository:theRepo error:error] autorelease];
 }
 
-- (id)initByResolvingRef:(GTReference *)symbolicRef error:(NSError **)error {
+- (id)initByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error {
 	
 	if((self = [super init])) {
 		
@@ -112,13 +112,13 @@
 				*error = [NSError gitErrorForResloveRef:gitError];
 			return nil;
 		}
-		self.repo = symbolicRef.repo;
+		self.repository = symbolicRef.repository;
 	}
 	return self;
 }
-+ (id)referenceByResolvingRef:(GTReference *)symbolicRef error:(NSError **)error {
++ (id)referenceByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error {
 	
-	return [[[self alloc] initByResolvingRef:symbolicRef error:error] autorelease];
+	return [[[self alloc] initByResolvingSymbolicReference:symbolicRef error:error] autorelease];
 }
 
 - (NSString *)name {
@@ -141,10 +141,10 @@
 	return [NSString stringForUTF8String:git_object_type2string(git_reference_type(self.ref))];
 }
 
-+ (NSArray *)listReferenceNamesInRepo:(GTRepository *)theRepo types:(GTReferenceTypes)types error:(NSError **)error {
++ (NSArray *)referenceNamesInRepository:(GTRepository *)theRepo types:(GTReferenceTypes)types error:(NSError **)error {
 	
 	NSParameterAssert(theRepo != nil);
-	NSParameterAssert(theRepo.repo != nil);
+	NSParameterAssert(theRepo.repository != nil);
 	
 	git_strarray array;
 	
@@ -163,9 +163,9 @@
 	return references;
 }
 
-+ (NSArray *)listAllReferenceNamesInRepo:(GTRepository *)theRepo error:(NSError **)error {
++ (NSArray *)referenceNamesInRepository:(GTRepository *)theRepo error:(NSError **)error {
 	
-	return [self listReferenceNamesInRepo:theRepo types:GTReferenceTypesListAll error:error];
+	return [self referenceNamesInRepository:theRepo types:GTReferenceTypesListAll error:error];
 }
 
 - (NSString *)target {
@@ -204,9 +204,9 @@
 	return YES;
 }
 
-- (BOOL)packAllAndReturnError:(NSError **)error {
+- (BOOL)packAllWithError:(NSError **)error {
 	
-	int gitError = git_reference_packall(self.repo.repo);
+	int gitError = git_reference_packall(self.repository.repo);
 	if(gitError != GIT_SUCCESS) {
 		if(error != NULL)
 			*error = [NSError gitErrorForPackAllRefs:gitError];
@@ -215,7 +215,7 @@
 	return YES;
 }
 
-- (BOOL)deleteAndReturnError:(NSError **)error {
+- (BOOL)deleteWithError:(NSError **)error {
 	
 	int gitError = git_reference_delete(self.ref);
 	if(gitError != GIT_SUCCESS) {
@@ -227,9 +227,9 @@
 	return YES;
 }
 
-- (GTReference *)resolveAndReturnError:(NSError **)error {
+- (GTReference *)resolvedReferenceWithError:(NSError **)error {
 	
-	return [GTReference referenceByResolvingRef:self error:error];
+	return [GTReference referenceByResolvingSymbolicReference:self error:error];
 }
 
 @end

--- a/Classes/GTRepository.h
+++ b/Classes/GTRepository.h
@@ -28,18 +28,17 @@
 //
 
 #import <git2.h>
+#import "GTObject.h"
 #import "GTWalker.h"
 #import "GTReference.h"
 
 
-@class GTWalker;
-@class GTObject;
 @class GTOdbObject;
 @class GTCommit;
 @class GTIndex;
 @class GTBranch;
 
-@interface GTRepository : NSObject {}
+@interface GTRepository : NSObject <GTObject> {}
 
 @property (nonatomic, assign, readonly) git_repository *repo;
 @property (nonatomic, retain, readonly) NSURL *fileUrl;
@@ -62,10 +61,10 @@
 + (NSString *)hash:(NSString *)data type:(GTObjectType)type error:(NSError **)error;
 
 // Lookup objects in the repo by oid or sha1
-- (GTObject *)lookupByOid:(git_oid *)oid type:(GTObjectType)type error:(NSError **)error;
-- (GTObject *)lookupByOid:(git_oid *)oid error:(NSError **)error;
-- (GTObject *)lookupBySha:(NSString *)sha type:(GTObjectType)type error:(NSError **)error;
-- (GTObject *)lookupBySha:(NSString *)sha error:(NSError **)error;
+- (GTObject *)lookupObjectByOid:(git_oid *)oid type:(GTObjectType)type error:(NSError **)error;
+- (GTObject *)lookupObjectByOid:(git_oid *)oid error:(NSError **)error;
+- (GTObject *)lookupObjectBySha:(NSString *)sha type:(GTObjectType)type error:(NSError **)error;
+- (GTObject *)lookupObjectBySha:(NSString *)sha error:(NSError **)error;
 
 // Check to see if objects exist in the repo
 - (BOOL)exists:(NSString *)sha error:(NSError **)error;
@@ -80,25 +79,25 @@
 - (BOOL)walk:(NSString *)sha error:(NSError **)error block:(void (^)(GTCommit *commit, BOOL *stop))block;
 - (NSArray *)selectCommitsStartingFrom:(NSString *)sha error:(NSError **)error block:(BOOL (^)(GTCommit *commit, BOOL *stop))block;
 
-- (BOOL)setupIndexAndReturnError:(NSError **)error;
+- (BOOL)setupIndex:(NSError **)error;
 
-- (GTReference *)headAndReturnError:(NSError **)error;
+- (GTReference *)headReference:(NSError **)error;
 
 // Convenience methods to return references in this repository (see GTReference.h)
-- (NSArray *)listReferenceNamesOfTypes:(GTReferenceTypes)types error:(NSError **)error;
-- (NSArray *)listAllReferenceNamesAndReturnError:(NSError **)error;
+- (NSArray *)allReferenceNamesOfTypes:(GTReferenceTypes)types error:(NSError **)error;
+- (NSArray *)allReferenceNames:(NSError **)error;
 
 // Convenience methods to return branches in the repository
-- (NSArray *)listAllBranchesAndReturnError:(NSError **)error;
+- (NSArray *)allBranches:(NSError **)error;
 
 // Count all commits in the current branch (HEAD)
 //
 // error(out) - will be filled if an error occurs
 //
 // returns number of commits in the current branch or NSNotFound if an error occurred
-- (NSInteger)numberOfCommitsInCurrentBranchAndReturnError:(NSError **)error;
+- (NSInteger)numberOfCommitsInCurrentBranch:(NSError **)error;
 
-- (GTBranch *)createBranchFrom:(GTReference *)ref named:(NSString *)name error:(NSError **)error;
+- (GTBranch *)createBranchNamed:(NSString *)name fromReference:(GTReference *)ref error:(NSError **)error;
 
 - (BOOL)isEmpty;
 	

--- a/Classes/GTSignature.h
+++ b/Classes/GTSignature.h
@@ -32,14 +32,14 @@
 
 @interface GTSignature : NSObject {}
 
-@property (nonatomic, assign) git_signature *signature;
+@property (nonatomic, assign) git_signature *sig;
 @property (nonatomic, assign) NSString *name;
 @property (nonatomic, assign) NSString *email;
 @property (nonatomic, assign) NSDate *time;
 
 // Convenience initializers
-- (id)initWithSignature:(git_signature *)theSignature;
-+ (id)signatureWithSignature:(git_signature *)theSignature;
+- (id)initWithSig:(git_signature *)theSignature;
++ (id)signatureWithSig:(git_signature *)theSignature;
 
 - (id)initWithName:(NSString *)theName email:(NSString *)theEmail time:(NSDate *)theTime;
 + (id)signatureWithName:(NSString *)theName email:(NSString *)theEmail time:(NSDate *)theTime;

--- a/Classes/GTSignature.m
+++ b/Classes/GTSignature.m
@@ -51,27 +51,27 @@
 #pragma mark -
 #pragma mark API 
 
-@synthesize signature;
+@synthesize sig;
 @synthesize name;
 @synthesize email;
 @synthesize time;
 
-- (id)initWithSignature:(git_signature *)theSignature {
+- (id)initWithSig:(git_signature *)theSignature {
 	
 	if((self = [self init])) {
-		self.signature = theSignature;
+		self.sig = theSignature;
 	}
 	return self;
 }
-+ (id)signatureWithSignature:(git_signature *)theSignature {
++ (id)signatureWithSig:(git_signature *)theSignature {
 	
-	return [[[self alloc] initWithSignature:theSignature] autorelease];
+	return [[[self alloc] initWithSig:theSignature] autorelease];
 }
 
 - (id)initWithName:(NSString *)theName email:(NSString *)theEmail time:(NSDate *)theTime {
 	
 	if((self = [super init])) {
-		self.signature = git_signature_new(
+		self.sig = git_signature_new(
 										   [NSString utf8StringForString:theName], 
 										   [NSString utf8StringForString:theEmail], 
 										   [theTime timeIntervalSince1970], 
@@ -87,31 +87,31 @@
 
 - (NSString *)name {
 	
-	return [NSString stringForUTF8String:self.signature->name];
+	return [NSString stringForUTF8String:self.sig->name];
 }
 - (void)setName:(NSString *)n {
 	
-	free(self.signature->name);
-	self.signature->name = strdup([n cStringUsingEncoding:NSUTF8StringEncoding]);
+	free(self.sig->name);
+	self.sig->name = strdup([n cStringUsingEncoding:NSUTF8StringEncoding]);
 }
 
 - (NSString *)email {
 	
-	return [NSString stringForUTF8String:self.signature->email];
+	return [NSString stringForUTF8String:self.sig->email];
 }
 - (void)setEmail:(NSString *)e {
 	
-	free(self.signature->email);
-	self.signature->email = strdup([e cStringUsingEncoding:NSUTF8StringEncoding]);
+	free(self.sig->email);
+	self.sig->email = strdup([e cStringUsingEncoding:NSUTF8StringEncoding]);
 }
 
 - (NSDate *)time {
 	
-	return [NSDate dateWithTimeIntervalSince1970:self.signature->when.time];
+	return [NSDate dateWithTimeIntervalSince1970:self.sig->when.time];
 }
 - (void)setTime:(NSDate *)d {
 	
-	self.signature->when.time = [d timeIntervalSince1970];
+	self.sig->when.time = [d timeIntervalSince1970];
 }
 
 @end

--- a/Classes/GTTag.h
+++ b/Classes/GTTag.h
@@ -39,8 +39,8 @@
 @property (nonatomic, readonly) git_tag *tag;
 @property (nonatomic, readonly) GTSignature *tagger;
 
-+ (GTTag *)tagInRepo:(GTRepository *)theRepo name:(NSString *)tagName target:(GTObject *)theTarget tagger:(GTSignature *)theTagger message:(NSString *)theMessage error:(NSError **)error;
-+ (NSString *)createTagInRepo:(GTRepository *)theRepo name:(NSString *)tagName target:(GTObject *)theTarget tagger:(GTSignature *)theTagger message:(NSString *)theMessage error:(NSError **)error;
++ (GTTag *)tagInRepository:(GTRepository *)theRepo name:(NSString *)tagName target:(GTObject *)theTarget tagger:(GTSignature *)theTagger message:(NSString *)theMessage error:(NSError **)error;
++ (NSString *)shaByCreatingTagInRepository:(GTRepository *)theRepo name:(NSString *)tagName target:(GTObject *)theTarget tagger:(GTSignature *)theTagger message:(NSString *)theMessage error:(NSError **)error;
 
 - (NSString *)message;
 - (NSString *)name;

--- a/Classes/GTTag.m
+++ b/Classes/GTTag.m
@@ -40,7 +40,7 @@
 
 - (git_tag *)tag {
 	
-	return (git_tag *)self.object;
+	return (git_tag *)self.obj;
 }
 
 #pragma mark -
@@ -48,16 +48,16 @@
 
 @synthesize tagger;
 
-+ (GTTag *)tagInRepo:(GTRepository *)theRepo name:(NSString *)tagName target:(GTObject *)theTarget tagger:(GTSignature *)theTagger message:(NSString *)theMessage error:(NSError **)error {
++ (GTTag *)tagInRepository:(GTRepository *)theRepo name:(NSString *)tagName target:(GTObject *)theTarget tagger:(GTSignature *)theTagger message:(NSString *)theMessage error:(NSError **)error {
 
-	NSString *sha = [GTTag createTagInRepo:theRepo name:tagName target:theTarget tagger:theTagger message:theMessage error:error];
-	return sha ? (GTTag *)[theRepo lookupBySha:sha type:GTObjectTypeTag error:error] : nil;
+	NSString *sha = [GTTag shaByCreatingTagInRepository:theRepo name:tagName target:theTarget tagger:theTagger message:theMessage error:error];
+	return sha ? (GTTag *)[theRepo lookupObjectBySha:sha type:GTObjectTypeTag error:error] : nil;
 }
 
-+ (NSString *)createTagInRepo:(GTRepository *)theRepo name:(NSString *)tagName target:(GTObject *)theTarget tagger:(GTSignature *)theTagger message:(NSString *)theMessage error:(NSError **)error {
++ (NSString *)shaByCreatingTagInRepository:(GTRepository *)theRepo name:(NSString *)tagName target:(GTObject *)theTarget tagger:(GTSignature *)theTagger message:(NSString *)theMessage error:(NSError **)error {
 	
 	git_oid oid;
-	int gitError = git_tag_create_o(&oid, theRepo.repo, [NSString utf8StringForString:tagName], theTarget.object, theTagger.signature, [NSString utf8StringForString:theMessage]);
+	int gitError = git_tag_create_o(&oid, theRepo.repo, [NSString utf8StringForString:tagName], theTarget.obj, theTagger.sig, [NSString utf8StringForString:theMessage]);
 	if(gitError != GIT_SUCCESS) {
 		if(error != NULL)
 			*error = [NSError gitErrorFor:gitError withDescription:@"Failed to create tag in repository"];
@@ -83,7 +83,7 @@
 	// todo: might want to actually return an error here
 	int gitError = git_tag_target(&t, self.tag);
 	if(gitError != GIT_SUCCESS) return nil;
-	return [GTObject objectInRepo:self.repo withObject:(git_object *)t];
+    return [GTObject objectWithObj:(git_object *)t inRepository:self.repository];
 }
 
 - (NSString *)targetType {
@@ -94,7 +94,7 @@
 - (GTSignature *)tagger {
 	
 	if(tagger == nil) {
-		tagger = [GTSignature signatureWithSignature:(git_signature *)git_tag_tagger(self.tag)];
+		tagger = [GTSignature signatureWithSig:(git_signature *)git_tag_tagger(self.tag)];
 	}
 	return tagger;
 }

--- a/Classes/GTTree.h
+++ b/Classes/GTTree.h
@@ -40,7 +40,7 @@
 // Get the number of entries
 //
 // returns the number of entries in this tree
-- (NSInteger)entryCount;
+- (NSInteger)numberOfEntries;
 
 // Get a entry at the specified index
 //
@@ -54,7 +54,7 @@
 // name - the name of the entry
 //
 // returns a GTTreeEntry or nil if there is nothing with the specified name
-- (GTTreeEntry *)entryByName:(NSString *)name;
+- (GTTreeEntry *)entryWithName:(NSString *)name;
 
 /*
 // Add an entry to the index

--- a/Classes/GTTree.m
+++ b/Classes/GTTree.m
@@ -38,13 +38,13 @@
 
 - (git_tree *)tree {
 	
-	return (git_tree *)self.object;
+	return (git_tree *)self.obj;
 }
 
 #pragma mark -
 #pragma mark API
 
-- (NSInteger)entryCount {
+- (NSInteger)numberOfEntries {
 	
 	return [[NSNumber numberWithInt:git_tree_entrycount(self.tree)] integerValue];
 }
@@ -59,7 +59,7 @@
 	return [self createEntryWithEntry:git_tree_entry_byindex(self.tree, index)];
 }
 
-- (GTTreeEntry *)entryByName:(NSString *)name {
+- (GTTreeEntry *)entryWithName:(NSString *)name {
 	
 	return [self createEntryWithEntry:git_tree_entry_byname(self.tree, [NSString utf8StringForString:name])];
 }

--- a/Classes/GTTreeEntry.h
+++ b/Classes/GTTreeEntry.h
@@ -28,12 +28,11 @@
 //
 
 #import <git2.h>
-
+#import "GTObject.h"
 
 @class GTTree;
-@class GTObject;
 
-@interface GTTreeEntry : NSObject {}
+@interface GTTreeEntry : NSObject <GTObject> {}
 
 @property (nonatomic, assign, readonly) const git_tree_entry *entry;
 @property (nonatomic, assign, readonly) GTTree *tree;
@@ -51,5 +50,12 @@
 //
 // returns this entry as a GTObject or nil if an error occurred.
 - (GTObject *)toObjectAndReturnError:(NSError **)error;
+
+@end
+
+@interface GTObject (GTTreeEntry)
+
++ (id)objectWithTreeEntry:(GTTreeEntry *)treeEntry error:(NSError **)error;
+- (id)initWithTreeEntry:(GTTreeEntry *)treeEntry error:(NSError **)error;
 
 @end

--- a/Classes/GTWalker.h
+++ b/Classes/GTWalker.h
@@ -40,13 +40,14 @@ typedef enum {
 
 @class GTRepository;
 @class GTCommit;
+@protocol GTObject;
 
 // This object is usually used from within a repository. You generally don't 
 // need to instantiate a GTWalker. Instead, use the walker property on 
 // GTRepository
-@interface GTWalker : NSObject {}
+@interface GTWalker : NSObject <GTObject> {}
 
-@property (nonatomic, assign) GTRepository *repo;
+@property (nonatomic, assign) GTRepository *repository;
 
 - (id)initWithRepository:(GTRepository *)theRepo error:(NSError **)error;
 + (id)walkerWithRepository:(GTRepository *)theRepo error:(NSError **)error;

--- a/Classes/GTWalker.m
+++ b/Classes/GTWalker.m
@@ -43,22 +43,22 @@
 - (void)dealloc {
 	
 	git_revwalk_free(self.walk);
-	self.repo = nil;
+	self.repository = nil;
 	[super dealloc];
 }
 
 #pragma mark -
 #pragma mark API
 
-@synthesize repo;
+@synthesize repository;
 @synthesize walk;
 
 - (id)initWithRepository:(GTRepository *)theRepo error:(NSError **)error {
 	
 	if((self = [super init])) {
-		self.repo = theRepo;
+		self.repository = theRepo;
 		git_revwalk *w;
-		int gitError = git_revwalk_new(&w, self.repo.repo);
+		int gitError = git_revwalk_new(&w, self.repository.repo);
 		if(gitError != GIT_SUCCESS) {
 			if (error != NULL)
 				*error = [NSError gitErrorForInitRevWalker:gitError];
@@ -124,7 +124,7 @@
 		return nil;
 	
 	// ignore error if we can't lookup object and just return nil
-	return (GTCommit *)[self.repo lookupBySha:[GTLib convertOidToSha:&oid] type:GTObjectTypeCommit error:nil];
+	return (GTCommit *)[self.repository lookupObjectBySha:[GTLib convertOidToSha:&oid] type:GTObjectTypeCommit error:nil];
 }
 
 - (NSInteger)countFromSha:(NSString *)sha error:(NSError **)error {

--- a/Tests/GTBlobTest.m
+++ b/Tests/GTBlobTest.m
@@ -48,7 +48,7 @@
 - (void)testCanReadBlobData {
 	
 	NSError *error = nil;
-	GTBlob *blob = (GTBlob *)[repo lookupBySha:sha error:&error];
+	GTBlob *blob = (GTBlob *)[repo lookupObjectBySha:sha error:&error];
 	GHAssertEquals(9, (int)blob.size, nil);
 	GHAssertEqualStrings(@"new file\n", blob.content, nil);
 	GHAssertEqualStrings(@"blob", blob.type, nil);
@@ -76,7 +76,7 @@
 - (void)testCanWriteNewBlobData {
 	
 	NSError *error = nil;
-	NSString *newSha = [GTBlob createInRepo:repo content:@"a new blob content" error:&error];
+	NSString *newSha = [GTBlob shaByCreatingBlobInRepository:repo content:@"a new blob content" error:&error];
 	GHAssertNotNil(newSha, [error localizedDescription]);
 	
 	rm_loose(newSha);
@@ -85,7 +85,7 @@
 - (void)testCanWriteNewBlobData2 {
 	
 	NSError *error = nil;
-	GTBlob *blob = [GTBlob blobInRepo:repo content:@"a new blob content" error:&error];
+	GTBlob *blob = [GTBlob blobInRepository:repo content:@"a new blob content" error:&error];
 	GHAssertNotNil(blob, [error localizedDescription]);
 	
 	rm_loose(blob.sha);
@@ -98,7 +98,7 @@
 	NSData *content = [NSData dataWithBytes:bytes length:sizeof(bytes)];
 	
 	
-	NSString *newSha = [GTBlob createInRepo:repo data:content error:&error];
+	NSString *newSha = [GTBlob shaByCreatingBlobInRepository:repo data:content error:&error];
 	GHAssertNotNil(newSha, [error localizedDescription]);
 	
 	rm_loose(newSha);

--- a/Tests/GTBranchTest.m
+++ b/Tests/GTBranchTest.m
@@ -33,7 +33,7 @@
 - (void)testCanListLocalBranchesInRepo {
 	
     NSError *error = nil;
-	NSArray *branches = [GTBranch listAllLocalBranchesInRepository:repo error:&error];
+	NSArray *branches = [GTBranch branchesInRepository:repo error:&error];
 	GHAssertNotNil(branches, [error localizedDescription], nil);
 	GHAssertEquals(2, (int)branches.count, nil);
 }
@@ -41,7 +41,7 @@
 - (void)testCanListRemoteBranchesInRepo {
 	
     NSError *error = nil;
-	NSArray *branches = [GTBranch listAllRemoteBranchesInRepository:repo error:&error];
+	NSArray *branches = [GTBranch remoteBranchesInRepository:repo error:&error];
 	GHAssertNotNil(branches, [error localizedDescription], nil);
 	GHAssertEquals(0, (int)branches.count, nil);
 }
@@ -49,12 +49,12 @@
 - (void)testCanCountCommitsInBranch {
 	
     NSError *error = nil;
-	GTReference *head = [repo headAndReturnError:&error];
+	GTReference *head = [repo headReference:&error];
 	GHAssertNotNil(head, [error localizedDescription]);
 	GTBranch *master = [GTBranch branchWithReference:head repository:repo];
 	GHAssertNotNil(master, [error localizedDescription]);
 	
-	NSUInteger n = [master numberOfCommitsAndReturnError:&error];
+	NSUInteger n = [master numberOfCommitsWithError:&error];
 	GHAssertNotEquals(n, (NSUInteger)NSNotFound, [error localizedDescription]);
 	GHAssertEquals((NSUInteger)3, n, nil);
 }
@@ -65,7 +65,7 @@
 	// This allows us to release the object and test that the branch
 	// is retaining properly.
     NSError *error = nil;
-    GTReference *head = [[GTReference alloc] initByLookingUpRef:@"HEAD" inRepo:repo error:&error];
+    GTReference *head = [[GTReference alloc] initByLookingUpReferenceNamed:@"HEAD" inRepository:repo error:&error];
 	GHAssertNotNil(head, [error localizedDescription]);
 	GTBranch *current = [GTBranch branchWithReference:head repository:repo];
 	GHAssertNotNil(current, [error localizedDescription]);

--- a/Tests/GTCommitTest.m
+++ b/Tests/GTCommitTest.m
@@ -49,7 +49,7 @@
 	
 	NSString *sha = @"8496071c1b46c854b31185ea97743be6a8774479";
 	NSError *error = nil;
-	GTObject *obj = [repo lookupBySha:sha error:&error];
+	GTObject *obj = [repo lookupObjectBySha:sha error:&error];
 	
 	GHAssertNil(error, [error localizedDescription]);
 	GHAssertNotNil(obj, nil);
@@ -81,7 +81,7 @@
 	
 	NSString *sha = @"a4a7dce85cf63874e984719f4fdd239f5145052f";
 	NSError *error = nil;
-	GTObject *obj = [repo lookupBySha:sha error:&error];
+	GTObject *obj = [repo lookupObjectBySha:sha error:&error];
 	
 	GHAssertNil(error, [error localizedDescription]);
 	GHAssertNotNil(obj, nil);
@@ -94,10 +94,10 @@
 	
 	NSError *error = nil;
 	NSString *sha = @"8496071c1b46c854b31185ea97743be6a8774479";
-	GTCommit *obj = (GTCommit *)[repo lookupBySha:sha error:&error];
+	GTCommit *obj = (GTCommit *)[repo lookupObjectBySha:sha error:&error];
 	GHAssertNotNil(obj, [error localizedDescription]);
 	
-	NSString *newSha = [GTCommit createCommitInRepo:repo 
+	NSString *newSha = [GTCommit shaByCreatingCommitInRepository:repo 
 									 updateRefNamed:nil 
 											 author:obj.author 
 										  committer:obj.committer 
@@ -115,7 +115,7 @@
 	
 	NSString *tsha = @"c4dc1555e4d4fa0e0c9c3fc46734c7c35b3ce90b";
 	NSError *error = nil;
-	GTObject *obj = [repo lookupBySha:tsha error:&error];
+	GTObject *obj = [repo lookupObjectBySha:tsha error:&error];
 	
 	GHAssertNil(error, [error localizedDescription]);
 	GHAssertNotNil(obj, nil);
@@ -125,7 +125,7 @@
 						   initWithName:@"Tim" 
 						   email:@"tclem@github.com" 
 						   time:[NSDate date]] autorelease];
-	GTCommit *commit = [GTCommit commitInRepo:repo updateRefNamed:nil author:person committer:person message:@"new message" tree:tree parents:nil error:&error];
+	GTCommit *commit = [GTCommit commitInRepository:repo updateRefNamed:nil author:person committer:person message:@"new message" tree:tree parents:nil error:&error];
 	GHAssertNotNil(commit, [error localizedDescription]);
 	GHTestLog(@"wrote sha %@", commit.sha);
 	
@@ -136,7 +136,7 @@
 	
 	NSString *tsha = @"c4dc1555e4d4fa0e0c9c3fc46734c7c35b3ce90b";
 	NSError *error = nil;
-	GTObject *obj = [repo lookupBySha:tsha error:&error];
+	GTObject *obj = [repo lookupObjectBySha:tsha error:&error];
 	
 	GHAssertNil(error, [error localizedDescription]);
 	GHAssertNotNil(obj, nil);
@@ -146,7 +146,7 @@
 							initWithName:@"Tim" 
 							email:@"tclem@github.com" 
 							time:[NSDate date]] autorelease];
-	GTCommit *commit = [GTCommit commitInRepo:repo updateRefNamed:nil author:person committer:person message:nil tree:tree parents:nil error:&error];
+	GTCommit *commit = [GTCommit commitInRepository:repo updateRefNamed:nil author:person committer:person message:nil tree:tree parents:nil error:&error];
 	GHAssertNotNil(commit, [error localizedDescription]);
 	GHTestLog(@"wrote sha %@", commit.sha);
 	

--- a/Tests/GTIndexTest.m
+++ b/Tests/GTIndexTest.m
@@ -44,7 +44,7 @@
 	
 	NSError *error = nil;
 	index = [GTIndex indexWithPath:[NSURL fileURLWithPath:TEST_INDEX_PATH()] error:&error];
-	BOOL success = [index refreshAndReturnError:&error];
+	BOOL success = [index refreshWithError:&error];
 	GHAssertTrue(success, [error localizedDescription]);
 }
 
@@ -66,8 +66,8 @@
 	GHAssertNotNil(e, nil);
 	GHAssertEqualStrings(@"README", e.path, nil);
 	GHAssertEqualStrings(@"1385f264afb75a56a5bec74243be9b367ba4ca08", e.sha, nil);
-	GHAssertEquals(1273360380, (int)[e.mTime timeIntervalSince1970], nil);
-	GHAssertEquals(1273360380, (int)[e.cTime timeIntervalSince1970], nil);
+	GHAssertEquals(1273360380, (int)[e.modificationDate timeIntervalSince1970], nil);
+	GHAssertEquals(1273360380, (int)[e.creationDate timeIntervalSince1970], nil);
 	GHAssertEquals((long long)4, e.fileSize, nil);
 	GHAssertEquals((NSUInteger)234881026, e.dev, nil);
 	GHAssertEquals((NSUInteger)6674088, e.ino, nil);
@@ -91,8 +91,8 @@
 	e.path = @"new_path";
 	BOOL success = [e setSha:@"d385f264afb75a56a5bec74243be9b367ba4ca08" error:&error];
 	GHAssertTrue(success, [error localizedDescription]);
-	e.mTime = now;
-	e.cTime = now;
+	e.modificationDate = now;
+	e.creationDate = now;
 	e.fileSize = 1000;
 	e.dev = 234881027;
 	e.ino = 88888;
@@ -128,8 +128,8 @@
 	e.path = @"new_path";
 	BOOL success = [e setSha:@"12ea3153a78002a988bb92f4123e7e831fd1138a" error:&error];
 	GHAssertTrue(success, [error localizedDescription]);
-	e.mTime = now;
-	e.cTime = now;
+	e.modificationDate = now;
+	e.creationDate = now;
 	e.fileSize = 1000;
 	e.dev = 234881027;
 	e.ino = 88888;
@@ -140,8 +140,8 @@
 	
 	GHAssertEqualStrings(@"new_path", e.path, nil);
 	GHAssertEqualStrings(@"12ea3153a78002a988bb92f4123e7e831fd1138a", e.sha, nil);
-	GHAssertEquals((int)[now timeIntervalSince1970], (int)[e.mTime timeIntervalSince1970], nil);
-	GHAssertEquals((int)[now timeIntervalSince1970], (int)[e.cTime timeIntervalSince1970], nil);
+	GHAssertEquals((int)[now timeIntervalSince1970], (int)[e.modificationDate timeIntervalSince1970], nil);
+	GHAssertEquals((int)[now timeIntervalSince1970], (int)[e.creationDate timeIntervalSince1970], nil);
 	GHAssertEquals((long long)1000, e.fileSize, nil);
 	GHAssertEquals((NSUInteger)234881027, e.dev, nil);
 	GHAssertEquals((NSUInteger)88888, e.ino, nil);
@@ -179,7 +179,7 @@
 	
 	wIndex = [GTIndex indexWithPath:tempPath error:&error];
 	GHAssertNil(error, [error localizedDescription]);
-	BOOL success = [wIndex refreshAndReturnError:&error];
+	BOOL success = [wIndex refreshWithError:&error];
 	GHAssertTrue(success, [error localizedDescription]);
 }
 
@@ -194,12 +194,12 @@
 	e.path = @"else.txt";
 	success = [wIndex addEntry:e error:&error];
 	GHAssertTrue(success, [error localizedDescription]);
-	success = [wIndex writeAndReturnError:&error];
+	success = [wIndex writeWithError:&error];
 	GHAssertTrue(success, [error localizedDescription]);
 	
 	GTIndex *index2 = [GTIndex indexWithPath:tempPath error:&error];
 	GHAssertNil(error, [error localizedDescription]);
-	success = [index2 refreshAndReturnError:&error];
+	success = [index2 refreshWithError:&error];
 	GHAssertTrue(success, [error localizedDescription]);
 	GHAssertEquals(4, (int)[index2 entryCount], nil);
 }

--- a/Tests/GTObjectTest.m
+++ b/Tests/GTObjectTest.m
@@ -46,7 +46,7 @@
 - (void)testCanLookupEmptyStringFails {
 	
 	NSError *error = nil;
-	GTObject *obj = [repo lookupBySha:@"" error:&error];
+	GTObject *obj = [repo lookupObjectBySha:@"" error:&error];
 	
 	GHAssertNotNil(error, nil);
 	GHAssertNil(obj, nil);
@@ -56,7 +56,7 @@
 - (void)testCanLookupBadObjectFails {
 	
 	NSError *error = nil;
-	GTObject *obj = [repo lookupBySha:@"a496071c1b46c854b31185ea97743be6a8774479" error:&error];
+	GTObject *obj = [repo lookupObjectBySha:@"a496071c1b46c854b31185ea97743be6a8774479" error:&error];
 	
 	GHAssertNotNil(error, nil);
 	GHAssertNil(obj, nil);
@@ -66,7 +66,7 @@
 - (void)testCanLookupAnObject {
 	
 	NSError *error = nil;
-	GTObject *obj = [repo lookupBySha:@"8496071c1b46c854b31185ea97743be6a8774479" error:&error];
+	GTObject *obj = [repo lookupObjectBySha:@"8496071c1b46c854b31185ea97743be6a8774479" error:&error];
 	
 	GHAssertNil(error, [error localizedDescription]);
 	GHAssertNotNil(obj, nil);
@@ -77,8 +77,8 @@
 - (void)testTwoObjectsAreTheSame {
 	
 	NSError *error = nil;
-	GTObject *obj1 = [repo lookupBySha:@"8496071c1b46c854b31185ea97743be6a8774479" error:&error];
-	GTObject *obj2 = [repo lookupBySha:@"8496071c1b46c854b31185ea97743be6a8774479" error:&error];
+	GTObject *obj1 = [repo lookupObjectBySha:@"8496071c1b46c854b31185ea97743be6a8774479" error:&error];
+	GTObject *obj2 = [repo lookupObjectBySha:@"8496071c1b46c854b31185ea97743be6a8774479" error:&error];
 	
 	GHAssertNotNil(obj1, nil);
 	GHAssertNotNil(obj2, nil);
@@ -88,7 +88,7 @@
 - (void)testCanReadRawDataFromObject {
 	
 	NSError *error = nil;
-	GTObject *obj = [repo lookupBySha:@"8496071c1b46c854b31185ea97743be6a8774479" error:&error];
+	GTObject *obj = [repo lookupObjectBySha:@"8496071c1b46c854b31185ea97743be6a8774479" error:&error];
 	
 	GHAssertNotNil(obj, nil);
 	

--- a/Tests/GTReferenceTest.m
+++ b/Tests/GTReferenceTest.m
@@ -26,7 +26,7 @@
 	NSError *error = nil;
 	GTRepository *repo = [GTRepository repoByOpeningRepositoryInDirectory:[NSURL fileURLWithPath:TEST_REPO_PATH()] error:&error];
 	GHAssertNil(error, [error localizedDescription]);
-	GTReference *ref = [GTReference referenceByLookingUpRef:@"refs/heads/master" inRepo:repo error:&error];
+	GTReference *ref = [GTReference referenceByLookingUpReferencedNamed:@"refs/heads/master" inRepository:repo error:&error];
 	GHAssertNil(error, [error localizedDescription]);
 	GHAssertNotNil(ref, nil);
 	
@@ -40,7 +40,7 @@
 	NSError *error = nil;
 	GTRepository *repo = [GTRepository repoByOpeningRepositoryInDirectory:[NSURL fileURLWithPath:TEST_REPO_PATH()] error:&error];
 	GHAssertNil(error, [error localizedDescription]);
-	GTReference *ref = [GTReference referenceByLookingUpRef:@"refs/tags/v0.9" inRepo:repo error:&error];
+	GTReference *ref = [GTReference referenceByLookingUpReferencedNamed:@"refs/tags/v0.9" inRepository:repo error:&error];
 	GHAssertNil(error, [error localizedDescription]);
 	GHAssertNotNil(ref, nil);
 	
@@ -54,7 +54,7 @@
 	NSError *error = nil;
 	GTRepository *repo = [GTRepository repoByOpeningRepositoryInDirectory:[NSURL fileURLWithPath:TEST_REPO_PATH()] error:&error];
 	GHAssertNil(error, [error localizedDescription]);
-	GTReference *ref = [GTReference referenceByCreatingRef:@"refs/heads/unit_test" fromRef:@"refs/heads/master" inRepo:repo error:&error];
+	GTReference *ref = [GTReference referenceByCreatingReferenceNamed:@"refs/heads/unit_test" fromReferenceTarget:@"refs/heads/master" inRepository:repo error:&error];
 	GHAssertNil(error, [error localizedDescription]);
 	GHAssertNotNil(ref, nil);
 	
@@ -62,7 +62,7 @@
 	GHAssertEqualStrings(@"tree", ref.type, nil);
 	GHAssertEqualStrings(@"refs/heads/unit_test", ref.name, nil);
 	
-	BOOL success = [ref deleteAndReturnError:&error];
+	BOOL success = [ref deleteWithError:&error];
 	GHAssertTrue(success, [error localizedDescription]);
 }
 
@@ -71,7 +71,7 @@
 	NSError *error = nil;
 	GTRepository *repo = [GTRepository repoByOpeningRepositoryInDirectory:[NSURL fileURLWithPath:TEST_REPO_PATH()] error:&error];
 	GHAssertNil(error, [error localizedDescription]);
-	GTReference *ref = [GTReference referenceByCreatingRef:@"refs/heads/unit_test" fromRef:@"36060c58702ed4c2a40832c51758d5344201d89a" inRepo:repo error:&error];
+	GTReference *ref = [GTReference referenceByCreatingReferenceNamed:@"refs/heads/unit_test" fromReferenceTarget:@"36060c58702ed4c2a40832c51758d5344201d89a" inRepository:repo error:&error];
 	GHAssertNil(error, [error localizedDescription]);
 	GHAssertNotNil(ref, nil);
 	
@@ -79,7 +79,7 @@
 	GHAssertEqualStrings(@"commit", ref.type, nil);
 	GHAssertEqualStrings(@"refs/heads/unit_test", ref.name, nil);
 	
-	BOOL success = [ref deleteAndReturnError:&error];
+	BOOL success = [ref deleteWithError:&error];
 	GHAssertTrue(success, [error localizedDescription]);
 }
 
@@ -88,7 +88,7 @@
 	NSError *error = nil;
 	GTRepository *repo = [GTRepository repoByOpeningRepositoryInDirectory:[NSURL fileURLWithPath:TEST_REPO_PATH()] error:&error];
 	GHAssertNil(error, [error localizedDescription]);
-	GTReference *ref = [GTReference referenceByCreatingRef:@"refs/heads/unit_test" fromRef:@"36060c58702ed4c2a40832c51758d5344201d89a" inRepo:repo error:&error];
+	GTReference *ref = [GTReference referenceByCreatingReferenceNamed:@"refs/heads/unit_test" fromReferenceTarget:@"36060c58702ed4c2a40832c51758d5344201d89a" inRepository:repo error:&error];
 	GHAssertNil(error, [error localizedDescription]);
 	GHAssertNotNil(ref, nil);
 	GHAssertEqualStrings(@"36060c58702ed4c2a40832c51758d5344201d89a", ref.target, nil);
@@ -99,7 +99,7 @@
 	GHAssertTrue(success, [error localizedDescription]);
 	GHAssertEqualStrings(@"refs/heads/new_name", ref.name, nil);
 	
-	success = [ref deleteAndReturnError:&error];
+	success = [ref deleteWithError:&error];
 	GHAssertTrue(success, [error localizedDescription]);
 }
 
@@ -108,7 +108,7 @@
 	NSError *error = nil;
 	GTRepository *repo = [GTRepository repoByOpeningRepositoryInDirectory:[NSURL fileURLWithPath:TEST_REPO_PATH()] error:&error];
 	GHAssertNil(error, [error localizedDescription]);
-	GTReference *ref = [GTReference referenceByCreatingRef:@"refs/heads/unit_test" fromRef:@"36060c58702ed4c2a40832c51758d5344201d89a" inRepo:repo error:&error];
+	GTReference *ref = [GTReference referenceByCreatingReferenceNamed:@"refs/heads/unit_test" fromReferenceTarget:@"36060c58702ed4c2a40832c51758d5344201d89a" inRepository:repo error:&error];
 	GHAssertNil(error, [error localizedDescription]);
 	GHAssertNotNil(ref, nil);
 	GHAssertEqualStrings(@"36060c58702ed4c2a40832c51758d5344201d89a", ref.target, nil);
@@ -120,7 +120,7 @@
 	GHAssertTrue(success, [error localizedDescription]);
 	GHAssertEqualStrings(@"5b5b025afb0b4c913b4c338a42934a3863bf3644", ref.target, nil);
 	
-	success = [ref deleteAndReturnError:&error];
+	success = [ref deleteWithError:&error];
 	GHAssertTrue(success, [error localizedDescription]);
 }
 
@@ -130,7 +130,7 @@
 	GTRepository *repo = [GTRepository repoByOpeningRepositoryInDirectory:[NSURL fileURLWithPath:TEST_REPO_PATH()] error:&error];
 	GHAssertNil(error, [error localizedDescription]);
 	
-	NSArray *refs = [GTReference listAllReferenceNamesInRepo:repo error:&error];
+	NSArray *refs = [GTReference referenceNamesInRepository:repo error:&error];
 	GHAssertNil(error, [error localizedDescription]);
 	GHAssertEquals(4, (int)refs.count, nil);
 	
@@ -146,7 +146,7 @@
 	GTRepository *repo = [GTRepository repoByOpeningRepositoryInDirectory:[NSURL fileURLWithPath:TEST_REPO_PATH()] error:&error];
 	GHAssertNil(error, [error localizedDescription]);
 	
-	NSArray *refs = [GTReference listReferenceNamesInRepo:repo types:GTReferenceTypesOid error:&error];
+	NSArray *refs = [GTReference referenceNamesInRepository:repo types:GTReferenceTypesOid error:&error];
 	GHAssertNil(error, [error localizedDescription]);
 	GHAssertEquals(3, (int)refs.count, nil);
 	
@@ -162,7 +162,7 @@
 	GHAssertNil(error, [error localizedDescription]);
 	
 	// create a symbolic reference
-	GTReference *ref = [GTReference referenceByCreatingRef:@"refs/heads/unit_test" fromRef:@"refs/heads/master" inRepo:repo error:&error];
+	GTReference *ref = [GTReference referenceByCreatingReferenceNamed:@"refs/heads/unit_test" fromReferenceTarget:@"refs/heads/master" inRepository:repo error:&error];
 	GHAssertNotNil(ref, [error localizedDescription]);
 	
 	@try {
@@ -185,7 +185,7 @@
 	GTRepository *repo = [GTRepository repoByOpeningRepositoryInDirectory:[NSURL fileURLWithPath:TEST_REPO_PATH()] error:&error];
 	GHAssertNil(error, [error localizedDescription]);
 	
-	NSArray *refs = [GTReference listReferenceNamesInRepo:repo types:GTReferenceTypesPacked error:&error];
+	NSArray *refs = [GTReference referenceNamesInRepository:repo types:GTReferenceTypesPacked error:&error];
 	GHAssertNil(error, [error localizedDescription]);
 	GHAssertEquals(1, (int)refs.count, nil);
 	

--- a/Tests/GTRepositoryTest.m
+++ b/Tests/GTRepositoryTest.m
@@ -65,7 +65,7 @@
 	GHAssertNil(error, [error localizedDescription]);
 	GHAssertNotNil(newRepo, nil);
 	GHAssertNotNil(newRepo.fileUrl, nil);
-	GHAssertNotNULL(newRepo.repo, nil);
+	GHAssertNotNULL(newRepo.repository, nil);
 }
 
 - (void)testFailsToOpenNonExistentRepo {
@@ -205,7 +205,7 @@
 - (void)testLookupHead {
 	
 	NSError *error = nil;
-	GTReference *head = [repo headAndReturnError:&error];
+	GTReference *head = [repo headReference:&error];
 	GHAssertNil(error, [error localizedDescription]);
 	GHAssertEqualStrings(head.target, @"36060c58702ed4c2a40832c51758d5344201d89a", nil);
 	GHAssertEqualStrings(head.type, @"commit", nil);

--- a/Tests/GTTagTest.m
+++ b/Tests/GTTagTest.m
@@ -40,7 +40,7 @@
 	NSError *error = nil;
 	GTRepository *repo = [GTRepository repoByOpeningRepositoryInDirectory:[NSURL fileURLWithPath:TEST_REPO_PATH()] error:&error];
 	NSString *sha = @"0c37a5391bbff43c37f0d0371823a5509eed5b1d";
-	GTTag *tag = (GTTag *)[repo lookupBySha:sha error:&error];
+	GTTag *tag = (GTTag *)[repo lookupObjectBySha:sha error:&error];
 	
 	GHAssertNil(error, [error localizedDescription]);
 	GHAssertNotNil(tag, nil);
@@ -62,9 +62,9 @@
 	NSError *error = nil;
 	NSString *sha = @"0c37a5391bbff43c37f0d0371823a5509eed5b1d";
 	GTRepository *repo = [GTRepository repoByOpeningRepositoryInDirectory:[NSURL fileURLWithPath:TEST_REPO_PATH()] error:&error];
-	GTTag *tag = (GTTag *)[repo lookupBySha:sha error:&error];
+	GTTag *tag = (GTTag *)[repo lookupObjectBySha:sha error:&error];
 	
-	[GTTag createTagInRepo:repo name:tag.name target:tag.target tagger:tag.tagger message:@"new message" error:&error];
+	[GTTag shaByCreatingTagInRepository:repo name:tag.name target:tag.target tagger:tag.tagger message:@"new message" error:&error];
 	GHAssertNotNil(error, nil);
 }
 
@@ -72,12 +72,12 @@
 	NSError *error = nil;
 	NSString *sha = @"0c37a5391bbff43c37f0d0371823a5509eed5b1d";
 	GTRepository *repo = [GTRepository repoByOpeningRepositoryInDirectory:[NSURL fileURLWithPath:TEST_REPO_PATH()] error:&error];
-	GTTag *tag = (GTTag *)[repo lookupBySha:sha error:&error];
+	GTTag *tag = (GTTag *)[repo lookupObjectBySha:sha error:&error];
 
-	NSString *newSha = [GTTag createTagInRepo:repo name:@"a_new_tag" target:tag.target tagger:tag.tagger message:@"my tag\n" error:&error];
+	NSString *newSha = [GTTag shaByCreatingTagInRepository:repo name:@"a_new_tag" target:tag.target tagger:tag.tagger message:@"my tag\n" error:&error];
 	GHAssertNotNil(newSha, [error localizedDescription]);
 	
-	tag = (GTTag *)[repo lookupBySha:newSha error:&error];
+	tag = (GTTag *)[repo lookupObjectBySha:newSha error:&error];
 	GHAssertNil(error, [error localizedDescription]);
 	GHAssertNotNil(tag, nil);
 	GHAssertEqualStrings(newSha, tag.sha, nil);

--- a/Tests/GTTreeTest.m
+++ b/Tests/GTTreeTest.m
@@ -45,14 +45,14 @@
 	NSError *error = nil;
 	repo = [GTRepository repoByOpeningRepositoryInDirectory:[NSURL fileURLWithPath:TEST_REPO_PATH()] error:&error];
 	sha = @"c4dc1555e4d4fa0e0c9c3fc46734c7c35b3ce90b";
-	tree = (GTTree *)[repo lookupBySha:sha error:&error];
+	tree = (GTTree *)[repo lookupObjectBySha:sha error:&error];
 }
 
 - (void)testCanReadTreeData {
 	
 	GHAssertEqualStrings(sha, tree.sha, nil);
 	GHAssertEqualStrings(@"tree", tree.type, nil);
-	GHAssertTrue([tree entryCount] == 3, nil);
+	GHAssertTrue([tree numberOfEntries] == 3, nil);
 	GHAssertEqualStrings(@"1385f264afb75a56a5bec74243be9b367ba4ca08", [tree entryAtIndex:0].sha, nil);
 	GHAssertEqualStrings(@"fa49b077972391ad58037050f2a75f74e3671e92", [tree entryAtIndex:1].sha, nil);
 }

--- a/Tests/GTWalkerTest.m
+++ b/Tests/GTWalkerTest.m
@@ -62,7 +62,7 @@
 	NSError *error = nil;
 	GTRepository *repo = [GTRepository repoByOpeningRepositoryInDirectory:[NSURL fileURLWithPath:TEST_REPO_PATH()] error:&error];
 	GHAssertNil(error, [error localizedDescription]);
-	GTReference *head = [repo headAndReturnError:&error];
+	GTReference *head = [repo headReference:&error];
 	GHAssertNil(error, [error localizedDescription]);
 				
 	__block int count = 0;


### PR DESCRIPTION
Hi objective-git maintainers,

I came across this project earlier today and was pleased to see it, but a little saddened by some of the names chosen for methods.  I've taken the liberty of refactoring these names to more closely follow standard Cocoa naming conventions.  The commit message describing these changes is below.

Cheers,

Dave

General convention followed in this process:
- Any parameter to a method that is an actual Objective-C object has its full name (sans prefix) in the method declaration.  In other words, `initWithRepo:` becomes `initWithRepository:`, because the parameter is of type `GTRepository`.
- Methods that require a libgit primitive use a shortened version of the libgit type in the method declaration.  For example, creating a `GTObject` from a `git_object` means the method is named: `objectWithObj:inRepository:` (again, the second part of the selector having the type fully spelled out, because the second parameter is an object).  Likewise, if you have a `git_signature *`, you can turn it into a `GTSignature` using `+signatureWithSig:`.
- Methods that return an `NSDate` now have the word "date" in the selector (as opposed to "time").
- Class-level convenience methods that return a sha hash are named `shaByCreating[Type]...` to emphasize that the returned type is a string.
- A `<GTObject>` protocol has been created to type any object that has a readonly `GTRepository` property.  This is to help unify the disparate GT\* objects that don't inherity from `GTObject`, yet have a `GTRepository` property.  The property is `readonly` to accomodate some classes exporting the property as `(nonatomic, readonly, assign)`.
- Methods that return arrays of objects have had the `listAll` prefix removed.
- `...AndReturnError:(NSError **)error` methods have been renamed to either `...WithError:` or just `error:` (as appropriate).
- Other general method name cleanup

Yes, most of these altered method names are much longer now, but they more strictly follow the Cocoa Naming Conventions and are much easier to understand.
