### PR TITLE
Pacify Xcode

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
-github "jspahrsummers/xcconfigs" >= 0.7
+github "jspahrsummers/xcconfigs" >= 0.7.1
 github "Quick/Quick" ~> 0.2
 github "Quick/Nimble" ~> 0.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "Quick/Nimble" "v0.2.0"
 github "Quick/Quick" "v0.2.2"
-github "jspahrsummers/xcconfigs" "0.7"
+github "jspahrsummers/xcconfigs" "0.7.1"

--- a/ObjectiveGitFramework.xcodeproj/project.pbxproj
+++ b/ObjectiveGitFramework.xcodeproj/project.pbxproj
@@ -1127,7 +1127,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastTestingUpgradeCheck = 0510;
-				LastUpgradeCheck = 0510;
+				LastUpgradeCheck = 0620;
 				ORGANIZATIONNAME = "GitHub, Inc";
 				TargetAttributes = {
 					D01B6ED219F82E2000D411BC = {
@@ -1502,6 +1502,7 @@
 					External,
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
 					"$(inherited)",
 					"-DGIT_SSH",

--- a/ObjectiveGitFramework.xcodeproj/xcshareddata/xcschemes/ObjectiveGit Mac.xcscheme
+++ b/ObjectiveGitFramework.xcodeproj/xcshareddata/xcschemes/ObjectiveGit Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0620"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ObjectiveGitFramework.xcodeproj/xcshareddata/xcschemes/ObjectiveGit iOS.xcscheme
+++ b/ObjectiveGitFramework.xcodeproj/xcshareddata/xcschemes/ObjectiveGit iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0620"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
For https://github.com/jspahrsummers/xcconfigs/pull/32.

And I know what you’re thinking, “But `ONLY_ACTIVE_ARCH` is already in the xcconfig!” Yes. Well. Xcode.