### PR TITLE
Fix code that could result in invalid/freed references

### DIFF
--- a/Classes/GTReference.m
+++ b/Classes/GTReference.m
@@ -142,6 +142,10 @@
 	if(gitError < GIT_OK) {
 		if(error != NULL)
 			*error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to rename reference."];
+
+		// Our reference might have been deleted (which implies being freed), so
+		// we should invalidate it.
+		self.git_reference = NULL;
 		return NO;
 	}
 	return YES;
@@ -243,7 +247,6 @@
 		}
 		
 		self.git_reference = NULL;
-		
 		return NO;
 	}
 	


### PR DESCRIPTION
There were a couple cases where libgit2 might free `GTReference.git_reference` and the code wouldn't have set it to `NULL`.
