### PR TITLE
Brought -[GTCommit shortMessage] back

### DIFF
--- a/Classes/GTCommit.h
+++ b/Classes/GTCommit.h
@@ -59,7 +59,7 @@
                                         error:(NSError **)error;
 
 - (NSString *)message;
-- (NSString *)shortMessage;
+- (NSString *)messageTitle;
 - (NSString *)messageDetails;
 - (NSDate *)commitDate;
 - (GTTree *)tree;

--- a/Classes/GTCommit.m
+++ b/Classes/GTCommit.m
@@ -108,7 +108,7 @@
 	return [NSString stringWithUTF8String:s];
 }
 
-- (NSString *)shortMessage {
+- (NSString *)messageTitle {
 	NSArray *lines = [[self message] componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
 	if ([lines count] == 0) return nil;
 	

--- a/Tests/GTCommitTest.m
+++ b/Tests/GTCommitTest.m
@@ -59,7 +59,7 @@
 	
 	GTCommit *commit = (GTCommit *)obj;
 	GHAssertEqualStrings(commit.message, @"testing\n", nil);
-	GHAssertEqualStrings(commit.shortMessage, @"testing", nil);
+	GHAssertEqualStrings(commit.messageTitle, @"testing", nil);
 	GHAssertEqualStrings(commit.messageDetails, @"", nil);
 	GHAssertEquals((int)[commit.commitDate timeIntervalSince1970], 1273360386, nil); 
 	


### PR DESCRIPTION
I thought this was a useful method and it seems fairly simple to reimplement it at the Objective Git level. 

That said, I'm not sure about this project's policy: do we strictly wrap `libgit2`'s API or can we add features?
