### PR TITLE
Enable libgit2 thread safety for iOS

### DIFF
--- a/script/update_libgit2_ios
+++ b/script/update_libgit2_ios
@@ -53,6 +53,7 @@ function build_libgit2 ()
         -DOPENSSL_CRYPTO_LIBRARY:FILEPATH=../../External/ios-openssl/lib/libcrypto.a \
         -DCMAKE_INSTALL_PREFIX:PATH="${INSTALL_PREFIX}/" \
         -DBUILD_CLAR:BOOL=OFF \
+        -DTHREADSAFE:BOOL=ON \
         "${SYS_ROOT}" \
         -DCMAKE_OSX_ARCHITECTURES:STRING="${ARCH}" \
         .. >> "${LOG}" 2>&1


### PR DESCRIPTION
No idea why this was ever disabled.

Resolves libgit2/libgit2#2384.

/cc @carlosmn @SquaredTiki
