### PR TITLE
Fix `userSignatureForNow` sometimes returning nil.

### DIFF
--- a/Classes/GTRepository.m
+++ b/Classes/GTRepository.m
@@ -684,13 +684,9 @@ static int submoduleEnumerationCallback(git_submodule *git_submodule, const char
 	GTConfiguration *configuration = [self configurationWithError:NULL];
 	NSString *name = [configuration stringForKey:@"user.name"];
 	if (name == nil) {
-		if (NSFullUserName().length != 0) {
-			name = NSFullUserName();
-		} else if (NSUserName().length != 0) {
-			name = NSUserName();
-		} else {
-			name = @"Nobody";
-		}
+		name = NSFullUserName();
+		if (name.length == 0) name = NSUserName();
+		if (name.length == 0) name = @"nobody";
 	}
 
 	NSString *email = [configuration stringForKey:@"user.email"];


### PR DESCRIPTION
On the iOS simulator, `NSFullUserName()` (and presumably `NSUserName()`) returns an empty string; currently we check for `nil`.
This leads to `userSignatureForNow` returning nil and, eventually, a crash. Instead make sure that `NSFullUserName()` and `NSUserName()` don’t return an empty string or `nil`.

Alas, I cannot create a test because I've only been able to reproduce on the iOS simulator.
