### PR TITLE
Renames for consistency

### DIFF
--- a/Classes/GTBranch.h
+++ b/Classes/GTBranch.h
@@ -38,7 +38,7 @@ typedef enum {
 
 @property (nonatomic, readonly) NSString *name;
 @property (nonatomic, readonly) NSString *shortName;
-@property (nonatomic, readonly) NSString *sha;
+@property (nonatomic, readonly) NSString *SHA;
 @property (nonatomic, readonly) NSString *remoteName;
 @property (nonatomic, readonly) GTBranchType branchType;
 @property (nonatomic, readonly, strong) GTRepository *repository;

--- a/Classes/GTBranch.m
+++ b/Classes/GTBranch.m
@@ -33,18 +33,18 @@
 @implementation GTBranch
 
 - (NSString *)description {
-  return [NSString stringWithFormat:@"<%@: %p> name: %@, shortName: %@, sha: %@, remoteName: %@, repository: %@", NSStringFromClass([self class]), self, self.name, self.shortName, self.sha, self.remoteName, self.repository];
+  return [NSString stringWithFormat:@"<%@: %p> name: %@, shortName: %@, sha: %@, remoteName: %@, repository: %@", NSStringFromClass([self class]), self, self.name, self.shortName, self.SHA, self.remoteName, self.repository];
 }
 
 - (BOOL)isEqual:(GTBranch *)otherBranch {
 	if (otherBranch == self) return YES;
 	if (![otherBranch isKindOfClass:self.class]) return NO;
 
-	return [self.name isEqual:otherBranch.name] && [self.sha isEqual:otherBranch.sha];
+	return [self.name isEqual:otherBranch.name] && [self.SHA isEqual:otherBranch.SHA];
 }
 
 - (NSUInteger)hash {
-	return self.name.hash ^ self.sha.hash;
+	return self.name.hash ^ self.SHA.hash;
 }
 
 
@@ -109,7 +109,7 @@
 	return @(name);
 }
 
-- (NSString *)sha {
+- (NSString *)SHA {
 	return self.reference.targetSHA;
 }
 
@@ -128,19 +128,19 @@
 }
 
 - (GTCommit *)targetCommitAndReturnError:(NSError **)error {
-	if (self.sha == nil) {
+	if (self.SHA == nil) {
 		if (error != NULL) *error = GTReference.invalidReferenceError;
 		return nil;
 	}
 
-	return (GTCommit *)[self.repository lookupObjectBySha:self.sha objectType:GTObjectTypeCommit error:error];
+	return (GTCommit *)[self.repository lookupObjectBySHA:self.SHA objectType:GTObjectTypeCommit error:error];
 }
 
 - (NSUInteger)numberOfCommitsWithError:(NSError **)error {
 	GTEnumerator *enumerator = [[GTEnumerator alloc] initWithRepository:self.repository error:error];
 	if (enumerator == nil) return NSNotFound;
 
-	if (![enumerator pushSHA:self.sha error:error]) return NSNotFound;
+	if (![enumerator pushSHA:self.SHA error:error]) return NSNotFound;
 	return [enumerator countRemainingObjects:error];
 }
 
@@ -163,10 +163,10 @@
 	
 	[enumerator resetWithOptions:GTEnumeratorOptionsTimeSort];
 	
-	BOOL success = [enumerator pushSHA:self.sha error:error];
+	BOOL success = [enumerator pushSHA:self.SHA error:error];
 	if (!success) return nil;
 
-	success = [enumerator hideSHA:mergeBase.sha error:error];
+	success = [enumerator hideSHA:mergeBase.SHA error:error];
 	if (!success) return nil;
 
 	return [enumerator allObjectsWithError:error];

--- a/Classes/GTCommit.m
+++ b/Classes/GTCommit.m
@@ -39,7 +39,7 @@
 @implementation GTCommit
 
 - (NSString *)description {
-	return [NSString stringWithFormat:@"<%@: %p>{ SHA: %@, author: %@, message: %@ }", self.class, self, self.sha, self.author, self.message];
+	return [NSString stringWithFormat:@"<%@: %p>{ SHA: %@, author: %@, message: %@ }", self.class, self, self.SHA, self.author, self.message];
 }
 
 - (git_commit *)git_commit {
@@ -50,7 +50,7 @@
 
 + (GTCommit *)commitInRepository:(GTRepository *)theRepo updateRefNamed:(NSString *)refName author:(GTSignature *)authorSig committer:(GTSignature *)committerSig message:(NSString *)newMessage tree:(GTTree *)theTree parents:(NSArray *)theParents error:(NSError **)error {
 	GTOID *oid = [GTCommit OIDByCreatingCommitInRepository:theRepo updateRefNamed:refName author:authorSig committer:committerSig message:newMessage tree:theTree parents:theParents error:error];
-	return oid ? (GTCommit *)[theRepo lookupObjectByOid:oid objectType:GTObjectTypeCommit error:error] : nil;
+	return oid ? (GTCommit *)[theRepo lookupObjectByOID:oid objectType:GTObjectTypeCommit error:error] : nil;
 }
 
 + (GTOID *)OIDByCreatingCommitInRepository:(GTRepository *)theRepo updateRefNamed:(NSString *)refName author:(GTSignature *)authorSig committer:(GTSignature *)committerSig message:(NSString *)newMessage tree:(GTTree *)theTree parents:(NSArray *)theParents error:(NSError **)error {

--- a/Classes/GTObject.h
+++ b/Classes/GTObject.h
@@ -49,8 +49,8 @@ typedef enum {
 @interface GTObject : NSObject
 
 @property (nonatomic, readonly) NSString *type;
-@property (nonatomic, readonly) NSString *sha;
-@property (nonatomic, readonly) NSString *shortSha;
+@property (nonatomic, readonly) NSString *SHA;
+@property (nonatomic, readonly) NSString *shortSHA;
 @property (nonatomic, readonly, strong) GTRepository *repository;
 @property (nonatomic, readonly) GTOID *OID;
 

--- a/Classes/GTObject.m
+++ b/Classes/GTObject.m
@@ -45,7 +45,7 @@
 @implementation GTObject
 
 - (NSString *)description {
-  return [NSString stringWithFormat:@"<%@: %p> type: %@, shortSha: %@, sha: %@", NSStringFromClass([self class]), self, self.type, self.shortSha, self.sha];
+  return [NSString stringWithFormat:@"<%@: %p> type: %@, shortSha: %@, sha: %@", NSStringFromClass([self class]), self, self.type, self.shortSHA, self.SHA];
 }
 
 - (void)dealloc {
@@ -56,7 +56,7 @@
 }
 
 - (NSUInteger)hash {
-	return [self.sha hash];
+	return [self.SHA hash];
 }
 
 - (BOOL)isEqual:(id)otherObject {
@@ -123,12 +123,12 @@
 	return [GTOID oidWithGitOid:git_object_id(self.git_object)];
 }
 
-- (NSString *)sha {
+- (NSString *)SHA {
 	return self.OID.SHA;
 }
 
-- (NSString *)shortSha {
-	return [self.sha git_shortUniqueShaString];
+- (NSString *)shortSHA {
+	return [self.SHA git_shortUniqueShaString];
 }
 
 - (GTOdbObject *)odbObjectWithError:(NSError **)error {

--- a/Classes/GTReference.m
+++ b/Classes/GTReference.m
@@ -167,7 +167,7 @@ static NSString *referenceTypeToString(GTReferenceType type) {
 		git_oid *oid = (git_oid *)git_reference_target(self.git_reference);
 		if (oid == NULL) return nil;
 
-		return [self.repository lookupObjectByOid:[GTOID oidWithGitOid: oid] error:NULL];
+		return [self.repository lookupObjectByOID:[GTOID oidWithGitOid: oid] error:NULL];
 	} else if (self.referenceType == GTReferenceTypeSymbolic) {
 		NSString *refName = @(git_reference_symbolic_target(self.git_reference));
 		if (refName == NULL) return nil;
@@ -190,7 +190,7 @@ static NSString *referenceTypeToString(GTReferenceType type) {
 }
 
 - (NSString *)targetSHA {
-	return [self.resolvedTarget sha];
+	return [self.resolvedTarget SHA];
 }
 
 - (GTReference *)referenceByUpdatingTarget:(NSString *)newTarget error:(NSError **)error {

--- a/Classes/GTRepository.h
+++ b/Classes/GTRepository.h
@@ -113,10 +113,10 @@ typedef void (^GTRepositoryStatusBlock)(NSURL *fileURL, GTRepositoryFileStatus s
 + (NSString *)hash:(NSString *)data objectType:(GTObjectType)type error:(NSError **)error;
 
 // Lookup objects in the repo by oid or sha1
-- (GTObject *)lookupObjectByOid:(GTOID *)oid objectType:(GTObjectType)type error:(NSError **)error;
-- (GTObject *)lookupObjectByOid:(GTOID *)oid error:(NSError **)error;
-- (GTObject *)lookupObjectBySha:(NSString *)sha objectType:(GTObjectType)type error:(NSError **)error;
-- (GTObject *)lookupObjectBySha:(NSString *)sha error:(NSError **)error;
+- (GTObject *)lookupObjectByOID:(GTOID *)oid objectType:(GTObjectType)type error:(NSError **)error;
+- (GTObject *)lookupObjectByOID:(GTOID *)oid error:(NSError **)error;
+- (GTObject *)lookupObjectBySHA:(NSString *)sha objectType:(GTObjectType)type error:(NSError **)error;
+- (GTObject *)lookupObjectBySHA:(NSString *)sha error:(NSError **)error;
 
 // Lookup an object in the repo using a revparse spec
 - (GTObject *)lookupObjectByRefspec:(NSString *)spec error:(NSError **)error;

--- a/Classes/GTRepository.m
+++ b/Classes/GTRepository.m
@@ -197,7 +197,7 @@ static int transferProgressCallback(const git_transfer_progress *progress, void 
 	return [GTOID oidWithGitOid:&oid].SHA;
 }
 
-- (GTObject *)lookupObjectByOid:(GTOID *)oid objectType:(GTObjectType)type error:(NSError **)error {
+- (GTObject *)lookupObjectByOID:(GTOID *)oid objectType:(GTObjectType)type error:(NSError **)error {
 	git_object *obj;
 
 	int gitError = git_object_lookup(&obj, self.git_repository, oid.git_oid, (git_otype)type);
@@ -209,19 +209,19 @@ static int transferProgressCallback(const git_transfer_progress *progress, void 
     return [GTObject objectWithObj:obj inRepository:self];
 }
 
-- (GTObject *)lookupObjectByOid:(GTOID *)oid error:(NSError **)error {
-	return [self lookupObjectByOid:oid objectType:GTObjectTypeAny error:error];
+- (GTObject *)lookupObjectByOID:(GTOID *)oid error:(NSError **)error {
+	return [self lookupObjectByOID:oid objectType:GTObjectTypeAny error:error];
 }
 
-- (GTObject *)lookupObjectBySha:(NSString *)sha objectType:(GTObjectType)type error:(NSError **)error {
+- (GTObject *)lookupObjectBySHA:(NSString *)sha objectType:(GTObjectType)type error:(NSError **)error {
 	GTOID *oid = [[GTOID alloc] initWithSHA:sha error:error];
 	if (!oid) return nil;
 
-	return [self lookupObjectByOid:oid objectType:type error:error];
+	return [self lookupObjectByOID:oid objectType:type error:error];
 }
 
-- (GTObject *)lookupObjectBySha:(NSString *)sha error:(NSError **)error {
-	return [self lookupObjectBySha:sha objectType:GTObjectTypeAny error:error];
+- (GTObject *)lookupObjectBySHA:(NSString *)sha error:(NSError **)error {
+	return [self lookupObjectBySHA:sha objectType:GTObjectTypeAny error:error];
 }
 
 - (GTObject *)lookupObjectByRefspec:(NSString *)spec error:(NSError **)error {
@@ -506,7 +506,7 @@ static int file_status_callback(const char *relativeFilePath, unsigned int gitSt
 		return nil;
 	}
 	
-	return (id)[self lookupObjectByOid:[GTOID oidWithGitOid:&mergeBase] objectType:GTObjectTypeCommit error:error];
+	return (id)[self lookupObjectByOID:[GTOID oidWithGitOid:&mergeBase] objectType:GTObjectTypeCommit error:error];
 }
 
 - (GTObjectDatabase *)objectDatabaseWithError:(NSError **)error {

--- a/Classes/GTTag.m
+++ b/Classes/GTTag.m
@@ -46,7 +46,7 @@
 
 + (GTTag *)tagInRepository:(GTRepository *)theRepo name:(NSString *)tagName target:(GTObject *)theTarget tagger:(GTSignature *)theTagger message:(NSString *)theMessage error:(NSError **)error {
 	NSString *sha = [GTTag shaByCreatingTagInRepository:theRepo name:tagName target:theTarget tagger:theTagger message:theMessage error:error];
-	return sha ? (GTTag *)[theRepo lookupObjectBySha:sha objectType:GTObjectTypeTag error:error] : nil;
+	return sha ? (GTTag *)[theRepo lookupObjectBySHA:sha objectType:GTObjectTypeTag error:error] : nil;
 }
 
 + (GTOID *)OIDByCreatingTagInRepository:(GTRepository *)theRepo name:(NSString *)tagName target:(GTObject *)theTarget tagger:(GTSignature *)theTagger message:(NSString *)theMessage error:(NSError **)error {

--- a/Classes/GTTreeEntry.h
+++ b/Classes/GTTreeEntry.h
@@ -43,7 +43,7 @@
 
 - (NSString *)name;
 - (NSInteger)attributes;
-- (NSString *)sha;
+- (NSString *)SHA;
 
 @property (nonatomic, readonly) GTOID *OID;
 

--- a/Classes/GTTreeEntry.m
+++ b/Classes/GTTreeEntry.m
@@ -44,7 +44,7 @@
 #pragma mark NSObject
 
 - (NSString *)description {
-	return [NSString stringWithFormat:@"<%@: %p> name: %@, type: %@, sha: %@, attributes: %lu", NSStringFromClass(self.class), self, self.name, self.typeString, self.sha, (unsigned long)self.attributes];
+	return [NSString stringWithFormat:@"<%@: %p> name: %@, type: %@, sha: %@, attributes: %lu", NSStringFromClass(self.class), self, self.name, self.typeString, self.SHA, (unsigned long)self.attributes];
 }
 
 - (NSUInteger)hash {
@@ -88,7 +88,7 @@
 	return [GTOID oidWithGitOid:git_tree_entry_id(self.git_tree_entry)];
 }
 
-- (NSString *)sha {
+- (NSString *)SHA {
 	return self.OID.SHA;
 }
 

--- a/ObjectiveGitTests/GTBlobTest.m
+++ b/ObjectiveGitTests/GTBlobTest.m
@@ -30,7 +30,7 @@
 @interface GTBlobTest : SenTestCase {
 	
 	GTRepository *repo;
-	NSString *sha;
+	NSString *blobSHA;
 }
 @end
 
@@ -40,17 +40,17 @@
 	
 	NSError *error = nil;
     repo = [GTRepository repositoryWithURL:[NSURL fileURLWithPath:TEST_REPO_PATH(self.class)] error:&error];
-	sha = @"fa49b077972391ad58037050f2a75f74e3671e92";
+	blobSHA = @"fa49b077972391ad58037050f2a75f74e3671e92";
 }
 
 - (void)testCanReadBlobData {
 	
 	NSError *error = nil;
-	GTBlob *blob = (GTBlob *)[repo lookupObjectBySha:sha error:&error];
+	GTBlob *blob = (GTBlob *)[repo lookupObjectBySHA:blobSHA error:&error];
 	STAssertEquals(9, (int)blob.size, nil);
 	STAssertEqualObjects(@"new file\n", blob.content, nil);
 	STAssertEqualObjects(@"blob", blob.type, nil);
-	STAssertEqualObjects(sha, blob.sha, nil);
+	STAssertEqualObjects(blobSHA, blob.SHA, nil);
 }
 
 // todo
@@ -75,10 +75,10 @@
 	
 	NSError *error = nil;
     GTBlob *blob = [GTBlob blobWithString:@"a new blob content" inRepository:repo error:&error];
-    NSString *newSha = [blob sha];
-	STAssertNotNil(newSha, [error localizedDescription]);
+    NSString *newSHA = [blob SHA];
+	STAssertNotNil(newSHA, [error localizedDescription]);
 	
-	rm_loose(self.class, newSha);
+	rm_loose(self.class, newSHA);
 }
 
 - (void)testCanWriteNewBlobData2 {
@@ -87,7 +87,7 @@
     GTBlob *blob = [GTBlob blobWithString:@"a new blob content" inRepository:repo error:&error];
 	STAssertNotNil(blob, [error localizedDescription]);
 	
-	rm_loose(self.class, blob.sha);
+	rm_loose(self.class, blob.SHA);
 }
 
 //- (void)testCanGetCompleteContentWithNulls {

--- a/ObjectiveGitTests/GTBranchSpec.m
+++ b/ObjectiveGitTests/GTBranchSpec.m
@@ -87,7 +87,7 @@ describe(@"-uniqueCommitsRelativeToBranch:error:", ^{
 
 		NSMutableArray *SHAs = [NSMutableArray array];
 		for (GTCommit *commit in commits) {
-			[SHAs addObject:commit.sha];
+			[SHAs addObject:commit.SHA];
 		}
 
 		NSArray *expectedSHAs = @[
@@ -117,13 +117,13 @@ describe(@"-reloadedBranchWithError:", ^{
 	it(@"should reload the branch from disk", ^{
 		static NSString * const originalSHA = @"a4bca6b67a5483169963572ee3da563da33712f7";
 		static NSString * const updatedSHA = @"6b0c1c8b8816416089c534e474f4c692a76ac14f";
-		expect([masterBranch targetCommitAndReturnError:NULL].sha).to.equal(originalSHA);
+		expect([masterBranch targetCommitAndReturnError:NULL].SHA).to.equal(originalSHA);
 		[masterBranch.reference referenceByUpdatingTarget:updatedSHA error:NULL];
 
 		GTBranch *reloadedBranch = [masterBranch reloadedBranchWithError:NULL];
 		expect(reloadedBranch).notTo.beNil();
-		expect([reloadedBranch targetCommitAndReturnError:NULL].sha).to.equal(updatedSHA);
-		expect([masterBranch targetCommitAndReturnError:NULL].sha).to.equal(originalSHA);
+		expect([reloadedBranch targetCommitAndReturnError:NULL].SHA).to.equal(updatedSHA);
+		expect([masterBranch targetCommitAndReturnError:NULL].SHA).to.equal(originalSHA);
 	});
 });
 

--- a/ObjectiveGitTests/GTCommitTest.m
+++ b/ObjectiveGitTests/GTCommitTest.m
@@ -45,15 +45,15 @@
 
 - (void)testCanReadCommitData {
 	
-	NSString *sha = @"8496071c1b46c854b31185ea97743be6a8774479";
+	NSString *commitSHA = @"8496071c1b46c854b31185ea97743be6a8774479";
 	NSError *error = nil;
-	GTObject *obj = [repo lookupObjectBySha:sha error:&error];
+	GTObject *obj = [repo lookupObjectBySHA:commitSHA error:&error];
 	
 	STAssertNil(error, [error localizedDescription]);
 	STAssertNotNil(obj, nil);
 	STAssertTrue([obj isKindOfClass:[GTCommit class]], nil);
 	STAssertEqualObjects(obj.type, @"commit", nil);
-	STAssertEqualObjects(obj.sha, sha, nil);
+	STAssertEqualObjects(obj.SHA, commitSHA, nil);
 	
 	GTCommit *commit = (GTCommit *)obj;
 	STAssertEqualObjects(commit.message, @"testing\n", nil);
@@ -71,15 +71,15 @@
 	STAssertEqualObjects(committer.email, @"schacon@gmail.com", nil);
 	STAssertEquals((int)[committer.time timeIntervalSince1970], 1273360386, nil);
 	
-	STAssertEqualObjects(commit.tree.sha, @"181037049a54a1eb5fab404658a3a250b44335d7", nil);
+	STAssertEqualObjects(commit.tree.SHA, @"181037049a54a1eb5fab404658a3a250b44335d7", nil);
 	STAssertTrue([commit.parents count] == 0, nil);
 }
 
 - (void)testCanHaveMultipleParents {
 	
-	NSString *sha = @"a4a7dce85cf63874e984719f4fdd239f5145052f";
+	NSString *commitSHA = @"a4a7dce85cf63874e984719f4fdd239f5145052f";
 	NSError *error = nil;
-	GTObject *obj = [repo lookupObjectBySha:sha error:&error];
+	GTObject *obj = [repo lookupObjectBySHA:commitSHA error:&error];
 	
 	STAssertNil(error, [error localizedDescription]);
 	STAssertNotNil(obj, nil);
@@ -91,8 +91,8 @@
 - (void)testCanWriteCommitData {
 	
 	NSError *error = nil;
-	NSString *sha = @"8496071c1b46c854b31185ea97743be6a8774479";
-	GTCommit *obj = (GTCommit *)[repo lookupObjectBySha:sha error:&error];
+	NSString *commitSHA = @"8496071c1b46c854b31185ea97743be6a8774479";
+	GTCommit *obj = (GTCommit *)[repo lookupObjectBySHA:commitSHA error:&error];
 	STAssertNotNil(obj, [error localizedDescription]);
 	
 	NSString *newSha = [GTCommit shaByCreatingCommitInRepository:repo 
@@ -111,9 +111,9 @@
 
 - (void)testCanWriteNewCommitData {
 	
-	NSString *tsha = @"c4dc1555e4d4fa0e0c9c3fc46734c7c35b3ce90b";
+	NSString *treeSHA = @"c4dc1555e4d4fa0e0c9c3fc46734c7c35b3ce90b";
 	NSError *error = nil;
-	GTObject *obj = [repo lookupObjectBySha:tsha error:&error];
+	GTObject *obj = [repo lookupObjectBySHA:treeSHA error:&error];
 	
 	STAssertNil(error, [error localizedDescription]);
 	STAssertNotNil(obj, nil);
@@ -125,16 +125,16 @@
 						   time:[NSDate date]];
 	GTCommit *commit = [GTCommit commitInRepository:repo updateRefNamed:nil author:person committer:person message:@"new message" tree:tree parents:nil error:&error];
 	STAssertNotNil(commit, [error localizedDescription]);
-	NSLog(@"wrote sha %@", commit.sha);
+	NSLog(@"wrote sha %@", commit.SHA);
 	
-	rm_loose(self.class, commit.sha);
+	rm_loose(self.class, commit.SHA);
 }
 
 - (void)testCanHandleNilWrites {
 	
 	NSString *tsha = @"c4dc1555e4d4fa0e0c9c3fc46734c7c35b3ce90b";
 	NSError *error = nil;
-	GTObject *obj = [repo lookupObjectBySha:tsha error:&error];
+	GTObject *obj = [repo lookupObjectBySHA:tsha error:&error];
 	
 	STAssertNil(error, [error localizedDescription]);
 	STAssertNotNil(obj, nil);
@@ -146,9 +146,9 @@
 							time:[NSDate date]];
 	GTCommit *commit = [GTCommit commitInRepository:repo updateRefNamed:nil author:person committer:person message:nil tree:tree parents:nil error:&error];
 	STAssertNotNil(commit, [error localizedDescription]);
-	NSLog(@"wrote sha %@", commit.sha);
+	NSLog(@"wrote sha %@", commit.SHA);
 	
-	rm_loose(self.class, commit.sha);
+	rm_loose(self.class, commit.SHA);
 }
 
 @end

--- a/ObjectiveGitTests/GTDiffSpec.m
+++ b/ObjectiveGitTests/GTDiffSpec.m
@@ -18,10 +18,10 @@ describe(@"GTDiff initialisation", ^{
 		repository = [GTRepository repositoryWithURL:[NSURL fileURLWithPath:TEST_REPO_PATH(self.class)] error:NULL];
 		expect(repository).toNot.beNil();
 		
-		firstCommit = (GTCommit *)[repository lookupObjectBySha:@"5b5b025afb0b4c913b4c338a42934a3863bf3644" objectType:GTObjectTypeCommit error:NULL];
+		firstCommit = (GTCommit *)[repository lookupObjectBySHA:@"5b5b025afb0b4c913b4c338a42934a3863bf3644" objectType:GTObjectTypeCommit error:NULL];
 		expect(firstCommit).toNot.beNil();
 		
-		secondCommit = (GTCommit *)[repository lookupObjectBySha:@"36060c58702ed4c2a40832c51758d5344201d89a" objectType:GTObjectTypeCommit error:NULL];
+		secondCommit = (GTCommit *)[repository lookupObjectBySHA:@"36060c58702ed4c2a40832c51758d5344201d89a" objectType:GTObjectTypeCommit error:NULL];
 		expect(secondCommit).toNot.beNil();
 	});
 	
@@ -70,9 +70,9 @@ describe(@"GTDiff diffing", ^{
 		expect(repository).toNot.beNil();
 		
 		setupDiffFromCommitSHAsAndOptions = [^(NSString *firstCommitSHA, NSString *secondCommitSHA, NSDictionary *options) {
-			firstCommit = (GTCommit *)[repository lookupObjectBySha:firstCommitSHA objectType:GTObjectTypeCommit error:NULL];
+			firstCommit = (GTCommit *)[repository lookupObjectBySHA:firstCommitSHA objectType:GTObjectTypeCommit error:NULL];
 			expect(firstCommit).toNot.beNil();
-			secondCommit = (GTCommit *)[repository lookupObjectBySha:secondCommitSHA objectType:GTObjectTypeCommit error:NULL];
+			secondCommit = (GTCommit *)[repository lookupObjectBySHA:secondCommitSHA objectType:GTObjectTypeCommit error:NULL];
 			expect(secondCommit).toNot.beNil();
 			
 			diff = [GTDiff diffOldTree:firstCommit.tree withNewTree:secondCommit.tree inRepository:repository options:options error:NULL];

--- a/ObjectiveGitTests/GTEnumeratorSpec.m
+++ b/ObjectiveGitTests/GTEnumeratorSpec.m
@@ -55,7 +55,7 @@ describe(@"with a rev list", ^{
 			NSMutableArray *SHAs = [NSMutableArray array];
 			for (GTCommit *commit in enumerator) {
 				expect(commit).to.beKindOf(GTCommit.class);
-				[SHAs addObject:commit.sha];
+				[SHAs addObject:commit.SHA];
 			}
 
 			expect(SHAs).to.equal(expectedSHAs);
@@ -113,7 +113,7 @@ describe(@"globbing", ^{
 		verifyEnumerator = ^{
 			NSMutableArray *SHAs = [NSMutableArray array];
 			for (GTCommit *commit in enumerator) {
-				[SHAs addObject:commit.sha];
+				[SHAs addObject:commit.SHA];
 			}
 
 			expect(SHAs).to.equal(expectedSHAs);

--- a/ObjectiveGitTests/GTObjectTest.m
+++ b/ObjectiveGitTests/GTObjectTest.m
@@ -44,7 +44,7 @@
 - (void)testCanLookupEmptyStringFails {
 	
 	NSError *error = nil;
-	GTObject *obj = [repo lookupObjectBySha:@"" error:&error];
+	GTObject *obj = [repo lookupObjectBySHA:@"" error:&error];
 	
 	STAssertNotNil(error, nil);
 	STAssertNil(obj, nil);
@@ -54,7 +54,7 @@
 - (void)testCanLookupBadObjectFails {
 	
 	NSError *error = nil;
-	GTObject *obj = [repo lookupObjectBySha:@"a496071c1b46c854b31185ea97743be6a8774479" error:&error];
+	GTObject *obj = [repo lookupObjectBySHA:@"a496071c1b46c854b31185ea97743be6a8774479" error:&error];
 	
 	STAssertNotNil(error, nil);
 	STAssertNil(obj, nil);
@@ -64,19 +64,19 @@
 - (void)testCanLookupAnObject {
 	
 	NSError *error = nil;
-	GTObject *obj = [repo lookupObjectBySha:@"8496071c1b46c854b31185ea97743be6a8774479" error:&error];
+	GTObject *obj = [repo lookupObjectBySHA:@"8496071c1b46c854b31185ea97743be6a8774479" error:&error];
 	
 	STAssertNil(error, [error localizedDescription]);
 	STAssertNotNil(obj, nil);
 	STAssertEqualObjects(obj.type, @"commit", nil);
-	STAssertEqualObjects(obj.sha, @"8496071c1b46c854b31185ea97743be6a8774479", nil);
+	STAssertEqualObjects(obj.SHA, @"8496071c1b46c854b31185ea97743be6a8774479", nil);
 }
 
 - (void)testTwoObjectsAreTheSame {
 	
 	NSError *error = nil;
-	GTObject *obj1 = [repo lookupObjectBySha:@"8496071c1b46c854b31185ea97743be6a8774479" error:&error];
-	GTObject *obj2 = [repo lookupObjectBySha:@"8496071c1b46c854b31185ea97743be6a8774479" error:&error];
+	GTObject *obj1 = [repo lookupObjectBySHA:@"8496071c1b46c854b31185ea97743be6a8774479" error:&error];
+	GTObject *obj2 = [repo lookupObjectBySHA:@"8496071c1b46c854b31185ea97743be6a8774479" error:&error];
 	
 	STAssertNotNil(obj1, nil);
 	STAssertNotNil(obj2, nil);
@@ -86,7 +86,7 @@
 - (void)testCanReadRawDataFromObject {
 	
 	NSError *error = nil;
-	GTObject *obj = [repo lookupObjectBySha:@"8496071c1b46c854b31185ea97743be6a8774479" error:&error];
+	GTObject *obj = [repo lookupObjectBySHA:@"8496071c1b46c854b31185ea97743be6a8774479" error:&error];
 	
 	STAssertNotNil(obj, nil);
 	

--- a/ObjectiveGitTests/GTRepositorySpec.m
+++ b/ObjectiveGitTests/GTRepositorySpec.m
@@ -47,7 +47,7 @@ describe(@"-mergeBaseBetweenFirstOID:secondOID:error:", ^{
 
 		GTCommit *mergeBase = [repository mergeBaseBetweenFirstOID:masterBranch.reference.OID secondOID:otherBranch.reference.OID error:&error];
 		expect(mergeBase).notTo.beNil();
-		expect(mergeBase.sha).to.equal(@"f7ecd8f4404d3a388efbff6711f1bdf28ffd16a0");
+		expect(mergeBase.SHA).to.equal(@"f7ecd8f4404d3a388efbff6711f1bdf28ffd16a0");
 	});
 });
 

--- a/ObjectiveGitTests/GTRepositoryTest.m
+++ b/ObjectiveGitTests/GTRepositoryTest.m
@@ -107,14 +107,14 @@
     GTReference *originalHead = [aRepo headReferenceWithError:NULL];
     NSString *resetTargetSha = @"8496071c1b46c854b31185ea97743be6a8774479";
 
-	GTCommit *commit = (GTCommit *)[aRepo lookupObjectBySha:resetTargetSha error:NULL];
+	GTCommit *commit = (GTCommit *)[aRepo lookupObjectBySHA:resetTargetSha error:NULL];
     
     BOOL success = [aRepo resetToCommit:commit withResetType:GTRepositoryResetTypeSoft error:&err];
     STAssertTrue(success, @"Failed to reset, error given: %@", err);
     GTReference *head = [aRepo headReferenceWithError:&err];
     STAssertEqualObjects(head.targetSHA, resetTargetSha, @"Reset failed to move head to given commit");
     
-    GTCommit *originalHeadCommit = (GTCommit *)[aRepo lookupObjectBySha:originalHead.targetSHA error:NULL];
+    GTCommit *originalHeadCommit = (GTCommit *)[aRepo lookupObjectBySHA:originalHead.targetSHA error:NULL];
     [aRepo resetToCommit:originalHeadCommit withResetType:GTRepositoryResetTypeSoft error:NULL];
     head = [aRepo headReferenceWithError:&err];
     STAssertEqualObjects(head.unresolvedTarget, originalHead.unresolvedTarget, @"Reset failed to move head back to the original position");
@@ -127,7 +127,7 @@
 	if (sha != nil) {
 		STAssertEquals((NSInteger)GIT_OK, err.code, @"git_revparse_single didn't return 0: %d", err.code);
 		STAssertNotNil(obj, @"Couldn't find object for %@", refspec);
-		STAssertEqualObjects(sha, obj.sha, @"Revparse '%@': expected %@, got %@", refspec, sha, obj.sha);
+		STAssertEqualObjects(sha, obj.SHA, @"Revparse '%@': expected %@, got %@", refspec, sha, obj.SHA);
 	} else {
 		STAssertTrue(err.code != (NSInteger)GIT_OK, @"Expected error code, got 0");
 		STAssertNil(obj, @"Got object when expected none for %@", refspec);

--- a/ObjectiveGitTests/GTSubmoduleSpec.m
+++ b/ObjectiveGitTests/GTSubmoduleSpec.m
@@ -154,17 +154,17 @@ describe(@"clean, checked out submodule", ^{
 		GTRepository *submoduleRepo = [submodule submoduleRepository:NULL];
 		expect(submoduleRepo).notTo.beNil();
 
-		GTCommit *newHEAD = (id)[submoduleRepo lookupObjectBySha:@"82dc47f6ba3beecab33080a1136d8913098e1801" objectType:GTObjectTypeCommit error:NULL];
+		GTCommit *newHEAD = (id)[submoduleRepo lookupObjectBySHA:@"82dc47f6ba3beecab33080a1136d8913098e1801" objectType:GTObjectTypeCommit error:NULL];
 		expect(newHEAD).notTo.beNil();
 		expect([submoduleRepo resetToCommit:newHEAD withResetType:GTRepositoryResetTypeHard error:NULL]).to.beTruthy();
 
-		expect(submodule.workingDirectoryOID.SHA).notTo.equal(newHEAD.sha);
+		expect(submodule.workingDirectoryOID.SHA).notTo.equal(newHEAD.SHA);
 
 		__block NSError *error = nil;
 		expect([submodule reload:&error]).to.beTruthy();
 		expect(error).to.beNil();
 
-		expect(submodule.workingDirectoryOID.SHA).to.equal(newHEAD.sha);
+		expect(submodule.workingDirectoryOID.SHA).to.equal(newHEAD.SHA);
 	});
 });
 

--- a/ObjectiveGitTests/GTTagTest.m
+++ b/ObjectiveGitTests/GTTagTest.m
@@ -36,16 +36,16 @@
 	
 	NSError *error = nil;
 	GTRepository *repo = [GTRepository repositoryWithURL:[NSURL fileURLWithPath:TEST_REPO_PATH(self.class)] error:&error];
-	NSString *sha = @"0c37a5391bbff43c37f0d0371823a5509eed5b1d";
-	GTTag *tag = (GTTag *)[repo lookupObjectBySha:sha error:&error];
+	NSString *tagSHA = @"0c37a5391bbff43c37f0d0371823a5509eed5b1d";
+	GTTag *tag = (GTTag *)[repo lookupObjectBySHA:tagSHA error:&error];
 	
 	STAssertNil(error, [error localizedDescription]);
 	STAssertNotNil(tag, nil);
-	STAssertEqualObjects(sha, tag.sha, nil);
+	STAssertEqualObjects(tagSHA, tag.SHA, nil);
 	STAssertEqualObjects(@"tag", tag.type, nil);
 	STAssertEqualObjects(@"test tag message\n", tag.message, nil);
 	STAssertEqualObjects(@"v1.0", tag.name, nil);
-	STAssertEqualObjects(@"5b5b025afb0b4c913b4c338a42934a3863bf3644", tag.target.sha, nil);
+	STAssertEqualObjects(@"5b5b025afb0b4c913b4c338a42934a3863bf3644", tag.target.SHA, nil);
 	STAssertEqualObjects(@"commit", tag.targetType, nil);
 	
 	GTSignature *c = tag.tagger;
@@ -59,7 +59,7 @@
 	NSError *error = nil;
 	NSString *sha = @"0c37a5391bbff43c37f0d0371823a5509eed5b1d";
 	GTRepository *repo = [GTRepository repositoryWithURL:[NSURL fileURLWithPath:TEST_REPO_PATH(self.class)] error:&error];
-	GTTag *tag = (GTTag *)[repo lookupObjectBySha:sha error:&error];
+	GTTag *tag = (GTTag *)[repo lookupObjectBySHA:sha error:&error];
 	
 	[GTTag shaByCreatingTagInRepository:repo name:tag.name target:tag.target tagger:tag.tagger message:@"new message" error:&error];
 	STAssertNotNil(error, nil);
@@ -69,19 +69,19 @@
 	NSError *error = nil;
 	NSString *sha = @"0c37a5391bbff43c37f0d0371823a5509eed5b1d";
 	GTRepository *repo = [GTRepository repositoryWithURL:[NSURL fileURLWithPath:TEST_REPO_PATH(self.class)] error:&error];
-	GTTag *tag = (GTTag *)[repo lookupObjectBySha:sha error:&error];
+	GTTag *tag = (GTTag *)[repo lookupObjectBySHA:sha error:&error];
 
 	NSString *newSha = [GTTag shaByCreatingTagInRepository:repo name:@"a_new_tag" target:tag.target tagger:tag.tagger message:@"my tag\n" error:&error];
 	STAssertNotNil(newSha, [error localizedDescription]);
 	
-	tag = (GTTag *)[repo lookupObjectBySha:newSha error:&error];
+	tag = (GTTag *)[repo lookupObjectBySHA:newSha error:&error];
 	STAssertNil(error, [error localizedDescription]);
 	STAssertNotNil(tag, nil);
-	STAssertEqualObjects(newSha, tag.sha, nil);
+	STAssertEqualObjects(newSha, tag.SHA, nil);
 	STAssertEqualObjects(@"tag", tag.type, nil);
 	STAssertEqualObjects(@"my tag\n", tag.message, nil);
 	STAssertEqualObjects(@"a_new_tag", tag.name, nil);
-	STAssertEqualObjects(@"5b5b025afb0b4c913b4c338a42934a3863bf3644", tag.target.sha, nil);
+	STAssertEqualObjects(@"5b5b025afb0b4c913b4c338a42934a3863bf3644", tag.target.SHA, nil);
 	STAssertEqualObjects(@"commit", tag.targetType, nil);
 
 	rm_loose(self.class, newSha);

--- a/ObjectiveGitTests/GTTreeBuilderSpec.m
+++ b/ObjectiveGitTests/GTTreeBuilderSpec.m
@@ -30,7 +30,7 @@ it(@"should be possible to make a new tree builder from an existing tree", ^{
 	GTRepository *repo = [self fixtureRepositoryNamed:@"testrepo.git"];
 	expect(repo).notTo.beNil();
 	
-	GTTree *tree = (GTTree *)[repo lookupObjectBySha:testTreeSHA error:NULL];
+	GTTree *tree = (GTTree *)[repo lookupObjectBySHA:testTreeSHA error:NULL];
 	expect(tree).notTo.beNil();
 	
 	GTTreeBuilder *builder = [[GTTreeBuilder alloc] initWithTree:tree error:&error];
@@ -79,7 +79,7 @@ describe(@"GTTreeBuilder building", ^{
 		expect(blob).notTo.beNil();
 		expect(error).to.beNil();
 		
-		[builder addEntryWithSHA:blob.sha filename:@"hi.txt" filemode:GTFileModeBlob error:&error];
+		[builder addEntryWithSHA:blob.SHA filename:@"hi.txt" filemode:GTFileModeBlob error:&error];
 		
 		expect(builder.entryCount).to.equal(1);
 		
@@ -97,7 +97,7 @@ describe(@"GTTreeBuilder building", ^{
 		expect(error).to.beNil();
 		
 		GTTreeEntry *foundEntry = [builder entryWithName:filename];
-		expect(foundEntry.sha).to.equal(entry.sha);
+		expect(foundEntry.SHA).to.equal(entry.SHA);
 	});
 
 	it(@"should be possible to write a builder to a repository", ^{
@@ -108,13 +108,13 @@ describe(@"GTTreeBuilder building", ^{
 		expect(blob).notTo.beNil();
 		expect(error).to.beNil();
 		
-		[builder addEntryWithSHA:blob.sha filename:@"hi.txt" filemode:GTFileModeBlob error:&error];
+		[builder addEntryWithSHA:blob.SHA filename:@"hi.txt" filemode:GTFileModeBlob error:&error];
 		
 		GTTree *writtenTree = [builder writeTreeToRepository:repo error:&error];
 		expect(writtenTree).notTo.beNil();
 		expect(error).to.beNil();
 		
-		GTTree *readTree = (GTTree *)[repo lookupObjectBySha:writtenTree.sha objectType:GTObjectTypeTree error:&error];
+		GTTree *readTree = (GTTree *)[repo lookupObjectBySHA:writtenTree.SHA objectType:GTObjectTypeTree error:&error];
 		expect(readTree).notTo.beNil();
 		expect(error).to.beNil();
 		

--- a/ObjectiveGitTests/GTTreeSpec.m
+++ b/ObjectiveGitTests/GTTreeSpec.m
@@ -19,12 +19,12 @@ beforeEach(^{
 	GTRepository *repo = [self fixtureRepositoryNamed:@"testrepo.git"];
 	expect(repo).notTo.beNil();
 
-	tree = (GTTree *)[repo lookupObjectBySha:testTreeSHA error:NULL];
+	tree = (GTTree *)[repo lookupObjectBySHA:testTreeSHA error:NULL];
 	expect(tree).notTo.beNil();
 });
 
 it(@"should be able to read tree properties", ^{
-	expect(tree.sha).to.equal(testTreeSHA);
+	expect(tree.SHA).to.equal(testTreeSHA);
 	expect(tree.entryCount).to.equal(3);
 });
 
@@ -32,7 +32,7 @@ it(@"should be able to read tree entry properties", ^{
 	GTTreeEntry *entry = [tree entryAtIndex:0];
 	expect(entry).notTo.beNil();
 	expect(entry.name).to.equal(@"README");
-	expect(entry.sha).to.equal(@"1385f264afb75a56a5bec74243be9b367ba4ca08");
+	expect(entry.SHA).to.equal(@"1385f264afb75a56a5bec74243be9b367ba4ca08");
 });
 
 it(@"should give quick access to its contents", ^{


### PR DESCRIPTION
`sha` => `SHA` and `oid` => `OID`, with an exception on the latter when the
parameter is a `git_oid` (like the `GTOID` initializer).
