### PR TITLE
Soft link frameworks into /usr/local/lib

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -39,6 +39,10 @@ then
     sudo mkdir -p /usr/local/lib
     for lib in $products
     do
-        sudo ln -sF "$brew_prefix/lib/$lib" "/usr/local/lib/$lib"
+        destination="/usr/local/lib/$lib"
+        if [ ! -e "$destination" ]
+        then
+            sudo ln -s "$brew_prefix/lib/$lib" "$destination"
+        fi
     done    
 fi


### PR DESCRIPTION
This fixes the case when the user is not using a default homebrew
install (e.g. when on boxen).

As opposed to just telling the user what to do, we let the computer do
it, turns out they're pretty good at that.
