### PR TITLE
Update clone checkout strategy to GIT_CHECKOUT_SAFE_CREATE

### DIFF
--- a/Classes/GTRepository.m
+++ b/Classes/GTRepository.m
@@ -160,7 +160,7 @@ static int transferProgressCallback(const git_transfer_progress *progress, void 
 	
 	if (withCheckout) {
 		git_checkout_opts checkoutOptions = GIT_CHECKOUT_OPTS_INIT;
-		checkoutOptions.checkout_strategy = GIT_CHECKOUT_SAFE;
+		checkoutOptions.checkout_strategy = GIT_CHECKOUT_SAFE_CREATE;
 		checkoutOptions.progress_cb = checkoutProgressCallback;
 		checkoutOptions.progress_payload = (__bridge void *)checkoutProgressBlock;
 		cloneOptions.checkout_opts = checkoutOptions;


### PR DESCRIPTION
Per the libgit2 docs on what checkout strategy should be used for cloning
