### PR TITLE
Return the working directory path from `GTRepository.fileURL` as commented

### DIFF
--- a/Classes/GTRepository.m
+++ b/Classes/GTRepository.m
@@ -115,7 +115,7 @@
 }
 
 - (id)initWithURL:(NSURL *)localFileURL error:(NSError **)error {
-	NSURL* gitDirForLocalURL = [self.class _gitURLForURL:localFileURL error:error];
+	NSURL *gitDirForLocalURL = [self.class _gitURLForURL:localFileURL error:error];
 	if (gitDirForLocalURL == nil) return nil;
 
 	self = [super init];
@@ -437,7 +437,7 @@ static int file_status_callback(const char *relativeFilePath, unsigned int gitSt
 }
 
 - (NSURL *)fileURL {
-	const char* path = git_repository_workdir(self.git_repository);
+	const char *path = git_repository_workdir(self.git_repository);
 	// bare repository, you may be looking for gitDirectoryURL
 	if (path == NULL) return nil;
 


### PR DESCRIPTION
Implement the `NSURL* fileURL` property in the same manner as the `NSURL* gitDirectoryURL` one. It now returns the working directory as the header comments indicate (or `nil` in the case of a bare repository)

Without this change, the `fileURL` property was set to the value as the repo URL, because the parameter to the `-(id) initWithURL: error:` method was overridden by the search for the repository directory before the `self.fileURL` ivar was initialised.

This resulted in the path passed to the callback block of `-(void) enumerateFileStatusUsingBlock:` having the wrong (non-existent) path; as `int file_status_callback(const char*, unsigned int, void *)` appends the relative path passed by libgit2 to the `fileURL`
