### PR TITLE
Updates to fetch branch

### DIFF
--- a/Classes/GTRepository+RemoteOperations.h
+++ b/Classes/GTRepository+RemoteOperations.h
@@ -8,6 +8,9 @@
 
 #import <ObjectiveGit/ObjectiveGit.h>
 
+// A `GTCredentialProvider`, that will be used to authenticate against the remote.
+extern NSString *const GTRepositoryRemoteOptionsCredentialProvider;
+
 @interface GTRepository (RemoteOperations)
 
 // Fetch a remote.


### PR DESCRIPTION
- Added constant for the credential provider dictionary key instead of hardcoded string.
- Changed implementation of `- [GTRepository fetchRemote:withOptions:error:progress:]` to use libgit2 `git_remote_fetch` instead of reimplementing it here.
