### PR TITLE
Don't create a signature with an empty name

### DIFF
--- a/Classes/GTRepository.m
+++ b/Classes/GTRepository.m
@@ -666,7 +666,7 @@ static int submoduleEnumerationCallback(git_submodule *git_submodule, const char
 - (GTSignature *)userSignatureForNow {
 	GTConfiguration *configuration = [self configurationWithError:NULL];
 	NSString *name = [configuration stringForKey:@"user.name"];
-	if (name == nil) {
+	if (name.length == 0) {
 		name = NSFullUserName();
 		if (name.length == 0) name = NSUserName();
 		if (name.length == 0) name = @"nobody";


### PR DESCRIPTION
Libgit2 specifically checks to make sure the name isn't an empty string: https://github.com/libgit2/libgit2/blob/f1590a18b0c0b33ad1c194f5b6f8c66cf4c882c5/src/signature.c#L73
