### PR TITLE
if you want to ignore errors, you need to pass 0

### DIFF
--- a/Classes/GTRepository.m
+++ b/Classes/GTRepository.m
@@ -198,7 +198,7 @@ static int remoteCreate(git_remote **remote, git_repository *repo, const char *n
 		return error;
 	
 	if (pld->ignoreCertErrors)
-		git_remote_check_cert(*remote, pld->ignoreCertErrors);
+		git_remote_check_cert(*remote, !pld->ignoreCertErrors);
 	
 	return git_remote_set_callbacks(*remote, callbacks);
 }


### PR DESCRIPTION
It didn't work for me to ignore the certificates (due to the problems on iOS with github). But I guess, the semantic is flipped: git_remote_check_cert expects a flag, wether to check for a cert, not if to ignore the check.
