### PR TITLE
Small improvement to testCanReset

### DIFF
--- a/ObjectiveGitTests/GTRepositoryTest.m
+++ b/ObjectiveGitTests/GTRepositoryTest.m
@@ -245,6 +245,8 @@
     }];
     GTCommit *originalHeadCommit = originalHeadCommits[0];
     [aRepo resetToCommit:originalHeadCommit withResetType:GTRepositoryResetTypeSoft error:NULL];
+    head = [aRepo headReferenceWithError:&err];
+    STAssertEqualObjects(head.target, originalHead.target, @"Reset failed to move head back to the original position");
 }
 
 - (void)expectSHA:(NSString*)sha forRefspec:(NSString*)refspec {


### PR DESCRIPTION
While working on issue #117, I noticed an opportunity to add an additional check at the end of testCanReset to ensure that head was reset to its original reference. 
