### PR TITLE
Update README.md with correct getting started instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,18 @@ please consider [contributing a pull request](#contributing)!
 
 ## Getting Started
 
-To start building the framework, clone this repository and then run
-`script/bootstrap`. This will automatically pull down and install any
+To start building the framework, you must install the required dependencies, 
+[xctool](https://github.com/facebook/xctool) and 
+[cmake](https://github.com/Kitware/CMake). We recommend using 
+[Homebrew](http://brew.sh) to install these two tools. 
+
+Once you have the dependencies you should clone this repository and then run
+`script/bootstrap`. This will automatically pull down and install any other
 dependencies.
 
 Note that the `bootstrap` script automatically installs some libraries that
-ObjectiveGit relies upon, using [Homebrew](http://brew.sh). If you want this
-behavior, please make sure you have Homebrew installed.
+ObjectiveGit relies upon, using Homebrew. If you want this behavior, please 
+make sure you have Homebrew installed.
 
 ## Importing ObjectiveGit on OS X
 


### PR DESCRIPTION
The getting started instructions in the README imply the bootstrap script will install the objectiveGit dependencies with homebrew, but it actually requires `xctool` and `cmake` to be installed _before_ it does it's thing.

I assume the bootstrap script's dependency on xctool and cmake are by design so I've just updated the README to reflect the fact you need to install two other things first.
