### PR TITLE
Remove RunUnitTests script

### DIFF
--- a/ObjectiveGitFramework.xcodeproj/project.pbxproj
+++ b/ObjectiveGitFramework.xcodeproj/project.pbxproj
@@ -1224,7 +1224,6 @@
 				88F05A6616011E5400B7AD1D /* Sources */,
 				88F05A6716011E5400B7AD1D /* Frameworks */,
 				88F05A6816011E5400B7AD1D /* Resources */,
-				D0D81875174425AA00995A2E /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1455,19 +1454,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = script/update_libgit2_ios;
-		};
-		D0D81875174425AA00995A2E /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Not supported in Xcode 5's `xcodebuild`.

@alanjrogers Do we still need the separate arm64 target now that we're on Xcode 5?
