### PR TITLE
Compare against repositories when comparing branches.

### DIFF
--- a/Classes/GTBranch.m
+++ b/Classes/GTBranch.m
@@ -39,7 +39,7 @@
 - (BOOL)isEqual:(GTBranch *)otherBranch {
 	if (otherBranch == self) return YES;
 	if (![otherBranch isKindOfClass:self.class]) return NO;
-	if (![otherBranch.repository isEqual:self.repository]) return NO;
+	if (otherBranch.repository != self.repository) return NO;
 
 	return [self.name isEqual:otherBranch.name] && [self.SHA isEqual:otherBranch.SHA];
 }


### PR DESCRIPTION
As we weren't caring about which repository this object belonged to, this could result in a crash within libgit2.

One thing I'm not sure about here is whether we should care that it is the exact same repository object, as opposed to whether it's just the same repository on disk.

/cc @arrbee 
