### PR TITLE
Allow building as Objective-C++

### DIFF
--- a/Classes/GTDiff.h
+++ b/Classes/GTDiff.h
@@ -9,6 +9,7 @@
 #import "git2.h"
 
 #import "GTDiffDelta.h"
+#import "GTEnum.h"
 
 @class GTDiffDelta;
 @class GTRepository;
@@ -61,7 +62,7 @@ extern NSString *const GTDiffOptionsPathSpecArrayKey;
 // `GTDiffOptionsFlagsKey` key.
 //
 // See diff.h for documentation of each individual flag. 
-typedef enum : git_diff_option_t {
+typedef enum : underlying_libgit2_enum(git_diff_option_t) {
 	GTDiffOptionsFlagsNormal = GIT_DIFF_NORMAL,
 	GTDiffOptionsFlagsReverse = GIT_DIFF_REVERSE,
 	GTDiffOptionsFlagsForceText = GIT_DIFF_FORCE_TEXT,
@@ -136,7 +137,7 @@ extern NSString *const GTDiffFindOptionsRenameLimitKey;
 // Enum for options passed into `-findSimilarWithOptions:`.
 //
 // For individual case documentation see `diff.h`.
-typedef enum : git_diff_find_t {
+typedef enum : underlying_libgit2_enum(git_diff_find_t) {
 	GTDiffFindOptionsFlagsFindRenames = GIT_DIFF_FIND_RENAMES,
 	GTDiffFindOptionsFlagsFindRenamesFromRewrites = GIT_DIFF_FIND_RENAMES_FROM_REWRITES,
 	GTDiffFindOptionsFlagsFindCopies = GIT_DIFF_FIND_COPIES,

--- a/Classes/GTDiffDelta.h
+++ b/Classes/GTDiffDelta.h
@@ -8,6 +8,8 @@
 
 #import "git2.h"
 
+#import "GTEnum.h"
+
 @class GTDiffFile;
 @class GTDiffHunk;
 
@@ -24,7 +26,7 @@
 //                             and is therefore currently untracked.
 // GTDiffFileDeltaTypeChange - The file has changed from a blob to either a
 //                             submodule, symlink or directory. Or vice versa.
-typedef enum : git_delta_t {
+typedef enum : underlying_libgit2_enum(git_delta_t) {
 	GTDiffFileDeltaUnmodified = GIT_DELTA_UNMODIFIED,
 	GTDiffFileDeltaAdded = GIT_DELTA_ADDED,
 	GTDiffFileDeltaDeleted = GIT_DELTA_DELETED,

--- a/Classes/GTDiffFile.h
+++ b/Classes/GTDiffFile.h
@@ -7,11 +7,12 @@
 //
 
 #import "git2.h"
+#import "GTEnum.h"
 
 // Flags which may be set on the file.
 //
 // See diff.h for individual documentation.
-typedef enum : git_diff_flag_t {
+typedef enum : underlying_libgit2_enum(git_diff_flag_t) {
 	GTDiffFileFlagValidOID = GIT_DIFF_FLAG_VALID_OID,
 	GTDiffFileFlagBinary = GIT_DIFF_FLAG_BINARY,
 	GTDiffFileFlagNotBinary = GIT_DIFF_FLAG_NOT_BINARY,

--- a/Classes/GTDiffLine.h
+++ b/Classes/GTDiffLine.h
@@ -7,11 +7,12 @@
 //
 
 #import "git2.h"
+#import "GTEnum.h"
 
 // A character representing the origin of a given line.
 //
 // See diff.h for individual documentation.
-typedef enum : git_diff_line_t {
+typedef enum : underlying_libgit2_enum(git_diff_line_t) {
 	GTDiffLineOriginContext = GIT_DIFF_LINE_CONTEXT,
 	GTDiffLineOriginAddition = GIT_DIFF_LINE_ADDITION,
 	GTDiffLineOriginDeletion = GIT_DIFF_LINE_DELETION,

--- a/Classes/GTRepository.h
+++ b/Classes/GTRepository.h
@@ -31,6 +31,7 @@
 #import "GTObject.h"
 #import "GTEnumerator.h"
 #import "GTReference.h"
+#import "GTEnum.h"
 
 @class GTBranch;
 @class GTCommit;
@@ -56,7 +57,7 @@ enum {
 
 typedef unsigned int GTRepositoryFileStatus;
 
-typedef enum : git_reset_t {
+typedef enum : underlying_libgit2_enum(git_reset_t) {
     GTRepositoryResetTypeSoft = GIT_RESET_SOFT,
     GTRepositoryResetTypeMixed = GIT_RESET_MIXED,
     GTRepositoryResetTypeHard = GIT_RESET_HARD

--- a/Classes/GTSubmodule.h
+++ b/Classes/GTSubmodule.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import "GTObject.h"
+#import "GTEnum.h"
 
 @class GTOID;
 
@@ -15,7 +16,7 @@
 // ignored when retrieving its status.
 //
 // These flags are mutually exclusive.
-typedef enum : git_submodule_ignore_t {
+typedef enum : underlying_libgit2_enum(git_submodule_ignore_t) {
 	GTSubmoduleIgnoreDefault = GIT_SUBMODULE_IGNORE_DEFAULT,
 	GTSubmoduleIgnoreNone = GIT_SUBMODULE_IGNORE_NONE,
 	GTSubmoduleIgnoreUntracked = GIT_SUBMODULE_IGNORE_UNTRACKED,
@@ -26,7 +27,7 @@ typedef enum : git_submodule_ignore_t {
 // Describes the status of a submodule.
 //
 // These flags may be ORed together.
-typedef enum : git_submodule_status_t {
+typedef enum : underlying_libgit2_enum(git_submodule_status_t) {
 	GTSubmoduleStatusUnknown = 0,
 
 	GTSubmoduleStatusExistsInHEAD = GIT_SUBMODULE_STATUS_IN_HEAD,

--- a/Classes/GTTreeBuilder.h
+++ b/Classes/GTTreeBuilder.h
@@ -30,8 +30,10 @@
 #import <Foundation/Foundation.h>
 #include "git2.h"
 
+#import "GTEnum.h"
+
 // The mode of an index or tree entry.
-typedef enum : git_filemode_t {
+typedef enum : underlying_libgit2_enum(git_filemode_t) {
 	GTFileModeNew = GIT_FILEMODE_NEW,
 	GTFileModeTree = GIT_FILEMODE_TREE,
 	GTFileModeBlob = GIT_FILEMODE_BLOB,

--- a/GTEnum.h
+++ b/GTEnum.h
@@ -1,0 +1,16 @@
+//
+//  GTEnum.h
+//  ObjectiveGitFramework
+//
+//
+
+#ifndef ObjectiveGitFramework_GTEnum_h
+#define ObjectiveGitFramework_GTEnum_h
+
+#ifdef __cplusplus
+#define underlying_libgit2_enum(X) __underlying_type(X)
+#else
+#define underlying_libgit2_enum(X) X
+#endif
+
+#endif

--- a/ObjectiveGitFramework.xcodeproj/project.pbxproj
+++ b/ObjectiveGitFramework.xcodeproj/project.pbxproj
@@ -89,6 +89,8 @@
 		30FDC08116835A8100654BF0 /* GTDiffLine.m in Sources */ = {isa = PBXBuildFile; fileRef = 30FDC07E16835A8100654BF0 /* GTDiffLine.m */; };
 		30FDC08216835A8100654BF0 /* GTDiffLine.m in Sources */ = {isa = PBXBuildFile; fileRef = 30FDC07E16835A8100654BF0 /* GTDiffLine.m */; };
 		3E0A23E5159E0FDB00A6068F /* GTObjectDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = 55C8054C13861F34004DCB0F /* GTObjectDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4A1223161763601A0041B567 /* GTEnum.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A12230B17635F340041B567 /* GTEnum.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4A12231D176361AB0041B567 /* GTEnum.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A12230B17635F340041B567 /* GTEnum.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55C8054F13861FE7004DCB0F /* GTObjectDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = 55C8054D13861F34004DCB0F /* GTObjectDatabase.m */; };
 		55C8055013861FE7004DCB0F /* GTObjectDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = 55C8054D13861F34004DCB0F /* GTObjectDatabase.m */; };
 		55C8057A13875578004DCB0F /* NSString+Git.m in Sources */ = {isa = PBXBuildFile; fileRef = 55C8057313874CDF004DCB0F /* NSString+Git.m */; };
@@ -330,6 +332,7 @@
 		30FDC07D16835A8100654BF0 /* GTDiffLine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GTDiffLine.h; sourceTree = "<group>"; };
 		30FDC07E16835A8100654BF0 /* GTDiffLine.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GTDiffLine.m; sourceTree = "<group>"; };
 		32DBCF5E0370ADEE00C91783 /* ObjectiveGitFramework_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjectiveGitFramework_Prefix.pch; sourceTree = "<group>"; };
+		4A12230B17635F340041B567 /* GTEnum.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GTEnum.h; sourceTree = "<group>"; };
 		55C8054C13861F34004DCB0F /* GTObjectDatabase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GTObjectDatabase.h; sourceTree = "<group>"; };
 		55C8054D13861F34004DCB0F /* GTObjectDatabase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = GTObjectDatabase.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		55C8057213874CDF004DCB0F /* NSString+Git.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+Git.h"; sourceTree = "<group>"; };
@@ -578,6 +581,7 @@
 				32DBCF5E0370ADEE00C91783 /* ObjectiveGitFramework_Prefix.pch */,
 				79262F0E13C697BE00A4B1EA /* git2 */,
 				79262F8A13C69B1600A4B1EA /* git2.h */,
+				4A12230B17635F340041B567 /* GTEnum.h */,
 			);
 			name = "Other Sources";
 			sourceTree = "<group>";
@@ -830,6 +834,7 @@
 				3011D8781668F29600CE3409 /* GTDiffDelta.h in Headers */,
 				8821547E17147B3600D76B76 /* GTOID.h in Headers */,
 				8821546A1714740500D76B76 /* GTReflog.h in Headers */,
+				4A12231D176361AB0041B567 /* GTEnum.h in Headers */,
 				6A74CA3616A942C000E1A3C5 /* GTConfiguration+Private.h in Headers */,
 				30B1E7EF1703522100D0814D /* NSDate+GTTimeAdditions.h in Headers */,
 				D09C2E371755F16200065E36 /* GTSubmodule.h in Headers */,
@@ -872,6 +877,7 @@
 				8821547D17147B3600D76B76 /* GTOID.h in Headers */,
 				8821547617147A5200D76B76 /* GTReflogEntry.h in Headers */,
 				30B1E7EE1703522100D0814D /* NSDate+GTTimeAdditions.h in Headers */,
+				4A1223161763601A0041B567 /* GTEnum.h in Headers */,
 				D09C2E361755F16200065E36 /* GTSubmodule.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Under C++, the libgit2 enums are their own non-integral type that cannot
be used as an underlying representation in an enum definition themselves.

There are other fixes for this for this (i.e. C++11 `std::underlying_type< gt_enum_t >::type`), but since I'm unsure why the underlying type is even being specified, or if Objective-C++ fixes will be accepted, I don't know how elaborate to get with this.

I'd like to know what case specifying the storage is expected to fix, given that both Objective-Git and libgit2 are going to have to be ABI compatible to even link, I expect the enums mapped with the same count and values as the libgit2 ones to be implicitly identical in storage.
