### PR TITLE
Retrieve (all) configuration keys, and list of remotes defined in the repo

### DIFF
--- a/Classes/GTConfiguration.h
+++ b/Classes/GTConfiguration.h
@@ -32,4 +32,5 @@
 - (void)addRemote:(NSString *)remoteName withCloneURL:(NSURL *)cloneURL;
 - (void)addBranch:(NSString *)branchName trackingRemoteName:(NSString *)remoteName;
 
+- (NSArray*) configurationKeys;
 @end

--- a/Classes/GTConfiguration.m
+++ b/Classes/GTConfiguration.m
@@ -100,4 +100,20 @@
 	}
 }
 
+int configCallback(const char* name, const char* value, void* payload);
+int configCallback(const char* name, const char* value, void* payload) {
+    NSMutableArray* configurationKeysArray = (__bridge NSMutableArray*)(payload);
+
+    [configurationKeysArray addObject: [NSString stringWithCString: name encoding: [NSString defaultCStringEncoding]]];
+
+    return 0;
+}
+
+- (NSArray*) configurationKeys {
+    NSMutableArray* output = [NSMutableArray array];
+
+    git_config_foreach(self.git_config, configCallback, (__bridge void*)(output));
+    return (output);
+
+}
 @end

--- a/Classes/GTRepository.h
+++ b/Classes/GTRepository.h
@@ -137,4 +137,6 @@
 // returns the local commits, an empty array if there is no remote branch, or nil if an error occurred
 - (NSArray *)localCommitsRelativeToRemoteBranch:(GTBranch *)remoteBranch error:(NSError **)error;
 
+- (NSArray*) remoteNames;
+- (BOOL) hasRemoteNamed: (NSString*) potentialRemoteName;
 @end

--- a/Classes/GTRepository.m
+++ b/Classes/GTRepository.m
@@ -160,6 +160,29 @@
 	return [NSString git_stringWithOid:&oid];
 }
 
+- (NSArray*) remoteNames {
+    NSMutableArray* arrayOfRemotes = [NSMutableArray array];
+
+	[[[self configuration] configurationKeys] enumerateObjectsUsingBlock: ^void (NSString* configKey, NSUInteger ind, BOOL* stop) {
+		if ([configKey hasPrefix: @"remote."]) {
+			NSArray* arrayByString = [configKey componentsSeparatedByString: @"."];
+			NSString* remoteName = [arrayByString objectAtIndex: 1];
+
+			if (![arrayOfRemotes containsObject: remoteName]) {
+				//only add the object if we haven't seen it yet.
+				// we'll see a lot of keys like remote.NAME.fetch and remote.NAME.merge
+				// but we only want to add one instance of the remote in this array
+				[arrayOfRemotes addObject: remoteName];
+			}
+		}
+	}];
+
+    return arrayOfRemotes;
+}
+
+- (BOOL) hasRemoteNamed: (NSString*) potentialRemoteName {
+	return [[self remoteNames] containsObject: potentialRemoteName];
+}
 - (GTObject *)lookupObjectByOid:(git_oid *)oid objectType:(GTObjectType)type error:(NSError **)error {
 	git_object *obj;
 	

--- a/Tests/GTRepositoryTest.m
+++ b/Tests/GTRepositoryTest.m
@@ -213,6 +213,14 @@
 	GHAssertFalse([repo isEmpty], nil);
 }
 
+- (void) testCanGetRemotes {
+    NSArray* remotesArray = [repo remoteNames];
+    
+    GHAssertTrue( [remotesArray containsObject: @"github"], @"remotes name did not contain expected remote" );
+    GHAssertTrue( [repo hasRemoteNamed: @"github"], @"remotes name was not found by query function" );
+    
+}
+
 // This messes other tests up b/c it writes a new HEAD, but doesn't set it back again
 /*
 - (void)testLookupHeadThenCommitAndThenLookupHeadAgain {


### PR DESCRIPTION
Hi!

I've added a method to the GTConfiguration class, which returns an array of all config keys defined.

Additionally (and building on that) now the Repository object can return a list of remote names to the caller.
