### PR TITLE
iOS error cloning https repositories: The SSL certificate is invalid

### DIFF
--- a/Classes/GTRepository.m
+++ b/Classes/GTRepository.m
@@ -185,6 +185,7 @@ static int transferProgressCallback(const git_transfer_progress *progress, void 
 
 	cloneOptions.fetch_progress_cb = transferProgressCallback;
 	cloneOptions.fetch_progress_payload = (__bridge void *)transferProgressBlock;
+	cloneOptions.transport_flags = GIT_TRANSPORTFLAGS_NO_CHECK_CERT;
 
 	const char *remoteURL = originURL.absoluteString.UTF8String;
 	const char *workingDirectoryPath = workdirURL.path.UTF8String;


### PR DESCRIPTION
Code to reproduce error:

``` objective-c
    NSURL *url = [NSURL URLWithString:@"https://github.com/isaac/test.git"];
    NSURL *dir = [NSURL fileURLWithPath:@"/Users/Isaac/Downloads/test"];
    NSError *error = nil;
    [GTRepository cloneFromURL:url toWorkingDirectory:dir barely:YES withCheckout:NO error:&error transferProgressBlock:NULL checkoutProgressBlock:NULL];
    NSLog(@"%@", error);
```

Full error:

```
2013-08-30 10:27:27.179 CloneiOS[69861:a0b] Error Domain=GTGitErrorDomain Code=-1 "Failed to clone repository from https://github.com/isaac/test.git to file:///Users/Isaac/Downloads/test" UserInfo=0x98c2f00 {NSUnderlyingError=0x98c2c20 "The SSL certificate is invalid", NSLocalizedDescription=Failed to clone repository from https://github.com/isaac/test.git to file:///Users/Isaac/Downloads/test}
```

The code above clones the repository successfully on Mac OS X with no errors.

This pull request suppresses the error on iOS, but I'm not sure if this is the right way to go.

Thoughts?
