### PR TITLE
Fix the call te git_commit_create in GTCommit.m which was causing the tes

### DIFF
--- a/Classes/GTCommit.m
+++ b/Classes/GTCommit.m
@@ -89,8 +89,8 @@
 									   refName ? [refName UTF8String] : NULL, 
 									   authorSig.sig, 
 									   committerSig.sig, 
-									   newMessage ? [newMessage UTF8String] : "",
 									   NULL,
+                                       newMessage ? [newMessage UTF8String] : "",
 									   theTree.tree, 
 									   (int)count, 
 									   parentCommits);


### PR DESCRIPTION
Fix the call te git_commit_create in GTCommit.m which was causing the tests to break

When updating for the new libgit2 API this method was rewritten but the parameters for the message and message_encoding were flipped.

Turned them round the correct way and the Mac OS tests now work on master.
