### PR TITLE
Fixed compilation error on Xcode 6 and iOS SDK 8.0

### DIFF
--- a/Classes/GTReference.m
+++ b/Classes/GTReference.m
@@ -127,7 +127,7 @@ static NSString *referenceTypeToString(GTReferenceType type) {
 	int gitError = git_reference_rename(&newRef, self.git_reference, newName.UTF8String, 0, [self.repository userSignatureForNow].git_signature, NULL);
 	if (gitError != GIT_OK) {
 		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to rename reference %@ to %@.", self.name, newName];
-		return NO;
+		return nil;
 	}
 
 	return [[self.class alloc] initWithGitReference:newRef repository:self.repository];

--- a/Classes/GTRepository.m
+++ b/Classes/GTRepository.m
@@ -119,7 +119,7 @@ typedef struct {
 + (instancetype)initializeEmptyRepositoryAtFileURL:(NSURL *)localFileURL bare:(BOOL)bare error:(NSError **)error {
 	if (!localFileURL.isFileURL || localFileURL.path == nil) {
 		if (error != NULL) *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteUnsupportedSchemeError userInfo:@{ NSLocalizedDescriptionKey: NSLocalizedString(@"Invalid file path URL to initialize repository.", @"") }];
-		return NO;
+		return nil;
 	}
 
 	const char *path = localFileURL.path.fileSystemRepresentation;
@@ -593,7 +593,7 @@ static int GTRepositoryForeachTagCallback(const char *name, git_oid *oid, void *
 	int gitError = git_repository_index(&index, self.git_repository);
 	if (gitError != GIT_OK) {
 		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to get index for repository."];
-		return NO;
+		return nil;
 	}
 
 	return [[GTIndex alloc] initWithGitIndex:index repository:self];


### PR DESCRIPTION
Full error: "Expression which evaluates to zero treated as a null pointer constant of type". There were three instances of this, where a value of `NO` was returned where a pointer was expected. I changed those to return `nil` instead.
