### PR TITLE
Added git_patch_to_buf method

### DIFF
--- a/ObjectiveGit/GTDiffPatch.h
+++ b/ObjectiveGit/GTDiffPatch.h
@@ -50,6 +50,9 @@
 /// Returns the raw size of the delta, in bytes.
 - (NSUInteger)sizeWithContext:(BOOL)includeContext hunkHeaders:(BOOL)includeHunkHeaders fileHeaders:(BOOL)includeFileHeaders;
 
+/// Returns the raw patch data as buffer.
+- (NSData*)toBuffer;
+
 /// Enumerate the hunks contained in the patch.
 ///
 /// This enumeration is synchronous, and will block the calling thread while

--- a/ObjectiveGit/GTDiffPatch.m
+++ b/ObjectiveGit/GTDiffPatch.m
@@ -59,6 +59,16 @@
 	return git_patch_size(self.git_patch, includeContext, includeHunkHeaders, includeFileHeaders);
 }
 
+- (NSData*)toBuffer {
+	git_buf buf = GIT_BUF_INIT_CONST(0, NULL);
+	git_patch_to_buf(&buf, self.git_patch);
+
+	NSData* buffer = [[NSData alloc] initWithBytes:buf.ptr length:buf.size];
+	git_buf_free(&buf);
+	
+	return buffer;
+}
+
 #pragma mark Hunks
 
 - (BOOL)enumerateHunksUsingBlock:(void (^)(GTDiffHunk *hunk, BOOL *stop))block {

--- a/ObjectiveGit/GTTree.h
+++ b/ObjectiveGit/GTTree.h
@@ -64,6 +64,8 @@ typedef NS_ENUM(NSInteger, GTTreeEnumerationOptions) {
 /// returns a GTTreeEntry or nil if there is nothing with the specified name
 - (GTTreeEntry *)entryWithName:(NSString *)name;
 
+- (GTTreeEntry*) treeEntryByPath:(NSString*) path error:(NSError**)error;
+
 /// Enumerates the contents of the tree
 ///
 /// options -  One of `GTTreeEnumerationOptionPre` (for pre-order walks) or

--- a/ObjectiveGit/GTTree.m
+++ b/ObjectiveGit/GTTree.m
@@ -68,6 +68,17 @@ typedef struct GTTreeEnumerationStruct {
 	return [self createEntryWithEntry:git_tree_entry_byname(self.git_tree, name.UTF8String)];
 }
 
+- (GTTreeEntry*) treeEntryByPath:(NSString*)path error:(NSError**)error {
+	git_tree_entry *entry = NULL;
+	int gitError = git_tree_entry_bypath(&entry, self.git_tree, path.UTF8String);
+	if (error != GIT_OK) {
+		*error = [NSError git_errorFor:gitError description:@"Failed to get tree ntry %@", path];
+		return nil;
+	}
+	
+	return [GTTreeEntry entryWithEntryToFree:entry parentTree:self];
+}
+
 - (git_tree *)git_tree {
 	return (git_tree *)self.git_object;
 }

--- a/ObjectiveGit/GTTreeEntry.h
+++ b/ObjectiveGit/GTTreeEntry.h
@@ -35,7 +35,9 @@
 
 /// Initializer and convience methods.
 - (instancetype)initWithEntry:(const git_tree_entry *)theEntry parentTree:(GTTree *)parent;
+- (instancetype)initWithEntryToFree:(git_tree_entry *)theEntry parentTree:(GTTree *)parent;
 + (instancetype)entryWithEntry:(const git_tree_entry *)theEntry parentTree:(GTTree *)parent;
++ (instancetype)entryWithEntryToFree:(git_tree_entry *)theEntry parentTree:(GTTree *)parent;
 
 /// The underlying `git_tree_entry`.
 - (const git_tree_entry *)git_tree_entry __attribute__((objc_returns_inner_pointer));

--- a/ObjectiveGit/GTTreeEntry.m
+++ b/ObjectiveGit/GTTreeEntry.m
@@ -39,6 +39,7 @@
 
 @interface GTTreeEntry ()
 @property (nonatomic, assign, readonly) const git_tree_entry *git_tree_entry;
+@property (nonatomic, assign, readonly) git_tree_entry* entry_to_free;
 @end
 
 @implementation GTTreeEntry
@@ -64,6 +65,12 @@
 	return git_tree_entry_cmp(self.git_tree_entry, treeEntry.git_tree_entry) == 0 ? YES : NO;
 }
 
+- (void)dealloc {
+	if (_entry_to_free != nil) {
+		git_tree_entry_free(_entry_to_free);
+	}
+}
+
 #pragma mark API
 
 - (instancetype)initWithEntry:(const git_tree_entry *)theEntry parentTree:(GTTree *)parent {
@@ -71,12 +78,27 @@
 	if((self = [super init])) {
 		_git_tree_entry = theEntry;
 		_tree = parent;
+		_entry_to_free = nil;
+	}
+	return self;
+}
+
+- (instancetype)initWithEntryToFree:(git_tree_entry *)theEntry parentTree:(GTTree *)parent {
+	NSParameterAssert(theEntry != NULL);
+	if((self = [super init])) {
+		_git_tree_entry = theEntry;
+		_tree = parent;
+		_entry_to_free = theEntry;
 	}
 	return self;
 }
 
 + (instancetype)entryWithEntry:(const git_tree_entry *)theEntry parentTree:(GTTree *)parent {
 	return [[self alloc] initWithEntry:theEntry parentTree:parent];
+}
+
++ (instancetype)entryWithEntryToFree:(git_tree_entry *)theEntry parentTree:(GTTree *)parent {
+	return [[self alloc] initWithEntryToFree:theEntry parentTree:parent];
 }
 
 - (NSString *)name {

--- a/ObjectiveGitFramework.xcodeproj/project.pbxproj
+++ b/ObjectiveGitFramework.xcodeproj/project.pbxproj
@@ -311,6 +311,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		3D6123BD1A6432F6008F831A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D0A330ED16027F1E00A616FA;
+			remoteInfo = libgit2;
+		};
 		6A28265A17C69D6300C6A948 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
@@ -345,13 +352,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = D0A330F216027F3600A616FA;
 			remoteInfo = "libgit2-iOS";
-		};
-		D0A330F716027F4900A616FA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D0A330ED16027F1E00A616FA;
-			remoteInfo = libgit2;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -412,6 +412,7 @@
 		30DCBA7017B4791A009B0EBD /* NSArray+StringArray.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+StringArray.m"; sourceTree = "<group>"; };
 		30FDC07D16835A8100654BF0 /* GTDiffLine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GTDiffLine.h; sourceTree = "<group>"; };
 		30FDC07E16835A8100654BF0 /* GTDiffLine.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GTDiffLine.m; sourceTree = "<group>"; };
+		3D6123BB1A643296008F831A /* libgit2.0.21.2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libgit2.0.21.2.dylib; path = ../../../../../usr/local/Cellar/libgit2/0.21.2/lib/libgit2.0.21.2.dylib; sourceTree = "<group>"; };
 		4D103ADC1819CFAA0029DB24 /* libiconv.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libiconv.dylib; path = usr/lib/libiconv.dylib; sourceTree = SDKROOT; };
 		4D12323F178E009E0048F785 /* GTRepositoryCommittingSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GTRepositoryCommittingSpec.m; sourceTree = "<group>"; };
 		4D1C40D7182C006D00BE2960 /* GTBlobSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GTBlobSpec.m; sourceTree = "<group>"; };
@@ -620,6 +621,7 @@
 		0867D691FE84028FC02AAC07 /* ObjectiveGitFramework */ = {
 			isa = PBXGroup;
 			children = (
+				3D6123BB1A643296008F831A /* libgit2.0.21.2.dylib */,
 				BDD8AB01130F01AB00CB5D40 /* README.md */,
 				887B948D1A3A38130070D41D /* ObjectiveGit.modulemap */,
 				BDE4C05E130EFE2C00851650 /* ObjectiveGit */,
@@ -1094,7 +1096,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				D0A330F816027F4900A616FA /* PBXTargetDependency */,
+				3D6123BE1A6432F6008F831A /* PBXTargetDependency */,
 			);
 			name = "ObjectiveGit-Mac";
 			productInstallPath = "$(HOME)/Library/Frameworks";
@@ -1396,6 +1398,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		3D6123BE1A6432F6008F831A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D0A330ED16027F1E00A616FA /* libgit2 */;
+			targetProxy = 3D6123BD1A6432F6008F831A /* PBXContainerItemProxy */;
+		};
 		6A28265B17C69D6300C6A948 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 6A28265217C69CB400C6A948 /* OpenSSL-iOS */;
@@ -1421,11 +1428,6 @@
 			target = D0A330F216027F3600A616FA /* libgit2-iOS */;
 			targetProxy = D019779619F8335100F523DA /* PBXContainerItemProxy */;
 		};
-		D0A330F816027F4900A616FA /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = D0A330ED16027F1E00A616FA /* libgit2 */;
-			targetProxy = D0A330F716027F4900A616FA /* PBXContainerItemProxy */;
-		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
@@ -1449,6 +1451,10 @@
 				DYLIB_CURRENT_VERSION = 1;
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Info.plist;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					/usr/local/Cellar/libgit2/0.21.2/lib,
+				);
 				MODULEMAP_FILE = ObjectiveGit.modulemap;
 				OTHER_LDFLAGS = (
 					"-lgit2",
@@ -1472,6 +1478,10 @@
 				DYLIB_CURRENT_VERSION = 1;
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Info.plist;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					/usr/local/Cellar/libgit2/0.21.2/lib,
+				);
 				MODULEMAP_FILE = ObjectiveGit.modulemap;
 				OTHER_LDFLAGS = (
 					"-lgit2",
@@ -1656,6 +1666,10 @@
 				DYLIB_CURRENT_VERSION = 1;
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Info.plist;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					/usr/local/Cellar/libgit2/0.21.2/lib,
+				);
 				MODULEMAP_FILE = ObjectiveGit.modulemap;
 				OTHER_LDFLAGS = (
 					"-lgit2",
@@ -1873,6 +1887,10 @@
 				DYLIB_CURRENT_VERSION = 1;
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Info.plist;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					/usr/local/Cellar/libgit2/0.21.2/lib,
+				);
 				MODULEMAP_FILE = ObjectiveGit.modulemap;
 				OTHER_LDFLAGS = (
 					"-lgit2",


### PR DESCRIPTION
Added a method to GTDiffPatch to call git_patch_to_buf to copy the entire patch data to an NSData object.