### PR TITLE
Fix -[GTCommit parents]

### DIFF
--- a/Classes/GTCommit.m
+++ b/Classes/GTCommit.m
@@ -161,7 +161,7 @@
 			int parentResult = git_commit_parent(&parent, self.git_commit, i);
 			if (parentResult != GIT_OK) continue;
 
-            [parents addObject:(GTCommit *)[GTObject objectWithObj:(git_object *)parent inRepository:self.repository]];
+			[parents addObject:(GTCommit *)[GTObject objectWithObj:(git_object *)parent inRepository:self.repository]];
 		}
 		
 		_parents = [parents copy];


### PR DESCRIPTION
Actually use the parent count instead of grabbing parents until an error happens.
