### PR TITLE
Use 7 characters instead of 6 for short SHAs

### DIFF
--- a/Classes/Categories/NSString+Git.m
+++ b/Classes/Categories/NSString+Git.m
@@ -51,9 +51,9 @@
 - (NSString *)git_shortUniqueShaString {
 	if ([self git_isHexString] == NO) { return nil; }
     
-	// Kyle says with a length of 6 our chances of collision are 9.6e-29, so we'll take those odds
+	// Seven characters matches the short form of git on the command line
 	// todo: Vicent wrote something to do this officially: consider using it instead
-	static const NSUInteger magicUniqueLength = 6;
+	static const NSUInteger magicUniqueLength = 7;
     if ([self length] < magicUniqueLength) {
         return nil;
     }


### PR DESCRIPTION
This matches the short form SHAs used on the command line (e.g., in `git diff` or `git rebase`), as well as github.com.
