### PR TITLE
Use int as the underlying type for libgit2 enums

### DIFF
--- a/Classes/GTDiff.h
+++ b/Classes/GTDiff.h
@@ -61,7 +61,7 @@ extern NSString *const GTDiffOptionsPathSpecArrayKey;
 // `GTDiffOptionsFlagsKey` key.
 //
 // See diff.h for documentation of each individual flag. 
-typedef enum : int {
+typedef enum {
 	GTDiffOptionsFlagsNormal = GIT_DIFF_NORMAL,
 	GTDiffOptionsFlagsReverse = GIT_DIFF_REVERSE,
 	GTDiffOptionsFlagsForceText = GIT_DIFF_FORCE_TEXT,
@@ -136,7 +136,7 @@ extern NSString *const GTDiffFindOptionsRenameLimitKey;
 // Enum for options passed into `-findSimilarWithOptions:`.
 //
 // For individual case documentation see `diff.h`.
-typedef enum : int {
+typedef enum {
 	GTDiffFindOptionsFlagsFindRenames = GIT_DIFF_FIND_RENAMES,
 	GTDiffFindOptionsFlagsFindRenamesFromRewrites = GIT_DIFF_FIND_RENAMES_FROM_REWRITES,
 	GTDiffFindOptionsFlagsFindCopies = GIT_DIFF_FIND_COPIES,

--- a/Classes/GTDiffDelta.h
+++ b/Classes/GTDiffDelta.h
@@ -24,7 +24,7 @@
 //                             and is therefore currently untracked.
 // GTDiffFileDeltaTypeChange - The file has changed from a blob to either a
 //                             submodule, symlink or directory. Or vice versa.
-typedef enum : int {
+typedef enum {
 	GTDiffFileDeltaUnmodified = GIT_DELTA_UNMODIFIED,
 	GTDiffFileDeltaAdded = GIT_DELTA_ADDED,
 	GTDiffFileDeltaDeleted = GIT_DELTA_DELETED,

--- a/Classes/GTDiffFile.h
+++ b/Classes/GTDiffFile.h
@@ -11,7 +11,7 @@
 // Flags which may be set on the file.
 //
 // See diff.h for individual documentation.
-typedef enum : int {
+typedef enum {
 	GTDiffFileFlagValidOID = GIT_DIFF_FLAG_VALID_OID,
 	GTDiffFileFlagBinary = GIT_DIFF_FLAG_BINARY,
 	GTDiffFileFlagNotBinary = GIT_DIFF_FLAG_NOT_BINARY,

--- a/Classes/GTDiffLine.h
+++ b/Classes/GTDiffLine.h
@@ -11,7 +11,7 @@
 // A character representing the origin of a given line.
 //
 // See diff.h for individual documentation.
-typedef enum : int {
+typedef enum {
 	GTDiffLineOriginContext = GIT_DIFF_LINE_CONTEXT,
 	GTDiffLineOriginAddition = GIT_DIFF_LINE_ADDITION,
 	GTDiffLineOriginDeletion = GIT_DIFF_LINE_DELETION,

--- a/Classes/GTRepository.h
+++ b/Classes/GTRepository.h
@@ -56,7 +56,7 @@ enum {
 
 typedef unsigned int GTRepositoryFileStatus;
 
-typedef enum : int {
+typedef enum {
     GTRepositoryResetTypeSoft = GIT_RESET_SOFT,
     GTRepositoryResetTypeMixed = GIT_RESET_MIXED,
     GTRepositoryResetTypeHard = GIT_RESET_HARD

--- a/Classes/GTSubmodule.h
+++ b/Classes/GTSubmodule.h
@@ -15,7 +15,7 @@
 // ignored when retrieving its status.
 //
 // These flags are mutually exclusive.
-typedef enum : int {
+typedef enum {
 	GTSubmoduleIgnoreDefault = GIT_SUBMODULE_IGNORE_DEFAULT,
 	GTSubmoduleIgnoreNone = GIT_SUBMODULE_IGNORE_NONE,
 	GTSubmoduleIgnoreUntracked = GIT_SUBMODULE_IGNORE_UNTRACKED,
@@ -26,7 +26,7 @@ typedef enum : int {
 // Describes the status of a submodule.
 //
 // These flags may be ORed together.
-typedef enum : int {
+typedef enum {
 	GTSubmoduleStatusUnknown = 0,
 
 	GTSubmoduleStatusExistsInHEAD = GIT_SUBMODULE_STATUS_IN_HEAD,

--- a/Classes/GTTreeBuilder.h
+++ b/Classes/GTTreeBuilder.h
@@ -31,7 +31,7 @@
 #include "git2.h"
 
 // The mode of an index or tree entry.
-typedef enum : int {
+typedef enum {
 	GTFileModeNew = GIT_FILEMODE_NEW,
 	GTFileModeTree = GIT_FILEMODE_TREE,
 	GTFileModeBlob = GIT_FILEMODE_BLOB,


### PR DESCRIPTION
The latest LLVM complains that we're using a non-integral type as the underlying type, which it doesn't allow.

This obviates the need for #181.
