### PR TITLE
Fix unit tests

### DIFF
--- a/ObjectiveGitFramework.xcworkspace/contents.xcworkspacedata
+++ b/ObjectiveGitFramework.xcworkspace/contents.xcworkspacedata
@@ -5,9 +5,9 @@
       location = "group:ObjectiveGitFramework.xcodeproj">
    </FileRef>
    <FileRef
-      location = "group:Carthage.checkout/Quick/Quick.xcodeproj">
+      location = "group:Carthage.checkout/Nimble/Nimble.xcodeproj">
    </FileRef>
    <FileRef
-      location = "group:Carthage.checkout/Nimble/Nimble.xcodeproj">
+      location = "group:Carthage.checkout/Quick/Quick.xcodeproj">
    </FileRef>
 </Workspace>


### PR DESCRIPTION
This should replace #425.

Xcode was choosing the Nimble from Quick, which is older and only has `beFalsy` and not `beFalse`. This reorders the projects in the workspace so that Xcode will choose the correct framework.
