### PR TITLE
Don't require equivalent repositories.

### DIFF
--- a/Classes/GTDiff.h
+++ b/Classes/GTDiff.h
@@ -185,10 +185,11 @@ typedef enum {
 //
 // The 2 trees must be from the same repository, or an exception will be thrown.
 //
-// oldTree    - The "left" side of the diff. May be nil to represent an empty tree.
+// oldTree    - The "left" side of the diff. May be nil to represent an empty
+//              tree.
 // newTree    - The "right" side of the diff. May be nil to represent an empty
 //              tree.
-// repository - The repository to be used for the diff.
+// repository - The repository to be used for the diff. Cannot be nil.
 // options    - A dictionary containing any of the above options key constants, or
 //              nil to use the defaults.
 // error      - Populated with an `NSError` object on error, if information is

--- a/Classes/GTDiff.m
+++ b/Classes/GTDiff.m
@@ -82,20 +82,17 @@ NSString *const GTDiffFindOptionsRenameLimitKey = @"GTDiffFindOptionsRenameLimit
 
 + (GTDiff *)diffOldTree:(GTTree *)oldTree withNewTree:(GTTree *)newTree inRepository:(GTRepository *)repository options:(NSDictionary *)options error:(NSError **)error {
 	NSParameterAssert(repository != nil);
-	NSParameterAssert(newTree == nil || [newTree.repository isEqual:repository]);
-	NSParameterAssert(oldTree == nil || [oldTree.repository isEqual:repository]);
 	
 	__block git_diff *diff;
-	int returnValue = [self handleParsedOptionsDictionary:options usingBlock:^(git_diff_options *optionsStruct) {
+	int status = [self handleParsedOptionsDictionary:options usingBlock:^(git_diff_options *optionsStruct) {
 		return git_diff_tree_to_tree(&diff, repository.git_repository, oldTree.git_tree, newTree.git_tree, optionsStruct);
 	}];
-	if (returnValue != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:returnValue description:@"Failed to create diff between %@ and %@", oldTree.SHA, newTree.SHA];
+	if (status != GIT_OK) {
+		if (error != NULL) *error = [NSError git_errorFor:status description:@"Failed to create diff between %@ and %@", oldTree.SHA, newTree.SHA];
 		return nil;
 	}
 	
-	GTDiff *newDiff = [[GTDiff alloc] initWithGitDiff:diff];
-	return newDiff;
+	return [[GTDiff alloc] initWithGitDiff:diff];
 }
 
 + (GTDiff *)diffIndexFromTree:(GTTree *)tree inRepository:(GTRepository *)repository options:(NSDictionary *)options error:(NSError **)error {


### PR DESCRIPTION
Repository equivalence is Tricky® and if we can’t diff, we’ll find out
from libgit2.
