### PR TITLE
Prefer the iOS paths when linking the iOS libs.

### DIFF
--- a/ObjectiveGitFramework.xcodeproj/project.pbxproj
+++ b/ObjectiveGitFramework.xcodeproj/project.pbxproj
@@ -1435,9 +1435,9 @@
 					"External/libssh2-ios/include/libssh2",
 				);
 				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
 					"External/ios-openssl/lib",
 					"External/libssh2-ios/lib",
+					"$(inherited)",
 				);
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = (
@@ -1467,9 +1467,9 @@
 					"External/libssh2-ios/include/libssh2",
 				);
 				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
 					"External/ios-openssl/lib",
 					"External/libssh2-ios/lib",
+					"$(inherited)",
 				);
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = (
@@ -1725,9 +1725,9 @@
 					"External/libssh2-ios/include/libssh2",
 				);
 				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
 					"External/ios-openssl/lib",
 					"External/libssh2-ios/lib",
+					"$(inherited)",
 				);
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = (


### PR DESCRIPTION
Fixes #369.

The basic issue was that we were trying to link the Mac libssl.a, etc., when building the iOS simulator lib.
