### PR TITLE
Fixed issue with -createBranchNamed:

### DIFF
--- a/Classes/GTRepository.m
+++ b/Classes/GTRepository.m
@@ -433,11 +433,9 @@ static int file_status_callback(const char *relativeFilePath, unsigned int gitSt
 	if (!success) return nil;
 
 	GTReference *newRef = [GTReference referenceByCreatingReferenceNamed:[NSString stringWithFormat:@"%@%@", [GTBranch localNamePrefix], name] fromReferenceTarget:ref.target inRepository:self error:error];
-	if (newRef) {
-		return [GTBranch branchWithReference:newRef repository:self];
-	} else {
-		return nil;
-	}
+	if (newRef == nil) return nil;
+	
+	return [GTBranch branchWithReference:newRef repository:self];
 }
 
 - (BOOL)isEmpty {


### PR DESCRIPTION
This function was returning a branch object even if it couldn't create the branch. This would happen if the branch already existed.
