### PR TITLE
Add GTCredential header to ObjectiveGit.h

### DIFF
--- a/Classes/ObjectiveGit.h
+++ b/Classes/ObjectiveGit.h
@@ -31,6 +31,7 @@
 #import <ObjectiveGit/GTRepository+Status.h>
 #import <ObjectiveGit/GTEnumerator.h>
 #import <ObjectiveGit/GTCommit.h>
+#import <ObjectiveGit/GTCredential.h>
 #import <ObjectiveGit/GTSignature.h>
 #import <ObjectiveGit/GTTree.h>
 #import <ObjectiveGit/GTTreeEntry.h>


### PR DESCRIPTION
GTCredential.h seems to be missing from ObjectiveGit.h. I'm assuming this was an oversight. There doesn't seem to be any order to the entries ObjectiveGit.h so I just added it under a similarly named header.
