### PR TITLE
Ignore RubyMotion build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 build/*
 .build/*
 build-iPhoneSimulator/*
+build-iPhoneOS/*
+objective-git.bridgesupport
 ObjectiveGitFramework/build/*
 ObjectiveGit-iOS.framework/*
 libgit2*.a


### PR DESCRIPTION
These files are created when you vendor the ObjectiveGit Xcode project
within a RubyMotion app
