### PR TITLE
-force_load all libgit2 symbols so they're available to consumers

### DIFF
--- a/ObjectiveGitFramework.xcodeproj/project.pbxproj
+++ b/ObjectiveGitFramework.xcodeproj/project.pbxproj
@@ -1274,8 +1274,7 @@
 				);
 				OTHER_LDFLAGS = (
 					"-lgit2-iOS",
-					"-force_load",
-					"libgit2-iOS.a",
+					"-all_load",
 				);
 				PRODUCT_NAME = "ObjectiveGit-iOS";
 				PUBLIC_HEADERS_FOLDER_PATH = /usr/local/include/ObjectiveGit;
@@ -1293,8 +1292,7 @@
 				);
 				OTHER_LDFLAGS = (
 					"-lgit2-iOS",
-					"-force_load",
-					"libgit2-iOS.a",
+					"-all_load",
 				);
 				PRODUCT_NAME = "ObjectiveGit-iOS";
 				PUBLIC_HEADERS_FOLDER_PATH = /usr/local/include/ObjectiveGit;
@@ -1447,8 +1445,7 @@
 				);
 				OTHER_LDFLAGS = (
 					"-lgit2-iOS",
-					"-force_load",
-					"libgit2-iOS.a",
+					"-all_load",
 				);
 				PRODUCT_NAME = "ObjectiveGit-iOS";
 				PUBLIC_HEADERS_FOLDER_PATH = /usr/local/include/ObjectiveGit;


### PR DESCRIPTION
If we don't do this, only those libgit2 symbols that are used by ObjectiveGit will be available. libgit2 symbols should always be available for use by apps.

@joshaber This is the root cause of the linker error you ran into as well.
