### PR TITLE
Remove test for 'shortMessage' which has been removed from the API

### DIFF
--- a/Tests/GTCommitTest.m
+++ b/Tests/GTCommitTest.m
@@ -59,7 +59,6 @@
 	
 	GTCommit *commit = (GTCommit *)obj;
 	GHAssertEqualStrings(commit.message, @"testing\n", nil);
-	GHAssertEqualStrings(commit.shortMessage, @"testing", nil);
 	GHAssertEqualStrings(commit.messageDetails, @"", nil);
 	GHAssertEquals((int)[commit.commitDate timeIntervalSince1970], 1273360386, nil); 
 	


### PR DESCRIPTION
The first thing that popped up after I cloned this.
