### PR TITLE
Repository equality is dumb. Let's go shopping.

### DIFF
--- a/Classes/GTDiff.m
+++ b/Classes/GTDiff.m
@@ -81,7 +81,7 @@ NSString *const GTDiffFindOptionsTargetLimitKey = @"GTDiffFindOptionsTargetLimit
 }
 
 + (GTDiff *)diffOldTree:(GTTree *)oldTree withNewTree:(GTTree *)newTree options:(NSDictionary *)options error:(NSError **)error {
-	NSParameterAssert([oldTree.repository.fileURL isEqual:newTree.repository.fileURL]);
+	NSParameterAssert([oldTree.repository isEqual:newTree.repository]);
 	
 	git_diff_options *optionsStruct = [self optionsStructFromDictionary:options];
 	git_diff_list *diffList;

--- a/Classes/GTRepository.m
+++ b/Classes/GTRepository.m
@@ -55,6 +55,10 @@
 	return [NSString stringWithFormat:@"<%@: %p> fileURL: %@", self.class, self, self.fileURL];
 }
 
+- (BOOL)isEqual:(GTRepository *)comparisonRepository {
+	return ([self.fileURL isEqual:comparisonRepository.fileURL]);
+}
+
 - (void)dealloc {
 	// Alright so git_revwalk needs to be free'd before the repository it points to is free'd, otherwise the odb is double-free'd and it crashes. But GTEnumerator shouldn't have to know anything about the lifetime of its GTRepository to keep from crashing. So the repository keeps track of all the enumerators pointing to it and nils out their repository when they're being dealloc'd. That tells the enumerator that it should go ahead and free its revwalk. And so life goes on.
 	for (NSValue *weakWrappedValue in self.weakEnumerators) {


### PR DESCRIPTION
Turns out that comparing repositories is an absolute shitshow. Let's just compare against the repository file URLs. 

This works way better in practice.
