### PR TITLE
Expose git_remote_check_cert so that fetch can ignore cert errors

### DIFF
--- a/Classes/GTRemote.h
+++ b/Classes/GTRemote.h
@@ -42,6 +42,9 @@ typedef enum {
 /// Whether the remote is connected or not.
 @property (nonatomic, readonly, getter=isConnected) BOOL connected;
 
+/// whether the remote checks SSL certificates
+- (void)setCheckCert:(BOOL)check;
+
 /// Whether the remote updates FETCH_HEAD when fetched.
 /// Defaults to YES.
 @property (nonatomic) BOOL updatesFetchHead;

--- a/Classes/GTRemote.m
+++ b/Classes/GTRemote.m
@@ -159,6 +159,11 @@ NSString * const GTRemoteRenameProblematicRefSpecs = @"GTRemoteRenameProblematic
 	return git_remote_connected(self.git_remote) != 0;
 }
 
+- (void)setCheckCert:(BOOL)check {
+	git_remote_check_cert(self.git_remote, check);
+}
+
+
 #pragma mark Renaming
 
 - (BOOL)rename:(NSString *)name error:(NSError **)error {


### PR DESCRIPTION
Usage:

```
    GTRemote* remote = [GTRemote remoteWithName:@"origin" inRepository:repo error:&error];
    remote.checkCert = NO;
    [repo fetchRemote:remote withOptions:@{} error:&error progress:^(const git_transfer_progress *stats, BOOL *stop) {}];
```
