### PR TITLE
Re-add error checking to -initWithURL:error:

### DIFF
--- a/Classes/GTRepository.m
+++ b/Classes/GTRepository.m
@@ -110,6 +110,11 @@
 }
 
 - (id)initWithURL:(NSURL *)localFileURL error:(NSError **)error {
+	if (![localFileURL isFileURL] || localFileURL.path == nil) {
+		if (error != NULL) *error = [NSError errorWithDomain:NSCocoaErrorDomain code:kCFURLErrorUnsupportedURL userInfo:@{ NSLocalizedDescriptionKey: NSLocalizedString(@"Invalid file path URL to open.", @"") }];
+		return nil;
+	}
+
 	self = [super init];
 	if (self == nil) return nil;
 


### PR DESCRIPTION
Although libgit2 does some error checking, it also likes to assert against `NULL`. Avoid crashing by short-circuiting the `nil` or obviously invalid case.

CC @rowanj
