### PR TITLE
iOS app crashes with NSInvalidArgumentException when a cloning error is generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ not allowing third-party dynamic frameworks. A work-around for this is as follow
 5. Build Settings - User Header Search Paths
 5.1. Add $(BUILT_PRODUCTS_DIR)/usr/local/include
 5.2. Add $(SRCROOT)../Libs/objective-git/libgit2/include
+6. Build Settings - Other Linker Flags - Add -all_load
 
 ## Todo
 


### PR DESCRIPTION
The easiest way I have found to reproduce this exception is to try and clone a repository to a directory that already exists:

``` objective-c
NSURL *url = [NSURL URLWithString:@"http://github.com/libgit2/objective-git.git"];
NSURL *dir = [NSURL fileURLWithPath:NSHomeDirectory()];
NSError *error = nil;
[GTRepository cloneFromURL:url toWorkingDirectory:dir barely:YES withCheckout:NO error:&error transferProgressBlock:NULL checkoutProgressBlock:NULL];
NSLog(@"%@", error);
```

This produces the following exception:

```
+[NSError git_errorFor:withAdditionalDescription:]: unrecognized selector sent to class 0x163d26c
Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '+[NSError git_errorFor:withAdditionalDescription:]: unrecognized selector sent to class 0x163d26c'
```

Here is the call stack:

```
*** First throw call stack:
(
    0   CoreFoundation                      0x019eb6f4 __exceptionPreprocess + 180
    1   libobjc.A.dylib                     0x0176b8b6 objc_exception_throw + 44
    2   CoreFoundation                      0x01a88823 +[NSObject(NSObject) doesNotRecognizeSelector:] + 275
    3   CoreFoundation                      0x019dba1b ___forwarding___ + 1019
    4   CoreFoundation                      0x019db5fe _CF_forwarding_prep_0 + 14
    5   CloneiOS                            0x000081f6 +[GTRepository cloneFromURL:toWorkingDirectory:barely:withCheckout:error:transferProgressBlock:checkoutProgressBlock:] + 1398
    6   CloneiOS                            0x00005fa3 -[AppDelegate application:didFinishLaunchingWithOptions:] + 339
    7   UIKit                               0x004dd525 -[UIApplication _handleDelegateCallbacksWithOptions:isSuspended:restoreState:] + 309
    8   UIKit                               0x004ddd65 -[UIApplication _callInitializationDelegatesForURL:payload:suspended:] + 1536
    9   UIKit                               0x004e2578 -[UIApplication _runWithURL:payload:launchOrientation:statusBarStyle:statusBarHidden:] + 824
    10  UIKit                               0x004f657c -[UIApplication handleEvent:withNewEvent:] + 3447
    11  UIKit                               0x004f6ae9 -[UIApplication sendEvent:] + 85
    12  UIKit                               0x004e41f5 _UIApplicationHandleEvent + 736
    13  GraphicsServices                    0x038f633b _PurpleEventCallback + 776
    14  GraphicsServices                    0x038f5e46 PurpleEventCallback + 46
    15  CoreFoundation                      0x01966e95 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE1_PERFORM_FUNCTION__ + 53
    16  CoreFoundation                      0x01966bcb __CFRunLoopDoSource1 + 523
    17  CoreFoundation                      0x019918ac __CFRunLoopRun + 2156
    18  CoreFoundation                      0x01990bf3 CFRunLoopRunSpecific + 467
    19  CoreFoundation                      0x01990a0b CFRunLoopRunInMode + 123
    20  UIKit                               0x004e1cad -[UIApplication _run] + 840
    21  UIKit                               0x004e3f0b UIApplicationMain + 1225
    22  CloneiOS                            0x0000656d main + 141
    23  libdyld.dylib                       0x01f2a725 start + 0
)
libc++abi.dylib: terminating with uncaught exception of type NSException
```

When I run the same code in a Mac OS X app it returns an error as expected and the app doesn't crash.
