### PR TITLE
Handle multiple string encodings in a GTDiffLine.

### DIFF
--- a/Classes/GTDiffLine.m
+++ b/Classes/GTDiffLine.m
@@ -29,19 +29,7 @@
 	[encodings enumerateObjectsUsingBlock:^(NSNumber *encoding, NSUInteger idx, BOOL *stop) {
 		string = [[NSString alloc] initWithData:lineData encoding:encoding.unsignedIntegerValue];
 
-		// Try the next encoding
-		if (string == nil) return;
-
-		// If this string is already UTF8 we're done.
-		if (encoding.unsignedIntegerValue == NSUTF8StringEncoding) {
-			*stop = YES;
-			return;
-		}
-
-		// Check we can convert to UTF8
-		NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding allowLossyConversion:YES];
-		string = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-
+		// Return the first encoding that works :)
 		if (string != nil) *stop = YES;
 	}];
 


### PR DESCRIPTION
If we hit a character in a line in a diff that can't be interpreted as UTF8, we'll have `content == nil` on the resulting `GTDiffLine`, and if that's used for diff display, the line won't be rendered as it should. :trolleybus: 

Example commit: https://github.com/anatomecha/arise_unity/commit/a61792298365ef1cf62c6ab1899abf9dffab9205#diff-01c4f817ee772d4374776fd205679d77R26

Also `-[NSString initWithBytes:length:]` is documented to return `nil` If the length of the byte string is greater than the specified length. Which makes little sense, and is most likely an error in the documentation, but better to be safe than sorry and wrap the bytes in an `NSData` object first.
