### PR TITLE
Remove public headers path setting from the project

### DIFF
--- a/ObjectiveGitFramework.xcodeproj/project.pbxproj
+++ b/ObjectiveGitFramework.xcodeproj/project.pbxproj
@@ -1543,7 +1543,6 @@
 					"$(inherited)",
 					"-DGIT_SSH",
 				);
-				PUBLIC_HEADERS_FOLDER_PATH = include/ObjectiveGit;
 				TEST_AFTER_BUILD = NO;
 			};
 			name = Debug;
@@ -1568,7 +1567,6 @@
 					"$(inherited)",
 					"-DGIT_SSH",
 				);
-				PUBLIC_HEADERS_FOLDER_PATH = include/ObjectiveGit;
 				TEST_AFTER_BUILD = NO;
 			};
 			name = Release;
@@ -1677,7 +1675,6 @@
 					"$(inherited)",
 					"-DGIT_SSH",
 				);
-				PUBLIC_HEADERS_FOLDER_PATH = include/ObjectiveGit;
 				TEST_AFTER_BUILD = NO;
 			};
 			name = Profile;


### PR DESCRIPTION
This was being inherited in the framework inappropriately, this removes the
project setting because the static targets already have the value in their
config and reverts the framework target back to the default.
