### PR TITLE
fix that could not update the submodule

### DIFF
--- a/script/update_libgit2
+++ b/script/update_libgit2
@@ -13,7 +13,7 @@ then
     exit 0
 fi
 
-cd "../libgit2"
+cd "libgit2"
 
 if [ -d "build" ]; then
     rm -rf "build"

--- a/script/update_libgit2_ios
+++ b/script/update_libgit2_ios
@@ -15,7 +15,7 @@ fi
 
 ios_version="6.1";
 
-cd "../libgit2"
+cd "libgit2"
 
 # armv7 build
 


### PR DESCRIPTION
I find that the submodule url used `git://` could not clone the code.
Using the `https://` works well.
