### PR TITLE
Fix libgit2 build scripts

### DIFF
--- a/script/update_libgit2
+++ b/script/update_libgit2
@@ -22,7 +22,11 @@ fi
 mkdir build
 cd build
 
-cmake -DBUILD_SHARED_LIBS:BOOL=OFF -DBUILD_CLAR:BOOL=OFF -DTHREADSAFE:BOOL=ON ..
+cmake -DBUILD_SHARED_LIBS:BOOL=OFF \
+	-DLIBSSH2_INCLUDE_DIR:PATH=../../External/libssh2-ios/include/libssh2/ \
+	-DBUILD_CLAR:BOOL=OFF \
+	-DTHREADSAFE:BOOL=ON \
+	..
 cmake --build .
 
 product="libgit2.a"

--- a/script/update_libgit2
+++ b/script/update_libgit2
@@ -22,11 +22,7 @@ fi
 mkdir build
 cd build
 
-cmake -DBUILD_SHARED_LIBS:BOOL=OFF \
-	-DLIBSSH2_INCLUDE_DIR:PATH=../../External/libssh2-ios/include/libssh2/ \
-	-DBUILD_CLAR:BOOL=OFF \
-	-DTHREADSAFE:BOOL=ON \
-	..
+cmake -DBUILD_SHARED_LIBS:BOOL=OFF -DBUILD_CLAR:BOOL=OFF -DTHREADSAFE:BOOL=ON ..
 cmake --build .
 
 product="libgit2.a"

--- a/script/update_libgit2
+++ b/script/update_libgit2
@@ -22,7 +22,11 @@ fi
 mkdir build
 cd build
 
-cmake -DBUILD_SHARED_LIBS:BOOL=OFF -DBUILD_CLAR:BOOL=OFF -DTHREADSAFE:BOOL=ON ..
+cmake -DBUILD_SHARED_LIBS:BOOL=OFF \
+	-DLIBSSH2_INCLUDE_DIR:PATH=/usr/local/include/ \
+	-DBUILD_CLAR:BOOL=OFF \
+	-DTHREADSAFE:BOOL=ON \
+	..
 cmake --build .
 
 product="libgit2.a"

--- a/script/update_libgit2_ios
+++ b/script/update_libgit2_ios
@@ -47,7 +47,7 @@ function build_libgit2 ()
         -DBUILD_SHARED_LIBS:BOOL=OFF \
         -DOPENSSL_INCLUDE_DIR:PATH=../../External/ios-openssl/include/ \
         -DCMAKE_LIBRARY_PATH:PATH=../../External/libssh2-ios/lib/ \
-        -DCMAKE_INCLUDE_PATH:PATH=../../External/libssh2-ios/include/libssh2/ \
+        -DLIBSSH2_INCLUDE_DIR:PATH=../../External/libssh2-ios/include/libssh2/ \
         -DOPENSSL_SSL_LIBRARY:FILEPATH=../../External/ios-openssl/lib/libssl.a \
         -DCMAKE_LIBRARY_PATH:PATH="${SDKROOT}/usr/lib/" \
         -DOPENSSL_CRYPTO_LIBRARY:FILEPATH=../../External/ios-openssl/lib/libcrypto.a \


### PR DESCRIPTION
I had some trouble getting libgit2 to build in 0.5 and 0.6, getting errors about `'libssh2.h' file not found`. I wasn't sure if it was my setup (been on Xcode and Yosemite betas a lot lately), but by modifying the update_libgit2 scripts and defining `LIBSSH2_INCLUDE_DIR` it builds consistently.

Addresses #442