### PR TITLE
Fix test failure in aborting an index update

### DIFF
--- a/Classes/GTIndex.m
+++ b/Classes/GTIndex.m
@@ -263,7 +263,7 @@ int GTIndexPathspecMatchFound(const char *path, const char *matched_pathspec, vo
 	struct GTIndexPathspecMatchedInfo *info = payload;
 	GTIndexPathspecMatchedBlock block = info->block;
 	if (info->shouldAbortImmediately) {
-		return -1;
+		return GIT_EUSER;
 	}
 	
 	BOOL shouldStop = NO;
@@ -276,7 +276,7 @@ int GTIndexPathspecMatchFound(const char *path, const char *matched_pathspec, vo
 		}
 		return 0;
 	} else if (shouldStop) {
-		return -1;
+		return GIT_EUSER;
 	} else {
 		return 1;
 	}


### PR DESCRIPTION
Apparently the value we return is passed all the way up, unmodified. We have to return `GIT_EUSER` in order for it to arrive that way at the original call point.

Fixes [a test failure](https://github.com/libgit2/objective-git/blob/84d196cbb41c71c69011826939e35e7afb210a97/ObjectiveGitTests/GTIndexSpec.m#L133) from #306.

@PiersonBro @dannygreg 
