### PR TITLE
Hide GTSetupThreads, never shut them down

### DIFF
--- a/Classes/ObjectiveGit.h
+++ b/Classes/ObjectiveGit.h
@@ -58,13 +58,3 @@
 #import <ObjectiveGit/GTDiffFile.h>
 #import <ObjectiveGit/GTDiffHunk.h>
 #import <ObjectiveGit/GTDiffLine.h>
-
-// This must be called before doing any ObjectiveGit work.  Under normal
-// circumstances, it will automatically be called on your behalf.
-// If you've linked ObjectiveGit as a static library but haven't set
-// the -all_load linker flag, you'll have to call this manually.
-extern void GTSetupThreads(void);
-
-// If you called GTSetupThreads, you must call this after all your ObjectiveGit 
-// work is done before your app quits.
-extern void GTShutdownThreads(void);

--- a/Classes/ObjectiveGit.m
+++ b/Classes/ObjectiveGit.m
@@ -6,23 +6,9 @@
 //  Copyright (c) 2012 GitHub, Inc. All rights reserved.
 //
 
-#import "ObjectiveGit.h"
-
-
-void GTSetupThreads(void) {
-	git_threads_init();
-}
-
-extern void GTShutdownThreads(void) {
-	git_threads_shutdown();
-}
+#import "git2.h"
 
 __attribute__((constructor))
-static void initializer(void) {
-	GTSetupThreads();
-}
-
-__attribute__((destructor))
-static void finalizer(void) {
-	GTShutdownThreads();
+static void GTSetupThreads(void) {
+	git_threads_init();
 }


### PR DESCRIPTION
We've noticed crashes within `-[NSApplication terminate:]` where `GTShutdownThreads` will be run automatically and interfere with libgit2 threads that are still active. This can be avoided by just not shutting down threads.

It's unnecessary in most applications, and very error-prone due to its manipulation of global state. There's no reason to do it when the app is just exiting anyways.
