### PR TITLE
When opening a repository let libgit2 find the appropriate git directory

### DIFF
--- a/Classes/GTRepository.m
+++ b/Classes/GTRepository.m
@@ -85,24 +85,6 @@
 	return NO;
 }
 
-+ (NSURL *)_gitURLForURL:(NSURL *)url error:(NSError **)error {
-	if (!url.isFileURL) {
-		if (error != NULL) *error = [NSError errorWithDomain:NSCocoaErrorDomain code:kCFURLErrorUnsupportedURL userInfo:@{ NSLocalizedDescriptionKey: @"not a local file URL" }];
-		return nil;
-	}
-	NSURL *filePathURL = url.filePathURL;
-	if (filePathURL == nil) {
-		if (error != NULL) *error = [NSError errorWithDomain:NSCocoaErrorDomain code:kCFURLErrorUnsupportedURL userInfo:@{ NSLocalizedDescriptionKey: @"not a valid file path URL" }];
-		return nil;
-	}
-
-	if (![filePathURL.path hasSuffix:@".git"] || ![GTRepository isAGitDirectory:filePathURL]) {
-		filePathURL = [filePathURL URLByAppendingPathComponent:@".git"];
-	}
-
-	return filePathURL;
-}
-
 + (BOOL)initializeEmptyRepositoryAtURL:(NSURL *)localFileURL error:(NSError **)error {
 	const char *path = localFileURL.path.UTF8String;
 
@@ -128,9 +110,6 @@
 }
 
 - (id)initWithURL:(NSURL *)localFileURL error:(NSError **)error {
-	NSURL *gitDirForLocalURL = [self.class _gitURLForURL:localFileURL error:error];
-	if (gitDirForLocalURL == nil) return nil;
-
 	self = [super init];
 	if (self == nil) return nil;
 


### PR DESCRIPTION
It seems to me that this is something that is likely to be already handled; but I couldn't get my GitX fork to handle submodules initialised under git 1.8 (within the root .git dir) without making this change.

The crux of the issue is that passing the already-converted-to-repository dir to libgit2 meant that it doesn't know which submodule you're actually referring to.

---

This is required when the repository's submodules
have been initialised with git 1.8, and their .git
is nested within the root project's.

If opened directly through the git directory,
libgit2 will lose track of which working directory
a user is trying to manipulate; will be unable to
find refs, and other such fun.
