### PR TITLE
GTEnumerator; don't convert an OID to a SHA just to get an OID

### DIFF
--- a/Classes/GTEnumerator.m
+++ b/Classes/GTEnumerator.m
@@ -147,7 +147,7 @@
 	}
 	
 	// Ignore error if we can't lookup object and just return nil.
-	GTCommit *commit = (id)[self.repository lookupObjectBySha:[NSString git_stringWithOid:&oid] objectType:GTObjectTypeCommit error:error];
+	GTCommit *commit = (id)[self.repository lookupObjectByOid:&oid objectType:GTObjectTypeCommit error:error];
 	if (success != NULL) *success = (commit != nil);
 	return commit;
 }


### PR DESCRIPTION
Saves ~15% runtime when walking a large tree (linux kernel)

Improvement for libgit2/objective-git#187
