### PR TITLE
Allow empty trees for all GTDiff initializers

### DIFF
--- a/Classes/GTDiff.h
+++ b/Classes/GTDiff.h
@@ -160,15 +160,17 @@ typedef enum : git_diff_find_t {
 //
 // The 2 trees must be from the same repository, or an exception will be thrown.
 //
-// oldTree - The "left" side of the diff. May be nil to represent an empty tree.
-// newTree - The "right" side of the diff.
-// options - A dictionary containing any of the above options key constants, or
-//           nil to use the defaults.
-// error   - Populated with an `NSError` object on error, if information is
-//           available.
+// oldTree    - The "left" side of the diff. May be nil to represent an empty tree.
+// newTree    - The "right" side of the diff. May be nil to represent an empty
+//              tree.
+// repository - The repository to be used for the diff.
+// options    - A dictionary containing any of the above options key constants, or
+//              nil to use the defaults.
+// error      - Populated with an `NSError` object on error, if information is
+//              available.
 //
 // Returns a newly created `GTDiff` object or nil on error.
-+ (GTDiff *)diffOldTree:(GTTree *)oldTree withNewTree:(GTTree *)newTree options:(NSDictionary *)options error:(NSError **)error;
++ (GTDiff *)diffOldTree:(GTTree *)oldTree withNewTree:(GTTree *)newTree inRepository:(GTRepository *)repository options:(NSDictionary *)options error:(NSError **)error;
 
 // Create a diff between a repository's current index.
 //
@@ -178,16 +180,17 @@ typedef enum : git_diff_find_t {
 // The tree you pass will be used for the "left" side of the diff, and the
 // index will be used for the "right" side of the diff.
 //
-// tree    - The tree to be diffed. The index will be taken from this tree's
-//           repository. The left side of the diff. May be nil to represent an
-//           empty tree.
-// options - A dictionary containing any of the above options key constants, or
-//           nil to use the defaults.
-// error   - Populated with an `NSError` object on error, if information is
-//           available.
+// tree       - The tree to be diffed. The index will be taken from this tree's
+//              repository. The left side of the diff. May be nil to represent an
+//              empty tree.
+// repository - The repository to be used for the diff.
+// options    - A dictionary containing any of the above options key constants, or
+//              nil to use the defaults.
+// error      - Populated with an `NSError` object on error, if information is
+//              available.
 //
 // Returns a newly created `GTDiff` object or nil on error.
-+ (GTDiff *)diffIndexFromTree:(GTTree *)tree options:(NSDictionary *)options error:(NSError **)error;
++ (GTDiff *)diffIndexFromTree:(GTTree *)tree inRepository:(GTRepository *)repository options:(NSDictionary *)options error:(NSError **)error;
 
 // Create a diff between the index and working directory in a given repository.
 //
@@ -204,17 +207,21 @@ typedef enum : git_diff_find_t {
 
 // Create a diff between a repository's working directory and a tree.
 //
-// tree    - The tree to be diffed. The tree will be the left side of the diff.
-//           May be nil to represent an empty tree.
-// options - A dictionary containing any of the above options key constants, or
-//           nil to use the defaults.
-// error   - Populated with an `NSError` object on error, if information is
-//           available.
+// tree       - The tree to be diffed. The tree will be the left side of the diff.
+//              May be nil to represent an empty tree.
+// repository - The repository to be used for the diff.
+// options    - A dictionary containing any of the above options key constants, or
+//              nil to use the defaults.
+// error      - Populated with an `NSError` object on error, if information is
+//              available.
 //
 // Returns a newly created `GTDiff` object or nil on error.
-+ (GTDiff *)diffWorkingDirectoryFromTree:(GTTree *)tree options:(NSDictionary *)options error:(NSError **)error;
++ (GTDiff *)diffWorkingDirectoryFromTree:(GTTree *)tree inRepository:(GTRepository *)repository options:(NSDictionary *)options error:(NSError **)error;
 
 // Create a diff between the working directory and HEAD.
+//
+// If the repository does not have a HEAD commit yet, this will create a diff of
+// the working directory as if everything would be part of the initial commit.
 //
 // repository - The repository to be used for the diff.
 // options    - A dictionary containing any of the above options key constants,

--- a/ObjectiveGitTests/GTDiffSpec.m
+++ b/ObjectiveGitTests/GTDiffSpec.m
@@ -26,27 +26,28 @@ describe(@"GTDiff initialisation", ^{
 	});
 	
 	it(@"should be able to initialise a diff from 2 trees", ^{
-		expect([GTDiff diffOldTree:firstCommit.tree withNewTree:secondCommit.tree options:nil error:NULL]).toNot.beNil();
+		expect([GTDiff diffOldTree:firstCommit.tree withNewTree:secondCommit.tree inRepository:repository options:nil error:NULL]).toNot.beNil();
 	});
 	
 	it(@"should be able to initialise a diff against an empty tree", ^{
-		expect([GTDiff diffOldTree:nil withNewTree:firstCommit.tree options:nil error:NULL]).toNot.beNil();
+		expect([GTDiff diffOldTree:nil withNewTree:firstCommit.tree inRepository:repository options:nil error:NULL]).toNot.beNil();
+		expect([GTDiff diffOldTree:firstCommit.tree withNewTree:nil inRepository:repository options:nil error:NULL]).toNot.beNil();
 	});
 	
 	it(@"should be able to initialise a diff against the index with a tree", ^{
-		expect([GTDiff diffIndexFromTree:secondCommit.tree options:nil error:NULL]).toNot.beNil();
+		expect([GTDiff diffIndexFromTree:secondCommit.tree inRepository:repository options:nil error:NULL]).toNot.beNil();
 	});
 	
 	it(@"should be able to initialise a diff against the index without a tree", ^{
-		expect([GTDiff diffIndexFromTree:nil options:nil error:NULL]).toNot.beNil();
+		expect([GTDiff diffIndexFromTree:nil inRepository:repository options:nil error:NULL]).toNot.beNil();
 	});
 	
 	it(@"should be able to initialise a diff against a working directory and a tree", ^{
-		expect([GTDiff diffWorkingDirectoryFromTree:firstCommit.tree options:nil error:NULL]).toNot.beNil();
+		expect([GTDiff diffWorkingDirectoryFromTree:firstCommit.tree inRepository:repository options:nil error:NULL]).toNot.beNil();
 	});
 	
 	it(@"should be able to initialise a diff against a working directory and an empty tree", ^{
-		expect([GTDiff diffWorkingDirectoryFromTree:nil options:nil error:NULL]).toNot.beNil();
+		expect([GTDiff diffWorkingDirectoryFromTree:nil inRepository:repository options:nil error:NULL]).toNot.beNil();
 	});
 	
 	it(@"should be able to initialse a diff against an index from a repo's working directory", ^{
@@ -74,7 +75,7 @@ describe(@"GTDiff diffing", ^{
 			secondCommit = (GTCommit *)[repository lookupObjectBySha:secondCommitSHA objectType:GTObjectTypeCommit error:NULL];
 			expect(secondCommit).toNot.beNil();
 			
-			diff = [GTDiff diffOldTree:firstCommit.tree withNewTree:secondCommit.tree options:options error:NULL];
+			diff = [GTDiff diffOldTree:firstCommit.tree withNewTree:secondCommit.tree inRepository:repository options:options error:NULL];
 			expect(diff).toNot.beNil();
 		} copy];
 	});


### PR DESCRIPTION
Otherwise, it's impossible to figure out what the contents of the initial commit will be.

@dannygreg 
