### PR TITLE
Give GTDiff a strong ref to its repository

### DIFF
--- a/Classes/GTDiff.h
+++ b/Classes/GTDiff.h
@@ -258,7 +258,12 @@ typedef enum {
 + (GTDiff *)diffWorkingDirectoryToHEADInRepository:(GTRepository *)repository options:(NSDictionary *)options error:(NSError **)error;
 
 // Designated initialiser.
-- (instancetype)initWithGitDiff:(git_diff *)diff;
+//
+// diff       - The diff to represent. Cannot be NULL.
+// repository - The repository in which the diff lives. Cannot be nil.
+//
+// Returns the initialized object.
+- (instancetype)initWithGitDiff:(git_diff *)diff repository:(GTRepository *)repository;
 
 // The libgit2 diff object.
 - (git_diff *)git_diff __attribute__((objc_returns_inner_pointer));

--- a/Classes/GTDiff.m
+++ b/Classes/GTDiff.m
@@ -36,6 +36,8 @@ NSString *const GTDiffFindOptionsRenameLimitKey = @"GTDiffFindOptionsRenameLimit
 
 @property (nonatomic, assign, readonly) git_diff *git_diff;
 
+@property (nonatomic, strong, readonly) GTRepository *repository;
+
 @end
 
 @implementation GTDiff
@@ -88,7 +90,7 @@ NSString *const GTDiffFindOptionsRenameLimitKey = @"GTDiffFindOptionsRenameLimit
 		return nil;
 	}
 	
-	return [[GTDiff alloc] initWithGitDiff:diff];
+	return [[GTDiff alloc] initWithGitDiff:diff repository:repository];
 }
 
 + (GTDiff *)diffIndexFromTree:(GTTree *)tree inRepository:(GTRepository *)repository options:(NSDictionary *)options error:(NSError **)error {
@@ -104,8 +106,7 @@ NSString *const GTDiffFindOptionsRenameLimitKey = @"GTDiffFindOptionsRenameLimit
 		return nil;
 	}
 	
-	GTDiff *newDiff = [[GTDiff alloc] initWithGitDiff:diff];
-	return newDiff;
+	return [[GTDiff alloc] initWithGitDiff:diff repository:repository];
 }
 
 + (GTDiff *)diffIndexToWorkingDirectoryInRepository:(GTRepository *)repository options:(NSDictionary *)options error:(NSError **)error {
@@ -120,8 +121,7 @@ NSString *const GTDiffFindOptionsRenameLimitKey = @"GTDiffFindOptionsRenameLimit
 		return nil;
 	}
 	
-	GTDiff *newDiff = [[GTDiff alloc] initWithGitDiff:diff];
-	return newDiff;
+	return [[GTDiff alloc] initWithGitDiff:diff repository:repository];
 }
 
 + (GTDiff *)diffWorkingDirectoryFromTree:(GTTree *)tree inRepository:(GTRepository *)repository options:(NSDictionary *)options error:(NSError **)error {
@@ -137,8 +137,7 @@ NSString *const GTDiffFindOptionsRenameLimitKey = @"GTDiffFindOptionsRenameLimit
 		return nil;
 	}
 	
-	GTDiff *newDiff = [[GTDiff alloc] initWithGitDiff:diff];
-	return newDiff;
+	return [[GTDiff alloc] initWithGitDiff:diff repository:repository];
 }
 
 + (GTDiff *)diffWorkingDirectoryToHEADInRepository:(GTRepository *)repository options:(NSDictionary *)options error:(NSError **)error {
@@ -156,13 +155,15 @@ NSString *const GTDiffFindOptionsRenameLimitKey = @"GTDiffFindOptionsRenameLimit
 	return HEADIndexDiff;
 }
 
-- (instancetype)initWithGitDiff:(git_diff *)diff {
+- (instancetype)initWithGitDiff:(git_diff *)diff repository:(GTRepository *)repository {
 	NSParameterAssert(diff != NULL);
+	NSParameterAssert(repository != nil);
 	
 	self = [super init];
 	if (self == nil) return nil;
 	
 	_git_diff = diff;
+	_repository = repository;
 	
 	return self;
 }


### PR DESCRIPTION
Under the covers libgit2 could try to access the `git_diff`’s repository, so we need to ensure that it stays alive as long as we are.
