### PR TITLE
GTTree tree entry methods return nil for non-existing entries, per documentation

### DIFF
--- a/Classes/GTTree.m
+++ b/Classes/GTTree.m
@@ -55,7 +55,7 @@ typedef struct GTTreeEnumerationStruct {
 }
 
 - (GTTreeEntry *)createEntryWithEntry:(const git_tree_entry *)entry {
-	return [GTTreeEntry entryWithEntry:entry parentTree:self];
+	return (entry != NULL) ? [GTTreeEntry entryWithEntry:entry parentTree:self] : nil;
 }
 
 - (GTTreeEntry *)entryAtIndex:(NSUInteger)index {

--- a/Classes/GTTreeEntry.m
+++ b/Classes/GTTreeEntry.m
@@ -65,6 +65,7 @@
 #pragma mark API
 
 - (id)initWithEntry:(const git_tree_entry *)theEntry parentTree:(GTTree *)parent {
+	NSParameterAssert(theEntry != NULL);
 	if((self = [super init])) {
 		_git_tree_entry = theEntry;
 		_tree = parent;

--- a/ObjectiveGitTests/GTTreeSpec.m
+++ b/ObjectiveGitTests/GTTreeSpec.m
@@ -50,4 +50,9 @@ it(@"should give quick access to its contents", ^{
 	expect(treeContents).to.contain(subdir);
 });
 
+it(@"should return nil for non-existent entries", ^{
+	expect([tree entryAtIndex:99]).to.beNil();
+	expect([tree entryWithName:@"_does not exist"]).to.beNil();
+});
+
 SpecEnd


### PR DESCRIPTION
They were documented to do so, but previously they returned a
GTTreeEntry which blew up when looked at (calling -description and other
methods dereferenced NULL).
