### PR TITLE
Only set the public headers path for the iOS static lib.

### DIFF
--- a/ObjectiveGitFramework.xcodeproj/project.pbxproj
+++ b/ObjectiveGitFramework.xcodeproj/project.pbxproj
@@ -1543,7 +1543,6 @@
 					"$(inherited)",
 					"-DGIT_SSH",
 				);
-				PUBLIC_HEADERS_FOLDER_PATH = include/ObjectiveGit;
 				TEST_AFTER_BUILD = NO;
 			};
 			name = Debug;
@@ -1568,7 +1567,6 @@
 					"$(inherited)",
 					"-DGIT_SSH",
 				);
-				PUBLIC_HEADERS_FOLDER_PATH = include/ObjectiveGit;
 				TEST_AFTER_BUILD = NO;
 			};
 			name = Release;
@@ -1677,7 +1675,6 @@
 					"$(inherited)",
 					"-DGIT_SSH",
 				);
-				PUBLIC_HEADERS_FOLDER_PATH = include/ObjectiveGit;
 				TEST_AFTER_BUILD = NO;
 			};
 			name = Profile;


### PR DESCRIPTION
Instead of applying the public headers path to all build configurations, only apply it to the targets where it is needed. This should retain the behaviour intended in https://github.com/libgit2/objective-git/commit/36ec513f7188a02b3d098da470d4d3d2d4c437fe (putting the headers in the built products dir instead of /usr/local) while correcting the problem where headers weren’t being placed into the Mac framework bundle, as described here: https://github.com/libgit2/objective-git/issues/344#issuecomment-38632852
