### PR TITLE
Fix `NSString` exception in `NSError+Git`

### DIFF
--- a/Classes/Categories/NSError+Git.m
+++ b/Classes/Categories/NSError+Git.m
@@ -44,8 +44,12 @@ NSString * const GTGitErrorDomain = @"GTGitErrorDomain";
 }
 
 + (NSError *)git_errorFor:(NSInteger)code withDescription:(NSString *)desc {
-	
-	NSString *gitErrorDesc = [NSString stringWithUTF8String:git_lasterror()];
+	const char* gitLastError = git_lasterror();
+	if (!gitLastError && code == GIT_EOSERR)
+	{
+		gitLastError = strerror(errno);
+	}
+	NSString *gitErrorDesc = [NSString stringWithUTF8String:gitLastError];
 	
 	return [NSError errorWithDomain:GTGitErrorDomain
 							   code:code


### PR DESCRIPTION
`git_lasterror()` may return NULL, which causes an exception in `[NSString stringWithUTF8String:]`

i.e. if `GTRepository - (id)initWithURL:(NSURL *)localFileURL error:(NSError **)error` is called with a `file://` URL that doesn't exist, the `git_repository_open(...)` call will fail with code `GIT_EOSERR`, which indicates that the operating system error codes should be checked.

We fix this case by using the result of `strerror(errno)` if:
- `git_lasterror()` returned `NULL`  AND
- The error `code` is `GIT_EOSERR`

This returns "No such file or directory" in the case given.
