### PR TITLE
Expose libgit2 headers in .framework/Headers.

### DIFF
--- a/Classes/Categories/NSError+Git.m
+++ b/Classes/Categories/NSError+Git.m
@@ -28,6 +28,7 @@
 //
 
 #import "NSError+Git.h"
+#include "git2.h"
 
 NSString * const GTGitErrorDomain = @"GTGitErrorDomain";
 

--- a/Classes/Categories/NSString+Git.h
+++ b/Classes/Categories/NSString+Git.h
@@ -27,6 +27,7 @@
 //  THE SOFTWARE.
 //
 
+#include "git2.h"
 
 @interface NSString (Git)
 

--- a/Classes/GTCommit.m
+++ b/Classes/GTCommit.m
@@ -33,6 +33,7 @@
 #import "NSError+Git.h"
 #import "GTRepository.h"
 #import "NSString+Git.h"
+#import "GTLog.h"
 
 
 @implementation GTCommit

--- a/Classes/GTIndex.h
+++ b/Classes/GTIndex.h
@@ -27,6 +27,7 @@
 //  THE SOFTWARE.
 //
 
+#include "git2.h"
 
 @class GTIndexEntry;
 

--- a/Classes/GTIndexEntry.h
+++ b/Classes/GTIndexEntry.h
@@ -27,6 +27,7 @@
 //  THE SOFTWARE.
 //
 
+#include "git2.h"
 
 @interface GTIndexEntry : NSObject {}
 

--- a/Classes/GTLog.h
+++ b/Classes/GTLog.h
@@ -1,0 +1,1 @@
+#define GTLog(fmt, ...) NSLog((@"%s [Line %d] " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__);

--- a/Classes/GTObject.h
+++ b/Classes/GTObject.h
@@ -27,6 +27,7 @@
 //  THE SOFTWARE.
 //
 
+#include "git2.h"
 
 typedef enum {
 	GTObjectTypeAny = GIT_OBJ_ANY,				/**< Object can be any of the following */

--- a/ObjectiveGitFramework.xcodeproj/project.pbxproj
+++ b/ObjectiveGitFramework.xcodeproj/project.pbxproj
@@ -77,6 +77,8 @@
 		55C8057E13875C1B004DCB0F /* NSString+Git.h in Headers */ = {isa = PBXBuildFile; fileRef = 55C8057213874CDF004DCB0F /* NSString+Git.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55C8057F13875C62004DCB0F /* NSData+Git.h in Headers */ = {isa = PBXBuildFile; fileRef = BD6C2266131459E700992935 /* NSData+Git.h */; };
 		55C8058013875C6E004DCB0F /* NSString+Git.h in Headers */ = {isa = PBXBuildFile; fileRef = 55C8057213874CDF004DCB0F /* NSString+Git.h */; };
+		79262F1013C697C100A4B1EA /* git2 in Copy git2 Headers */ = {isa = PBXBuildFile; fileRef = 79262F0E13C697BE00A4B1EA /* git2 */; };
+		79262F8B13C69B1600A4B1EA /* git2.h in Headers */ = {isa = PBXBuildFile; fileRef = 79262F8A13C69B1600A4B1EA /* git2.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8803DA871313145700E6E818 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 8803DA861313145700E6E818 /* libz.dylib */; };
 		88F50F59132054D800584FBE /* GTBranch.h in Headers */ = {isa = PBXBuildFile; fileRef = 88F50F56132054D800584FBE /* GTBranch.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		88F50F5A132054D800584FBE /* GTBranch.m in Sources */ = {isa = PBXBuildFile; fileRef = 88F50F57132054D800584FBE /* GTBranch.m */; };
@@ -169,6 +171,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		79262F0F13C697BE00A4B1EA /* Copy git2 Headers */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = Headers;
+			dstSubfolderSpec = 1;
+			files = (
+				79262F1013C697C100A4B1EA /* git2 in Copy git2 Headers */,
+			);
+			name = "Copy git2 Headers";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BDD8AF0B131331B700CB5D40 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -213,6 +226,9 @@
 		55C8054D13861F34004DCB0F /* GTObjectDatabase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = GTObjectDatabase.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		55C8057213874CDF004DCB0F /* NSString+Git.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+Git.h"; sourceTree = "<group>"; };
 		55C8057313874CDF004DCB0F /* NSString+Git.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+Git.m"; sourceTree = "<group>"; };
+		79262F0E13C697BE00A4B1EA /* git2 */ = {isa = PBXFileReference; lastKnownFileType = folder; name = git2; path = libgit2/include/git2; sourceTree = "<group>"; };
+		79262F8A13C69B1600A4B1EA /* git2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = git2.h; path = libgit2/include/git2.h; sourceTree = "<group>"; };
+		79762AC013C69129000EDD32 /* GTLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GTLog.h; sourceTree = "<group>"; };
 		8803DA861313145700E6E818 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
 		88F50F56132054D800584FBE /* GTBranch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GTBranch.h; sourceTree = "<group>"; };
 		88F50F57132054D800584FBE /* GTBranch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = GTBranch.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
@@ -395,6 +411,8 @@
 		32C88DFF0371C24200C91783 /* Other Sources */ = {
 			isa = PBXGroup;
 			children = (
+				79262F8A13C69B1600A4B1EA /* git2.h */,
+				79262F0E13C697BE00A4B1EA /* git2 */,
 				88F6D9D81320451F00CC0BA8 /* ObjectiveGit.h */,
 				BDD8AF18131331F800CB5D40 /* GHUnitTestMain.m */,
 				BDD9C486133BA73E003708E7 /* GHUnitIOSTestMain.m */,
@@ -489,6 +507,7 @@
 				55C8054D13861F34004DCB0F /* GTObjectDatabase.m */,
 				AA046110134F4D2000DF526B /* GTOdbObject.h */,
 				AA046111134F4D2000DF526B /* GTOdbObject.m */,
+				79762AC013C69129000EDD32 /* GTLog.h */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -557,6 +576,7 @@
 				BDE4C064130EFE2C00851650 /* NSError+Git.h in Headers */,
 				55C8057D13875C11004DCB0F /* NSData+Git.h in Headers */,
 				55C8057E13875C1B004DCB0F /* NSString+Git.h in Headers */,
+				79262F8B13C69B1600A4B1EA /* git2.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -585,6 +605,7 @@
 			buildConfigurationList = 1DEB91AD08733DA50010E9CD /* Build configuration list for PBXNativeTarget "ObjectiveGit" */;
 			buildPhases = (
 				8DC2EF500486A6940098B216 /* Headers */,
+				79262F0F13C697BE00A4B1EA /* Copy git2 Headers */,
 				8DC2EF520486A6940098B216 /* Resources */,
 				8DC2EF540486A6940098B216 /* Sources */,
 				8DC2EF560486A6940098B216 /* Frameworks */,

--- a/ObjectiveGitFramework_Prefix.pch
+++ b/ObjectiveGitFramework_Prefix.pch
@@ -4,7 +4,4 @@
 
 #ifdef __OBJC__
     #import <Foundation/Foundation.h>
-	#import <git2.h>
 #endif
-
-#define GTLog(fmt, ...) NSLog((@"%s [Line %d] " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__);


### PR DESCRIPTION
I also moved the #import "git2.h" from the PCH to individual files so thing will compile for folks who don't have libgit2 installed on their system (like me).
