### PR TITLE
GTBranch.repository should be strong

### DIFF
--- a/Classes/GTBranch.h
+++ b/Classes/GTBranch.h
@@ -41,7 +41,7 @@ typedef enum {
 @property (nonatomic, readonly) NSString *sha;
 @property (nonatomic, readonly) NSString *remoteName;
 @property (nonatomic, readonly) GTBranchType branchType;
-@property (nonatomic, readonly, unsafe_unretained) GTRepository *repository;
+@property (nonatomic, readonly, strong) GTRepository *repository;
 @property (nonatomic, readonly, strong) GTReference *reference;
 @property (nonatomic, copy) NSArray *remoteBranches;
 

--- a/Classes/GTBranch.m
+++ b/Classes/GTBranch.m
@@ -33,7 +33,7 @@
 
 @interface GTBranch ()
 @property (nonatomic, strong) GTReference *reference;
-@property (nonatomic, unsafe_unretained) GTRepository *repository;
+@property (nonatomic, strong) GTRepository *repository;
 @end
 
 @implementation GTBranch


### PR DESCRIPTION
This might seem counter-intuitive at first.

However, `GTRepository` does not retain `GTBranch` objects in any way, and several `GTBranch` methods make use of the repository. The result (right now) is that branches can easily outlive the repositories they're associated with, resulting in a crash when the branch needs to go to the repo to retrieve information.

The easiest solution here is to make `GTBranch.repository` strong, which (as implied by the above) will not cause a retain cycle.
