### PR TITLE
Don't crash on nil descriptions in +git_errorFor:

### DIFF
--- a/Classes/Categories/NSError+Git.h
+++ b/Classes/Categories/NSError+Git.h
@@ -36,7 +36,7 @@ extern NSString * const GTGitErrorDomain;
 //
 // code - The error code returned from libgit2.
 //
-// Returns an NSError.
+// Returns a non-nil NSError.
 + (NSError *)git_errorFor:(int)code;
 
 // Describes the given libgit2 error code, using `desc` as the error's
@@ -52,14 +52,20 @@ extern NSString * const GTGitErrorDomain;
 //          This may be nil.
 // ...    - Format arguments to insert into `reason`.
 //
-// Returns an NSError.
+// Returns a non-nil NSError.
 + (NSError *)git_errorFor:(int)code description:(NSString *)desc failureReason:(NSString *)reason, ... NS_FORMAT_FUNCTION(3, 4);
 
-// Describes the given libgit2 error code, using `desc` as the error's
-// description.
+// Describes the given libgit2 error code, using `desc` and the arguments that
+// follow as the error's description.
 //
-// This method is obsolescent. Prefer +git_errorFor:description:failureReason:
-// instead.
-+ (NSError *)git_errorFor:(int)code withAdditionalDescription:(NSString *)desc, ... NS_FORMAT_FUNCTION(2,3);
+// The created error will also have an `NSUnderlyingErrorKey` that contains the
+// result of +git_errorFor: on the same error code.
+//
+// code - The error code returned from libgit2.
+// desc - A format string to use for the created NSError's description. This may be nil.
+// ...  - Format arguments to insert into `desc`.
+//
+// Returns a non-nil NSError.
++ (NSError *)git_errorFor:(int)code description:(NSString *)desc, ... NS_FORMAT_FUNCTION(2, 3);
 
 @end

--- a/Classes/Categories/NSError+Git.m
+++ b/Classes/Categories/NSError+Git.m
@@ -34,7 +34,7 @@ NSString * const GTGitErrorDomain = @"GTGitErrorDomain";
 
 @implementation NSError (Git)
 
-+ (NSError *)git_errorFor:(int)code withAdditionalDescription:(NSString *)desc, ... {
++ (NSError *)git_errorFor:(int)code description:(NSString *)desc, ... {
 	NSString *formattedDesc = nil;
 	if (desc != nil) {
 		va_list args;

--- a/Classes/GTBlob.m
+++ b/Classes/GTBlob.m
@@ -59,7 +59,7 @@
     int gitError = git_object_lookup(&obj, repository.git_repository, oid, (git_otype) GTObjectTypeBlob);
     if (gitError < GIT_OK) {
         if (error != NULL) {
-            *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to lookup blob"];
+            *error = [NSError git_errorFor:gitError description:@"Failed to lookup blob"];
         }
         return nil;
     }
@@ -77,7 +77,7 @@
 	int gitError = git_blob_create_frombuffer(&oid, repository.git_repository, [data bytes], data.length);
 	if(gitError < GIT_OK) {
 		if(error != NULL) {
-			*error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to create blob from NSData"];
+			*error = [NSError git_errorFor:gitError description:@"Failed to create blob from NSData"];
         }
 		return nil;
 	}
@@ -90,7 +90,7 @@
 	int gitError = git_blob_create_fromworkdir(&oid, repository.git_repository, [[file path] UTF8String]);
 	if(gitError < GIT_OK) {
 		if(error != NULL) {
-			*error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to create blob from NSURL"];
+			*error = [NSError git_errorFor:gitError description:@"Failed to create blob from NSURL"];
         }
 		return nil;
 	}

--- a/Classes/GTBranch.m
+++ b/Classes/GTBranch.m
@@ -175,7 +175,7 @@
 - (BOOL)deleteWithError:(NSError **)error {
 	int gitError = git_branch_delete(self.reference.git_reference);
 	if (gitError != GIT_OK) {
-		if(error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to delete branch %@", self.name];
+		if(error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to delete branch %@", self.name];
 		return NO;
 	}
 
@@ -199,13 +199,13 @@
 
 	if (gitError != GIT_OK) {
 		if (success != NULL) *success = NO;
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to create reference to tracking branch from %@", self];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to create reference to tracking branch from %@", self];
 		return nil;
 	}
 
 	if (trackingRef == NULL) {
 		if (success != NULL) *success = NO;
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Got a NULL remote ref for %@", self];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Got a NULL remote ref for %@", self];
 		return nil;
 	}
 
@@ -230,7 +230,7 @@
 
 	int errorCode = git_graph_ahead_behind(ahead, behind, self.repository.git_repository, branch.reference.git_oid, self.reference.git_oid);
 	if (errorCode != GIT_OK && error != NULL) {
-		*error = [NSError git_errorFor:errorCode withAdditionalDescription:@"Failed to calculate ahead/behind count of %@ relative to %@", self, branch];
+		*error = [NSError git_errorFor:errorCode description:@"Failed to calculate ahead/behind count of %@ relative to %@", self, branch];
 		return NO;
 	}
 

--- a/Classes/GTCommit.m
+++ b/Classes/GTCommit.m
@@ -80,7 +80,7 @@
 
 	if(gitError < GIT_OK) {
 		if(error != NULL)
-			*error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to create commit in repository"];
+			*error = [NSError git_errorFor:gitError description:@"Failed to create commit in repository"];
 		return nil;
 	}
 

--- a/Classes/GTConfiguration.m
+++ b/Classes/GTConfiguration.m
@@ -142,7 +142,7 @@ static int configCallback(const git_config_entry *entry, void *payload) {
 - (BOOL)refresh:(NSError **)error {
 	int success = git_config_refresh(self.git_config);
 	if (success != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:success withAdditionalDescription:@"Couldn't reload the configuration from disk."];
+		if (error != NULL) *error = [NSError git_errorFor:success description:@"Couldn't reload the configuration from disk."];
 
 		return NO;
 	}

--- a/Classes/GTDiff.m
+++ b/Classes/GTDiff.m
@@ -92,7 +92,7 @@ NSString *const GTDiffFindOptionsRenameLimitKey = @"GTDiffFindOptionsRenameLimit
 		return git_diff_tree_to_tree(&diffList, repository.git_repository, oldTree.git_tree, newTree.git_tree, optionsStruct);
 	}];
 	if (returnValue != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:returnValue withAdditionalDescription:@"Failed to create diff between %@ and %@", oldTree.SHA, newTree.SHA];
+		if (error != NULL) *error = [NSError git_errorFor:returnValue description:@"Failed to create diff between %@ and %@", oldTree.SHA, newTree.SHA];
 		return nil;
 	}
 	
@@ -109,7 +109,7 @@ NSString *const GTDiffFindOptionsRenameLimitKey = @"GTDiffFindOptionsRenameLimit
 		return git_diff_tree_to_index(&diffList, repository.git_repository, tree.git_tree, NULL, optionsStruct);
 	}];
 	if (returnValue != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:returnValue withAdditionalDescription:@"Failed to create diff between index and %@", tree.SHA];
+		if (error != NULL) *error = [NSError git_errorFor:returnValue description:@"Failed to create diff between index and %@", tree.SHA];
 		return nil;
 	}
 	
@@ -125,7 +125,7 @@ NSString *const GTDiffFindOptionsRenameLimitKey = @"GTDiffFindOptionsRenameLimit
 		return git_diff_index_to_workdir(&diffList, repository.git_repository, NULL, optionsStruct);
 	}];
 	if (returnValue != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:returnValue withAdditionalDescription:@"Failed to create diff between working directory and index"];
+		if (error != NULL) *error = [NSError git_errorFor:returnValue description:@"Failed to create diff between working directory and index"];
 		return nil;
 	}
 	
@@ -142,7 +142,7 @@ NSString *const GTDiffFindOptionsRenameLimitKey = @"GTDiffFindOptionsRenameLimit
 		return git_diff_tree_to_workdir(&diffList, repository.git_repository, tree.git_tree, optionsStruct);
 	}];
 	if (returnValue != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:returnValue withAdditionalDescription:@"Failed to create diff between working directory and %@", tree.SHA];
+		if (error != NULL) *error = [NSError git_errorFor:returnValue description:@"Failed to create diff between working directory and %@", tree.SHA];
 		return nil;
 	}
 	

--- a/Classes/GTEnumerator.m
+++ b/Classes/GTEnumerator.m
@@ -57,7 +57,7 @@
 
 	int gitError = git_revwalk_new(&_walk, self.repository.git_repository);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to initialize rev walker."];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to initialize rev walker."];
 		return nil;
 	}
 
@@ -81,7 +81,7 @@
 	
 	int gitError = git_revwalk_push(self.walk, oid.git_oid);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to push SHA %@ onto rev walker.", sha];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to push SHA %@ onto rev walker.", sha];
 		return NO;
 	}
 	
@@ -93,7 +93,7 @@
 
 	int gitError = git_revwalk_push_glob(self.walk, refGlob.UTF8String);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to push glob %@ onto rev walker.", refGlob];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to push glob %@ onto rev walker.", refGlob];
 		return NO;
 	}
 	
@@ -108,7 +108,7 @@
 
 	int gitError = git_revwalk_hide(self.walk, oid.git_oid);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to hide SHA %@ on rev walker.", sha];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to hide SHA %@ on rev walker.", sha];
 		return NO;
 	}
 
@@ -120,7 +120,7 @@
 
 	int gitError = git_revwalk_hide_glob(self.walk, refGlob.UTF8String);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to push glob %@ onto rev walker.", refGlob];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to push glob %@ onto rev walker.", refGlob];
 		return NO;
 	}
 	
@@ -182,7 +182,7 @@
 	if (gitError == GIT_ITEROVER) {
 		return count;
 	} else {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to get next SHA with rev walker."];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to get next SHA with rev walker."];
 		return NSNotFound;
 	}
 }

--- a/Classes/GTIndex.m
+++ b/Classes/GTIndex.m
@@ -62,7 +62,7 @@
 	git_index *index = NULL;
 	int status = git_index_open(&index, fileURL.path.fileSystemRepresentation);
 	if (status != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:status withAdditionalDescription:@"Failed to initialize index with URL %@", fileURL];
+		if (error != NULL) *error = [NSError git_errorFor:status description:@"Failed to initialize index with URL %@", fileURL];
 		return nil;
 	}
 
@@ -94,7 +94,7 @@
 - (BOOL)refresh:(NSError **)error {
 	int status = git_index_read(self.git_index);
 	if (status != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:status withAdditionalDescription:@"Failed to refresh index."];
+		if (error != NULL) *error = [NSError git_errorFor:status description:@"Failed to refresh index."];
 		return NO;
 	}
 
@@ -120,7 +120,7 @@
 	size_t pos = 0;
 	int gitError = git_index_find(&pos, self.git_index, name.UTF8String);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"%@ not found in index", name];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"%@ not found in index", name];
 		return NULL;
 	}
 	return [self entryAtIndex:pos];
@@ -129,7 +129,7 @@
 - (BOOL)addEntry:(GTIndexEntry *)entry error:(NSError **)error {
 	int status = git_index_add(self.git_index, entry.git_index_entry);
 	if (status != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:status withAdditionalDescription:@"Failed to add entry to index."];
+		if (error != NULL) *error = [NSError git_errorFor:status description:@"Failed to add entry to index."];
 		return NO;
 	}
 
@@ -139,7 +139,7 @@
 - (BOOL)addFile:(NSString *)file error:(NSError **)error {
 	int status = git_index_add_bypath(self.git_index, file.UTF8String);
 	if (status != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:status withAdditionalDescription:@"Failed to add file %@ to index.", file];
+		if (error != NULL) *error = [NSError git_errorFor:status description:@"Failed to add file %@ to index.", file];
 		return NO;
 	}
 
@@ -149,7 +149,7 @@
 - (BOOL)write:(NSError **)error {
 	int status = git_index_write(self.git_index);
 	if (status != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:status withAdditionalDescription:@"Failed to write index."];
+		if (error != NULL) *error = [NSError git_errorFor:status description:@"Failed to write index."];
 		return NO;
 	}
 
@@ -161,7 +161,7 @@
   
 	int status = git_index_write_tree(&oid, self.git_index);
 	if (status != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:status withAdditionalDescription:@"Failed to write index."];
+		if (error != NULL) *error = [NSError git_errorFor:status description:@"Failed to write index."];
 		return NULL;
 	}
 

--- a/Classes/GTOID.m
+++ b/Classes/GTOID.m
@@ -65,7 +65,7 @@
 	int status = git_oid_fromstr(&_git_oid, string);
 	if (status != GIT_OK) {
 		if (error != NULL) {
-			*error = [NSError git_errorFor:status withAdditionalDescription:@"Failed to convert string '%s' to object id", string];
+			*error = [NSError git_errorFor:status description:@"Failed to convert string '%s' to object id", string];
 		}
 		return nil;
 	}

--- a/Classes/GTObject.m
+++ b/Classes/GTObject.m
@@ -142,7 +142,7 @@
 	git_object *peeled = NULL;
 	int gitError = git_object_peel(&peeled, self.git_object, (git_otype)type);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Cannot peel object"];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Cannot peel object"];
 		return nil;
 	}
 

--- a/Classes/GTObjectDatabase.m
+++ b/Classes/GTObjectDatabase.m
@@ -61,7 +61,7 @@
 
 	int gitError = git_repository_odb(&_git_odb, repo.git_repository);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to get ODB for repo."];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to get ODB for repo."];
 		return nil;
 	}
 
@@ -72,7 +72,7 @@
 	git_odb_object *obj;
 	int gitError = git_odb_read(&obj, self.git_odb, oid.git_oid);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to read raw object with OID %@", oid.SHA];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to read raw object with OID %@", oid.SHA];
 		return nil;
 	}
 
@@ -94,26 +94,26 @@
 	git_oid oid;
 	int gitError = git_odb_hash(&oid, data.bytes, data.length, (git_otype)type);
 	if (gitError < GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to create an OID for input data."];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to create an OID for input data."];
 		return nil;
 	}
 
 	git_odb_stream *stream;
 	gitError = git_odb_open_wstream(&stream, self.git_odb, data.length, (git_otype)type);
 	if (gitError < GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to open write stream on odb."];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to open write stream on odb."];
 		return nil;
 	}
 	
 	gitError = stream->write(stream, data.bytes, data.length);
 	if (gitError < GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to write to stream on odb."];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to write to stream on odb."];
 		return nil;
 	}
 	
 	gitError = stream->finalize_write(stream, &oid);
 	if (gitError < GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to finalize write on odb."];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to finalize write on odb."];
 		return nil;
 	}
     

--- a/Classes/GTReference.m
+++ b/Classes/GTReference.m
@@ -84,7 +84,7 @@ static NSString *referenceTypeToString(GTReferenceType type) {
 	git_reference *ref = NULL;
 	int gitError = git_reference_lookup(&ref, repo.git_repository, refName.UTF8String);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to lookup reference %@.", refName];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to lookup reference %@.", refName];
 		return nil;
 	}
 
@@ -106,7 +106,7 @@ static NSString *referenceTypeToString(GTReferenceType type) {
 	}
 
 	if (gitError != GIT_OK) {
-		if(error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to create symbolic reference to %@.", target];
+		if(error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to create symbolic reference to %@.", target];
 		return nil;
 	}
 
@@ -119,7 +119,7 @@ static NSString *referenceTypeToString(GTReferenceType type) {
 	git_reference *ref = NULL;
 	int gitError = git_reference_resolve(&ref, symbolicRef.git_reference);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to resolve reference %@.", symbolicRef.name];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to resolve reference %@.", symbolicRef.name];
 		return nil;
 	}
 
@@ -152,7 +152,7 @@ static NSString *referenceTypeToString(GTReferenceType type) {
 	git_reference *newRef = NULL;
 	int gitError = git_reference_rename(&newRef, self.git_reference, newName.UTF8String, 0);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to rename reference %@ to %@.", self.name, newName];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to rename reference %@ to %@.", self.name, newName];
 		return NO;
 	}
 
@@ -209,7 +209,7 @@ static NSString *referenceTypeToString(GTReferenceType type) {
 	}
 
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to update reference %@ to target %@.", self.name, newTarget];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to update reference %@ to target %@.", self.name, newTarget];
 		return nil;
 	}
 
@@ -219,7 +219,7 @@ static NSString *referenceTypeToString(GTReferenceType type) {
 - (BOOL)deleteWithError:(NSError **)error {
 	int gitError = git_reference_delete(self.git_reference);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to delete reference %@.", self.name];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to delete reference %@.", self.name];
 		return NO;
 	}
 
@@ -246,7 +246,7 @@ static NSString *referenceTypeToString(GTReferenceType type) {
 }
 
 + (NSError *)invalidReferenceError {
-	return [NSError git_errorFor:GTReferenceErrorCodeInvalidReference withAdditionalDescription:@"Invalid git_reference."];
+	return [NSError git_errorFor:GTReferenceErrorCodeInvalidReference description:@"Invalid git_reference."];
 }
 
 - (GTReflog *)reflog {

--- a/Classes/GTReflog.m
+++ b/Classes/GTReflog.m
@@ -51,7 +51,7 @@
 	int status = git_reflog_append(self.git_reflog, self.reference.git_oid, committer.git_signature, message.UTF8String);
 	if (status != GIT_OK) {
 		if (error != NULL) {
-			*error = [NSError git_errorFor:status withAdditionalDescription:@"Could not append to reflog"];
+			*error = [NSError git_errorFor:status description:@"Could not append to reflog"];
 		}
 		return NO;
 	}
@@ -59,7 +59,7 @@
 	status = git_reflog_write(self.git_reflog);
 	if (status != GIT_OK) {
 		if (error != NULL) {
-			*error = [NSError git_errorFor:status withAdditionalDescription:@"Could not write reflog"];
+			*error = [NSError git_errorFor:status description:@"Could not write reflog"];
 		}
 		return NO;
 	}

--- a/Classes/GTRepository.m
+++ b/Classes/GTRepository.m
@@ -119,7 +119,7 @@ typedef struct {
 	git_repository *r;
 	int gitError = git_repository_init(&r, path, bare);
 	if (gitError < GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to initialize empty repository at URL %@.", localFileURL];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to initialize empty repository at URL %@.", localFileURL];
 	}
 
 	return gitError == GIT_OK;
@@ -149,7 +149,7 @@ typedef struct {
 	git_repository *r;
 	int gitError = git_repository_open(&r, localFileURL.path.UTF8String);
 	if (gitError < GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to open repository at URL %@.", localFileURL];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to open repository at URL %@.", localFileURL];
 		return nil;
 	}
 
@@ -200,7 +200,7 @@ static int transferProgressCallback(const git_transfer_progress *progress, void 
 	git_repository *repository;
 	int gitError = git_clone(&repository, remoteURL, workingDirectoryPath, &cloneOptions);
 	if (gitError < GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to clone repository from %@ to %@", originURL, workdirURL];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to clone repository from %@ to %@", originURL, workdirURL];
 		return nil;
 	}
 
@@ -213,7 +213,7 @@ static int transferProgressCallback(const git_transfer_progress *progress, void 
 
 	int gitError = git_odb_hash(&oid, [data UTF8String], [data length], (git_otype) type);
 	if (gitError < GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to get hash for object."];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to get hash for object."];
 		return nil;
 	}
 
@@ -228,7 +228,7 @@ static int transferProgressCallback(const git_transfer_progress *progress, void 
 		if (error != NULL) {
 			char oid_str[GIT_OID_HEXSZ+1];
 			git_oid_tostr(oid_str, sizeof(oid_str), oid);
-			*error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to lookup object %s in repository.", oid_str];
+			*error = [NSError git_errorFor:gitError description:@"Failed to lookup object %s in repository.", oid_str];
 		}
 		return nil;
 	}
@@ -263,7 +263,7 @@ static int transferProgressCallback(const git_transfer_progress *progress, void 
 	git_object *obj;
 	int gitError = git_revparse_single(&obj, self.git_repository, spec.UTF8String);
 	if (gitError < GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to lookup object by refspec %@.", spec];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to lookup object by refspec %@.", spec];
 		return nil;
 	}
 	return [GTObject objectWithObj:obj inRepository:self];
@@ -330,7 +330,7 @@ static int file_status_callback(const char *relativeFilePath, unsigned int gitSt
 	git_reference *headRef;
 	int gitError = git_repository_head(&headRef, self.git_repository);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to get HEAD"];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to get HEAD"];
 		return nil;
 	}
 
@@ -418,7 +418,7 @@ static int GTRepositoryForeachTagCallback(const char *name, git_oid *oid, void *
 	};
 	int gitError = git_tag_foreach(self.git_repository, GTRepositoryForeachTagCallback, &payload);
 	if (gitError != GIT_OK && gitError != GIT_EUSER) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to enumerate tags"];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to enumerate tags"];
 		return NO;
 	}
 
@@ -473,7 +473,7 @@ static int GTRepositoryForeachTagCallback(const char *name, git_oid *oid, void *
 	git_strarray array;
 	int gitError = git_reference_list(&array, self.git_repository);
 	if (gitError < GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to list all references."];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to list all references."];
 		return nil;
 	}
 
@@ -523,7 +523,7 @@ static int GTRepositoryForeachTagCallback(const char *name, git_oid *oid, void *
     int result = git_reset(self.git_repository, commit.git_object, (git_reset_t)resetType);
     if (result == GIT_OK) return YES;
 
-    if (error != NULL) *error = [NSError git_errorFor:result withAdditionalDescription:@"Failed to reset repository to commit %@.", commit.SHA];
+    if (error != NULL) *error = [NSError git_errorFor:result description:@"Failed to reset repository to commit %@.", commit.SHA];
 
     return NO;
 }
@@ -536,7 +536,7 @@ static int GTRepositoryForeachTagCallback(const char *name, git_oid *oid, void *
 		}
 
 		if (error != NULL) {
-			*error = [NSError git_errorFor:errorCode withAdditionalDescription:@"Failed to read prepared message."];
+			*error = [NSError git_errorFor:errorCode description:@"Failed to read prepared message."];
 		}
 	};
 
@@ -584,7 +584,7 @@ static int GTRepositoryForeachTagCallback(const char *name, git_oid *oid, void *
 	git_oid mergeBase;
 	int errorCode = git_merge_base(&mergeBase, self.git_repository, firstOID.git_oid, secondOID.git_oid);
 	if (errorCode < GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:errorCode withAdditionalDescription:@"Failed to find merge base between commits %@ and %@.", firstOID.SHA, secondOID.SHA];
+		if (error != NULL) *error = [NSError git_errorFor:errorCode description:@"Failed to find merge base between commits %@ and %@.", firstOID.SHA, secondOID.SHA];
 		return nil;
 	}
 	
@@ -599,7 +599,7 @@ static int GTRepositoryForeachTagCallback(const char *name, git_oid *oid, void *
 	git_config *config = NULL;
 	int gitError = git_repository_config(&config, self.git_repository);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to get config for repository."];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to get config for repository."];
 		return nil;
 	}
 
@@ -610,7 +610,7 @@ static int GTRepositoryForeachTagCallback(const char *name, git_oid *oid, void *
 	git_index *index = NULL;
 	int gitError = git_repository_index(&index, self.git_repository);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to get index for repository."];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to get index for repository."];
 		return NO;
 	}
 
@@ -638,7 +638,7 @@ static int submoduleEnumerationCallback(git_submodule *git_submodule, const char
 - (BOOL)reloadSubmodules:(NSError **)error {
 	int gitError = git_submodule_reload_all(self.git_repository);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to reload submodules."];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to reload submodules."];
 		return NO;
 	}
 
@@ -665,7 +665,7 @@ static int submoduleEnumerationCallback(git_submodule *git_submodule, const char
 	git_submodule *submodule;
 	int gitError = git_submodule_lookup(&submodule, self.git_repository, name.UTF8String);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to look up submodule %@.", name];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to look up submodule %@.", name];
 		return nil;
 	}
 
@@ -700,7 +700,7 @@ static int submoduleEnumerationCallback(git_submodule *git_submodule, const char
 	git_oid oid;
 	int gitError = git_tag_create_lightweight(&oid, self.git_repository, tagName.UTF8String, target.git_object, 0);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Cannot create lightweight tag"];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Cannot create lightweight tag"];
 		return NO;
 	}
 
@@ -711,7 +711,7 @@ static int submoduleEnumerationCallback(git_submodule *git_submodule, const char
 	git_oid oid;
 	int gitError = git_tag_create(&oid, self.git_repository, [tagName UTF8String], theTarget.git_object, theTagger.git_signature, [theMessage UTF8String], 0);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to create tag in repository"];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to create tag in repository"];
 		return nil;
 	}
 
@@ -746,7 +746,7 @@ static int checkoutNotifyCallback(git_checkout_notify_t why, const char *path, c
 	
 	int gitError = git_repository_set_head(self.git_repository, reference.name.UTF8String);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to move HEAD to reference %@", reference.name];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to move HEAD to reference %@", reference.name];
 	}
 	
 	return gitError == GIT_OK;
@@ -757,7 +757,7 @@ static int checkoutNotifyCallback(git_checkout_notify_t why, const char *path, c
 	
 	int gitError = git_repository_set_head_detached(self.git_repository, commit.OID.git_oid);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to move HEAD to commit %@", commit.SHA];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to move HEAD to commit %@", commit.SHA];
 	}
 	
 	return gitError == GIT_OK;
@@ -777,7 +777,7 @@ static int checkoutNotifyCallback(git_checkout_notify_t why, const char *path, c
 	
 	int gitError = git_checkout_head(self.git_repository, &checkoutOptions);
 	if (gitError < GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to checkout tree."];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to checkout tree."];
 	}
 	
 	return gitError == GIT_OK;

--- a/Classes/GTSubmodule.m
+++ b/Classes/GTSubmodule.m
@@ -90,7 +90,7 @@
 	unsigned status;
 	int gitError = git_submodule_status(&status, self.git_submodule);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to get submodule %@ status.", self.name];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to get submodule %@ status.", self.name];
 		return GTSubmoduleStatusUnknown;
 	}
 
@@ -102,7 +102,7 @@
 - (BOOL)reload:(NSError **)error {
 	int gitError = git_submodule_reload(self.git_submodule);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to reload submodule %@.", self.name];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to reload submodule %@.", self.name];
 		return NO;
 	}
 
@@ -112,7 +112,7 @@
 - (BOOL)sync:(NSError **)error {
 	int gitError = git_submodule_sync(self.git_submodule);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to synchronize submodule %@.", self.name];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to synchronize submodule %@.", self.name];
 		return NO;
 	}
 
@@ -123,7 +123,7 @@
 	git_repository *repo;
 	int gitError = git_submodule_open(&repo, self.git_submodule);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to open submodule %@ repository.", self.name];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to open submodule %@ repository.", self.name];
 		return nil;
 	}
 
@@ -133,7 +133,7 @@
 - (BOOL)writeToParentConfigurationDestructively:(BOOL)overwrite error:(NSError **)error {
 	int gitError = git_submodule_init(self.git_submodule, (overwrite ? 1 : 0));
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to initialize submodule %@.", self.name];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to initialize submodule %@.", self.name];
 		return NO;
 	}
 

--- a/Classes/GTTag.m
+++ b/Classes/GTTag.m
@@ -74,7 +74,7 @@
 	git_object *target = nil;
 	int gitError = git_tag_peel(&target, self.git_tag);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Cannot peel tag"];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Cannot peel tag"];
 		return nil;
 	}
 

--- a/Classes/GTTree.m
+++ b/Classes/GTTree.m
@@ -100,7 +100,7 @@ static int treewalk_cb(const char *root, const git_tree_entry *git_entry, void *
 
 	int gitError = git_tree_walk(self.git_tree, (git_treewalk_mode)option, treewalk_cb, &enumStruct);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to enumerate tree %@", self.SHA];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to enumerate tree %@", self.SHA];
 	}
 	return gitError != GIT_OK;
 }
@@ -127,7 +127,7 @@ static int treewalk_cb(const char *root, const git_tree_entry *git_entry, void *
 	git_index *index;
 	int result = git_merge_trees(&index, self.repository.git_repository, ancestorTree.git_tree, self.git_tree, otherTree.git_tree, NULL);
 	if (result != GIT_OK || index == NULL) {
-		if (error != NULL) *error = [NSError git_errorFor:result withAdditionalDescription:@"Failed to merge tree %@ with tree %@", self.SHA, otherTree.SHA];
+		if (error != NULL) *error = [NSError git_errorFor:result description:@"Failed to merge tree %@ with tree %@", self.SHA, otherTree.SHA];
 		return nil;
 	}
 

--- a/Classes/GTTreeBuilder.m
+++ b/Classes/GTTreeBuilder.m
@@ -54,7 +54,7 @@
 
 	int status = git_treebuilder_create(&_git_treebuilder, treeOrNil.git_tree);
 	if (status != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:status withAdditionalDescription:@"Failed to create tree builder with tree %@.", treeOrNil.SHA];
+		if (error != NULL) *error = [NSError git_errorFor:status description:@"Failed to create tree builder with tree %@.", treeOrNil.SHA];
 		return nil;
 	}
 
@@ -102,7 +102,7 @@ static int filter_callback(const git_tree_entry *entry, void *payload) {
 	int status = git_treebuilder_insert(&entry, self.git_treebuilder, filename.UTF8String, oid.git_oid, (git_filemode_t)filemode);
 	
 	if (status != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:status withAdditionalDescription:@"Failed to add entry %@ to tree builder.", oid.SHA];
+		if (error != NULL) *error = [NSError git_errorFor:status description:@"Failed to add entry %@ to tree builder.", oid.SHA];
 		return nil;
 	}
 	
@@ -118,7 +118,7 @@ static int filter_callback(const git_tree_entry *entry, void *payload) {
 - (BOOL)removeEntryWithFilename:(NSString *)filename error:(NSError **)error {
 	int status = git_treebuilder_remove(self.git_treebuilder, filename.UTF8String);
 	if (status != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:status withAdditionalDescription:@"Failed to remove entry with name %@ from tree builder.", filename];
+		if (error != NULL) *error = [NSError git_errorFor:status description:@"Failed to remove entry with name %@ from tree builder.", filename];
 	}
 	
 	return (status == GIT_OK);
@@ -128,14 +128,14 @@ static int filter_callback(const git_tree_entry *entry, void *payload) {
 	git_oid treeOid;
 	int status = git_treebuilder_write(&treeOid, repository.git_repository, self.git_treebuilder);
 	if (status != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:status withAdditionalDescription:@"Failed to write tree in repository."];
+		if (error != NULL) *error = [NSError git_errorFor:status description:@"Failed to write tree in repository."];
 		return nil;
 	}
 	
 	git_object *object = NULL;
 	status = git_object_lookup(&object, repository.git_repository, &treeOid, GIT_OBJ_TREE);
 	if (status != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:status withAdditionalDescription:@"Failed to lookup tree in repository."];
+		if (error != NULL) *error = [NSError git_errorFor:status description:@"Failed to lookup tree in repository."];
 		return nil;
 	}
 	

--- a/Classes/GTTreeEntry.m
+++ b/Classes/GTTreeEntry.m
@@ -123,7 +123,7 @@
     int gitError = git_tree_entry_to_object(&obj, treeEntry.repository.git_repository, treeEntry.git_tree_entry);
     if (gitError < GIT_OK) {
         if (error != NULL) {
-            *error = [NSError git_errorFor:gitError withAdditionalDescription:@"Failed to get object for tree entry."];
+            *error = [NSError git_errorFor:gitError description:@"Failed to get object for tree entry."];
         }
         return nil;
     }

--- a/ObjectiveGitTests/NSErrorGitSpec.m
+++ b/ObjectiveGitTests/NSErrorGitSpec.m
@@ -11,7 +11,7 @@
 SpecBegin(NSErrorGit)
 
 it(@"should create an error with a nil description", ^{
-	NSError *error = [NSError git_errorFor:GIT_OK withAdditionalDescription:nil];
+	NSError *error = [NSError git_errorFor:GIT_OK description:nil];
 	expect(error).notTo.beNil();
 
 	expect(error.domain).to.equal(GTGitErrorDomain);
@@ -23,7 +23,7 @@ it(@"should create an error with a nil description", ^{
 });
 
 it(@"should create an error with a formatted description", ^{
-	NSError *error = [NSError git_errorFor:GIT_OK withAdditionalDescription:@"foo %@ bar %@", @1, @"buzz"];
+	NSError *error = [NSError git_errorFor:GIT_OK description:@"foo %@ bar %@", @1, @"buzz"];
 	expect(error).notTo.beNil();
 
 	expect(error.domain).to.equal(GTGitErrorDomain);


### PR DESCRIPTION
Because we may be particularly unfortunate and not get a real error description.
