### PR TITLE
Handle a NULL dereference causing a segfault

### DIFF
--- a/Classes/GTIndexEntry.m
+++ b/Classes/GTIndexEntry.m
@@ -76,8 +76,11 @@
 
 - (id)initWithEntry:(git_index_entry *)theEntry {
 	if((self = [self init])) {
-        git_index_entry *thisEntry = self.git_index_entry;
-        memcpy(thisEntry, theEntry, sizeof(git_index_entry));
+		if (theEntry)
+		{
+			git_index_entry *thisEntry = self.git_index_entry;
+			memcpy(thisEntry, theEntry, sizeof(git_index_entry));
+		}
 	}
 	return self;
 }


### PR DESCRIPTION
Stumbling blindly through the code while hacking away offline; I sent a gibberish string to

```
- (GTIndexEntry *) [GTIndex entryWithName:(NSString *)name]
```

If the string isn't found by `git_index_find(...)`, `git_index_get(...)` returns a NULL, which is passed blindly to

```
+ (id) [GTIndexEntry indexEntryWithEntry:(git_index_entry *)theEntry]
```

The `- (id) init` method of which promptly dereferences the NULL pointer, resulting in a good ol' SIGSEGV.

Here is my hacky handling - it'd probably be good to also check for the error state at the time of `git_index_find(...)` - but I didn't have the docs available at the time and I haven't read the new error handling document yet so I'm not up to speed on what the expected error handling behaviour is.

Regards,
    - Rowan James
