### PR TITLE
Add modulemap file to iOS target

### DIFF
--- a/ObjectiveGitFramework.xcodeproj/project.pbxproj
+++ b/ObjectiveGitFramework.xcodeproj/project.pbxproj
@@ -1700,6 +1700,7 @@
 					"External/libssh2-ios/lib",
 					"External/libgit2-ios",
 				);
+				MODULEMAP_FILE = ObjectiveGit.modulemap;
 				OTHER_LDFLAGS = (
 					"-lgit2-ios",
 					"-all_load",
@@ -1762,6 +1763,7 @@
 					"External/libssh2-ios/lib",
 					"External/libgit2-ios",
 				);
+				MODULEMAP_FILE = ObjectiveGit.modulemap;
 				OTHER_LDFLAGS = (
 					"-lgit2-ios",
 					"-all_load",
@@ -1792,6 +1794,7 @@
 					"External/libssh2-ios/lib",
 					"External/libgit2-ios",
 				);
+				MODULEMAP_FILE = ObjectiveGit.modulemap;
 				OTHER_LDFLAGS = (
 					"-lgit2-ios",
 					"-all_load",
@@ -1822,6 +1825,7 @@
 					"External/libssh2-ios/lib",
 					"External/libgit2-ios",
 				);
+				MODULEMAP_FILE = ObjectiveGit.modulemap;
 				OTHER_LDFLAGS = (
 					"-lgit2-ios",
 					"-all_load",


### PR DESCRIPTION
As discussed in #436 adding a module map file in iOS is required as it is in OS X.