### PR TITLE
Don’t try to add `nil` strings to an array.

### DIFF
--- a/Classes/Categories/NSArray+StringArray.m
+++ b/Classes/Categories/NSArray+StringArray.m
@@ -22,7 +22,10 @@
 		const char *cStr = strarray.strings[i];
 		if (cStr == NULL) continue;
 
-		NSString *string = @(cStr);
+		NSUInteger length = strlen(cStr);
+		NSString *string =
+			[[NSString alloc] initWithBytes:cStr length:length encoding:NSUTF8StringEncoding]
+		?:	[[NSString alloc] initWithBytes:cStr length:length encoding:NSASCIIStringEncoding];
 		if (string == nil) continue;
 
 		strings[stringsCount++] = string;


### PR DESCRIPTION
This can occur if one or more of the strings in `strarray` is invalid UTF8.

We’ve got a user seeing this when we’re pulling in their branch names. The on-disk `.git/refs/*` look ok, but I wonder if there’s something funky going on with the decomposed UTF16 filenames → assumed valid null-terminated UTF8 conversion in `@(cStr)`.

To wit, I think we should probably not be assuming valid null-terminated UTF8 here, but I’m not sure what we should assume instead.

I haven’t been able to synthesize a failing case (of filename → `nil` string literal) yet.
