### PR TITLE
Bump libgit2.

### DIFF
--- a/ObjectiveGit/GTConfiguration.m
+++ b/ObjectiveGit/GTConfiguration.m
@@ -15,6 +15,7 @@
 
 #import "git2/config.h"
 #import "git2/errors.h"
+#import "git2/buffer.h"
 
 @interface GTConfiguration ()
 @property (nonatomic, readonly, assign) git_config *git_config;
@@ -58,11 +59,13 @@
 }
 
 - (NSString *)stringForKey:(NSString *)key {
-	const char *string = NULL;
-	git_config_get_string(&string, self.git_config, key.UTF8String);
-	if (string == NULL) return nil;
+	git_buf buffer = {};
+	if (git_config_get_string_buf(&buffer, self.git_config, key.UTF8String) != 0) return nil;
 
-	return [NSString stringWithUTF8String:string];
+	NSString *string = [[NSString alloc] initWithBytes:buffer.ptr length:buffer.size encoding:NSUTF8StringEncoding];
+	git_buf_free(&buffer);
+
+	return string;
 }
 
 - (void)setBool:(BOOL)b forKey:(NSString *)key {

--- a/ObjectiveGit/GTConfiguration.m
+++ b/ObjectiveGit/GTConfiguration.m
@@ -10,8 +10,9 @@
 #import "GTConfiguration+Private.h"
 #import "GTRepository.h"
 #import "GTRemote.h"
-#import "NSError+Git.h"
 #import "GTSignature.h"
+#import "NSData+Git.h"
+#import "NSError+Git.h"
 
 #import "git2/config.h"
 #import "git2/errors.h"
@@ -62,10 +63,7 @@
 	git_buf buffer = {};
 	if (git_config_get_string_buf(&buffer, self.git_config, key.UTF8String) != 0) return nil;
 
-	NSString *string = [[NSString alloc] initWithBytes:buffer.ptr length:buffer.size encoding:NSUTF8StringEncoding];
-	git_buf_free(&buffer);
-
-	return string;
+	return [[NSString alloc] initWithData:[NSData git_dataWithBuffer:&buffer] encoding:NSUTF8StringEncoding];
 }
 
 - (void)setBool:(BOOL)b forKey:(NSString *)key {

--- a/ObjectiveGit/GTFilterList.h
+++ b/ObjectiveGit/GTFilterList.h
@@ -14,8 +14,8 @@
 
 /// The options for loading a filter list. See libgit2 for more information.
 typedef NS_OPTIONS(NSInteger, GTFilterListOptions) {
-	GTFilterListOptionsDefault = GIT_FILTER_OPT_DEFAULT,
-	GTFilterListOptionsAllowUnsafe = GIT_FILTER_OPT_ALLOW_UNSAFE,
+	GTFilterListOptionsDefault = GIT_FILTER_DEFAULT,
+	GTFilterListOptionsAllowUnsafe = GIT_FILTER_ALLOW_UNSAFE,
 };
 
 /// An opaque list of filters that apply to a given path.

--- a/ObjectiveGit/GTFilterList.m
+++ b/ObjectiveGit/GTFilterList.m
@@ -65,7 +65,11 @@
 	NSParameterAssert(repository != nil);
 
 	git_buf output = GIT_BUF_INIT_CONST(0, NULL);
-	int gitError = git_filter_list_apply_to_file(&output, self.git_filter_list, repository.git_repository, relativePath.UTF8String);
+	// fixme: This is a workaround for an issue where `git_filter_list_apply_to_file`
+	// will not resolve relative paths against the worktree. It should be reverted when
+	// libgit2 has been updated to resolve that.
+	NSString *absolutePath = relativePath.absolutePath ? relativePath : [repository.fileURL URLByAppendingPathComponent:relativePath].path;
+	int gitError = git_filter_list_apply_to_file(&output, self.git_filter_list, repository.git_repository, absolutePath.UTF8String);
 
 	if (gitError != GIT_OK) {
 		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to apply filter list to %@", relativePath];

--- a/ObjectiveGit/GTReference.h
+++ b/ObjectiveGit/GTReference.h
@@ -28,7 +28,6 @@
 
 @class GTOID;
 @class GTReflog;
-@class GTSignature;
 
 typedef NS_ENUM(NSInteger, GTReferenceErrorCode) {
 	GTReferenceErrorCodeInvalidReference = -4,
@@ -89,14 +88,12 @@ typedef NS_OPTIONS(NSInteger, GTReferenceType) {
 /// Note that this does *not* change the receiver's target.
 ///
 /// newTarget - The target for the new reference. This must not be nil.
-/// signature - A signature for the committer updating this ref, used for
-///             creating a reflog entry. This may be nil.
 /// message   - A message to use when creating the reflog entry for this action.
 ///             This may be nil.
 /// error     - The error if one occurred.
 ///
 /// Returns the updated reference, or nil if an error occurred.
-- (GTReference *)referenceByUpdatingTarget:(NSString *)newTarget committer:(GTSignature *)signature message:(NSString *)message error:(NSError **)error;
+- (GTReference *)referenceByUpdatingTarget:(NSString *)newTarget message:(NSString *)message error:(NSError **)error;
 
 /// The name of the reference.
 @property (nonatomic, readonly, copy) NSString *name;

--- a/ObjectiveGit/GTReference.m
+++ b/ObjectiveGit/GTReference.m
@@ -128,7 +128,7 @@ static NSString *referenceTypeToString(GTReferenceType type) {
 	NSParameterAssert(newName != nil);
 
 	git_reference *newRef = NULL;
-	int gitError = git_reference_rename(&newRef, self.git_reference, newName.UTF8String, 0, [self.repository userSignatureForNow].git_signature, NULL);
+	int gitError = git_reference_rename(&newRef, self.git_reference, newName.UTF8String, 0, NULL);
 	if (gitError != GIT_OK) {
 		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to rename reference %@ to %@.", self.name, newName];
 		return nil;
@@ -173,7 +173,7 @@ static NSString *referenceTypeToString(GTReferenceType type) {
 	return [self.resolvedTarget SHA];
 }
 
-- (GTReference *)referenceByUpdatingTarget:(NSString *)newTarget committer:(GTSignature *)signature message:(NSString *)message error:(NSError **)error {
+- (GTReference *)referenceByUpdatingTarget:(NSString *)newTarget message:(NSString *)message error:(NSError **)error {
 	NSParameterAssert(newTarget != nil);
 
 	int gitError;
@@ -182,9 +182,9 @@ static NSString *referenceTypeToString(GTReferenceType type) {
 		GTOID *oid = [[GTOID alloc] initWithSHA:newTarget error:error];
 		if (oid == nil) return nil;
 
-		gitError = git_reference_set_target(&newRef, self.git_reference, oid.git_oid, signature.git_signature, message.UTF8String);
+		gitError = git_reference_set_target(&newRef, self.git_reference, oid.git_oid, message.UTF8String);
 	} else {
-		gitError = git_reference_symbolic_set_target(&newRef, self.git_reference, newTarget.UTF8String, signature.git_signature, message.UTF8String);
+		gitError = git_reference_symbolic_set_target(&newRef, self.git_reference, newTarget.UTF8String, message.UTF8String);
 	}
 
 	if (gitError != GIT_OK) {

--- a/ObjectiveGit/GTRepository+RemoteOperations.m
+++ b/ObjectiveGit/GTRepository+RemoteOperations.m
@@ -95,7 +95,7 @@ int GTRemotePushTransferProgressCallback(unsigned int current, unsigned int tota
 		git_strarray_free(&refspecs);
 	};
 
-	gitError = git_remote_fetch(remote.git_remote, &refspecs, self.userSignatureForNow.git_signature, NULL);
+	gitError = git_remote_fetch(remote.git_remote, &refspecs, NULL);
 	if (gitError != GIT_OK) {
 		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to fetch from remote"];
 		return NO;
@@ -246,7 +246,7 @@ int GTFetchHeadEntriesCallback(const char *ref_name, const char *remote_url, con
 		return NO;
 	}
 
-	gitError = git_remote_update_tips(remote.git_remote, self.userSignatureForNow.git_signature, NULL);
+	gitError = git_remote_update_tips(remote.git_remote, NULL);
 	if (gitError != GIT_OK) {
 		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Update tips failed"];
 		return NO;

--- a/ObjectiveGit/GTRepository+Reset.m
+++ b/ObjectiveGit/GTRepository+Reset.m
@@ -20,7 +20,7 @@
 	NSParameterAssert(commit != nil);
 
 	git_checkout_options options = GIT_CHECKOUT_OPTIONS_INIT;
-	int gitError = git_reset(self.git_repository, commit.git_object, (git_reset_t)resetType, &options, (git_signature *)[self userSignatureForNow].git_signature, NULL);
+	int gitError = git_reset(self.git_repository, commit.git_object, (git_reset_t)resetType, &options);
 	if (gitError != GIT_OK) {
 		if (error != NULL) {
 			*error = [NSError git_errorFor:gitError description:@"Failed to reset repository to commit %@.", commit.SHA];

--- a/ObjectiveGit/GTRepository.h
+++ b/ObjectiveGit/GTRepository.h
@@ -57,7 +57,6 @@
 typedef NS_OPTIONS(NSInteger, GTCheckoutStrategyType) {
 	GTCheckoutStrategyNone = GIT_CHECKOUT_NONE,
 	GTCheckoutStrategySafe = GIT_CHECKOUT_SAFE,
-	GTCheckoutStrategySafeCreate = GIT_CHECKOUT_SAFE_CREATE,
 	GTCheckoutStrategyForce = GIT_CHECKOUT_FORCE,
 	GTCheckoutStrategyAllowConflicts = GIT_CHECKOUT_ALLOW_CONFLICTS,
 	GTCheckoutStrategyRemoveUntracked = GIT_CHECKOUT_REMOVE_UNTRACKED,

--- a/ObjectiveGit/GTRepository.h
+++ b/ObjectiveGit/GTRepository.h
@@ -279,41 +279,35 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 ///
 /// name      - The full name for the new reference. This must not be nil.
 /// targetOID - The OID that the new ref should point to. This must not be nil.
-/// signature - A signature for the committer creating this ref, used for
-///             creating a reflog entry. This may be nil.
 /// message   - A message to use when creating the reflog entry for this action.
 ///             This may be nil.
 /// error     - If not NULL, set to any error that occurs.
 ///
 /// Returns the created ref, or nil if an error occurred.
-- (GTReference *)createReferenceNamed:(NSString *)name fromOID:(GTOID *)targetOID committer:(GTSignature *)signature message:(NSString *)message error:(NSError **)error;
+- (GTReference *)createReferenceNamed:(NSString *)name fromOID:(GTOID *)targetOID message:(NSString *)message error:(NSError **)error;
 
 /// Creates a symbolic reference to another ref.
 ///
 /// name      - The full name for the new reference. This must not be nil.
 /// targetRef - The ref that the new ref should point to. This must not be nil.
-/// signature - A signature for the committer creating this ref, used for
-///             creating a reflog entry. This may be nil.
 /// message   - A message to use when creating the reflog entry for this action.
 ///             This may be nil.
 /// error     - If not NULL, set to any error that occurs.
 ///
 /// Returns the created ref, or nil if an error occurred.
-- (GTReference *)createReferenceNamed:(NSString *)name fromReference:(GTReference *)targetRef committer:(GTSignature *)signature message:(NSString *)message error:(NSError **)error;
+- (GTReference *)createReferenceNamed:(NSString *)name fromReference:(GTReference *)targetRef message:(NSString *)message error:(NSError **)error;
 
 /// Create a new local branch pointing to the given OID.
 ///
 /// name      - The name for the new branch (e.g., `master`). This must not be
 ///             nil.
 /// targetOID - The OID to create the new branch off. This must not be nil.
-/// signature - A signature for the committer creating this branch, used for
-///             creating a reflog entry. This may be nil.
 /// message   - A message to use when creating the reflog entry for this action.
 ///             This may be nil.
 /// error     - If not NULL, set to any error that occurs.
 ///
 /// Returns the new branch, or nil if an error occurred.
-- (GTBranch *)createBranchNamed:(NSString *)name fromOID:(GTOID *)targetOID committer:(GTSignature *)signature message:(NSString *)message error:(NSError **)error;
+- (GTBranch *)createBranchNamed:(NSString *)name fromOID:(GTOID *)targetOID message:(NSString *)message error:(NSError **)error;
 
 /// Get the current branch.
 ///

--- a/ObjectiveGit/GTRepository.m
+++ b/ObjectiveGit/GTRepository.m
@@ -493,12 +493,12 @@ static int GTRepositoryForeachTagCallback(const char *name, git_oid *oid, void *
 	return [currentBranch numberOfCommitsWithError:error];
 }
 
-- (GTReference *)createReferenceNamed:(NSString *)name fromOID:(GTOID *)targetOID committer:(GTSignature *)signature message:(NSString *)message error:(NSError **)error {
+- (GTReference *)createReferenceNamed:(NSString *)name fromOID:(GTOID *)targetOID message:(NSString *)message error:(NSError **)error {
 	NSParameterAssert(name != nil);
 	NSParameterAssert(targetOID != nil);
 
 	git_reference *ref;
-	int gitError = git_reference_create(&ref, self.git_repository, name.UTF8String, targetOID.git_oid, 0, signature.git_signature, message.UTF8String);
+	int gitError = git_reference_create(&ref, self.git_repository, name.UTF8String, targetOID.git_oid, 0, message.UTF8String);
 	if (gitError != GIT_OK) {
 		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to create direct reference to %@", targetOID];
 		return nil;
@@ -507,13 +507,13 @@ static int GTRepositoryForeachTagCallback(const char *name, git_oid *oid, void *
 	return [[GTReference alloc] initWithGitReference:ref repository:self];
 }
 
-- (GTReference *)createReferenceNamed:(NSString *)name fromReference:(GTReference *)targetRef committer:(GTSignature *)signature message:(NSString *)message error:(NSError **)error {
+- (GTReference *)createReferenceNamed:(NSString *)name fromReference:(GTReference *)targetRef message:(NSString *)message error:(NSError **)error {
 	NSParameterAssert(name != nil);
 	NSParameterAssert(targetRef != nil);
 	NSParameterAssert(targetRef.name != nil);
 
 	git_reference *ref;
-	int gitError = git_reference_symbolic_create(&ref, self.git_repository, name.UTF8String, targetRef.name.UTF8String, 0, signature.git_signature, message.UTF8String);
+	int gitError = git_reference_symbolic_create(&ref, self.git_repository, name.UTF8String, targetRef.name.UTF8String, 0, message.UTF8String);
 	if (gitError != GIT_OK) {
 		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to create symbolic reference to %@", targetRef];
 		return nil;
@@ -522,11 +522,11 @@ static int GTRepositoryForeachTagCallback(const char *name, git_oid *oid, void *
 	return [[GTReference alloc] initWithGitReference:ref repository:self];
 }
 
-- (GTBranch *)createBranchNamed:(NSString *)name fromOID:(GTOID *)targetOID committer:(GTSignature *)signature message:(NSString *)message error:(NSError **)error {
+- (GTBranch *)createBranchNamed:(NSString *)name fromOID:(GTOID *)targetOID message:(NSString *)message error:(NSError **)error {
 	NSParameterAssert(name != nil);
 	NSParameterAssert(targetOID != nil);
 
-	GTReference *newRef = [self createReferenceNamed:[GTBranch.localNamePrefix stringByAppendingString:name] fromOID:targetOID committer:signature message:message error:error];
+	GTReference *newRef = [self createReferenceNamed:[GTBranch.localNamePrefix stringByAppendingString:name] fromOID:targetOID message:message error:error];
 	if (newRef == nil) return nil;
 
 	return [GTBranch branchWithReference:newRef repository:self];
@@ -800,7 +800,7 @@ static int checkoutNotifyCallback(git_checkout_notify_t why, const char *path, c
 - (BOOL)moveHEADToReference:(GTReference *)reference error:(NSError **)error {
 	NSParameterAssert(reference != nil);
 
-	int gitError = git_repository_set_head(self.git_repository, reference.name.UTF8String, [self userSignatureForNow].git_signature, NULL);
+	int gitError = git_repository_set_head(self.git_repository, reference.name.UTF8String);
 	if (gitError != GIT_OK) {
 		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to move HEAD to reference %@", reference.name];
 	}
@@ -811,7 +811,7 @@ static int checkoutNotifyCallback(git_checkout_notify_t why, const char *path, c
 - (BOOL)moveHEADToCommit:(GTCommit *)commit error:(NSError **)error {
 	NSParameterAssert(commit != nil);
 
-	int gitError = git_repository_set_head_detached(self.git_repository, commit.OID.git_oid, [self userSignatureForNow].git_signature, NULL);
+	int gitError = git_repository_set_head_detached(self.git_repository, commit.OID.git_oid);
 	if (gitError != GIT_OK) {
 		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to move HEAD to commit %@", commit.SHA];
 	}

--- a/ObjectiveGit/GTRepository.m
+++ b/ObjectiveGit/GTRepository.m
@@ -236,7 +236,7 @@ struct GTRemoteCreatePayload {
 
 	if (withCheckout) {
 		git_checkout_options checkoutOptions = GIT_CHECKOUT_OPTIONS_INIT;
-		checkoutOptions.checkout_strategy = GIT_CHECKOUT_SAFE_CREATE;
+		checkoutOptions.checkout_strategy = GIT_CHECKOUT_SAFE;
 		checkoutOptions.progress_cb = checkoutProgressCallback;
 		checkoutOptions.progress_payload = (__bridge void *)checkoutProgressBlock;
 		cloneOptions.checkout_opts = checkoutOptions;

--- a/ObjectiveGitTests/GTBranchSpec.m
+++ b/ObjectiveGitTests/GTBranchSpec.m
@@ -122,7 +122,7 @@ describe(@"-reloadedBranchWithError:", ^{
 		static NSString * const originalSHA = @"a4bca6b67a5483169963572ee3da563da33712f7";
 		static NSString * const updatedSHA = @"6b0c1c8b8816416089c534e474f4c692a76ac14f";
 		expect([masterBranch targetCommitAndReturnError:NULL].SHA).to(equal(originalSHA));
-		[masterBranch.reference referenceByUpdatingTarget:updatedSHA committer:nil message:nil error:NULL];
+		[masterBranch.reference referenceByUpdatingTarget:updatedSHA message:nil error:NULL];
 
 		GTBranch *reloadedBranch = [masterBranch reloadedBranchWithError:NULL];
 		expect(reloadedBranch).notTo(beNil());
@@ -158,7 +158,7 @@ describe(@"-trackingBranchWithError:success:", ^{
 		GTOID *OID = [[GTOID alloc] initWithSHA:@"6b0c1c8b8816416089c534e474f4c692a76ac14f"];
 
 		NSError *error = nil;
-		GTReference *otherRef = [repository createReferenceNamed:@"refs/heads/yet-another-branch" fromOID:OID committer:nil message:nil error:&error];
+		GTReference *otherRef = [repository createReferenceNamed:@"refs/heads/yet-another-branch" fromOID:OID message:nil error:&error];
 		expect(otherRef).notTo(beNil());
 		expect(error).to(beNil());
 

--- a/ObjectiveGitTests/GTReferenceSpec.m
+++ b/ObjectiveGitTests/GTReferenceSpec.m
@@ -62,7 +62,7 @@ describe(@"transformations", ^{
 		expect(repository).notTo(beNil());
 
 		NSError *error;
-		reference = [repository createReferenceNamed:testRefName fromOID:testRefOID committer:nil message:nil error:&error];
+		reference = [repository createReferenceNamed:testRefName fromOID:testRefOID message:nil error:&error];
 		expect(reference).notTo(beNil());
 		expect(reference.name).to(equal(testRefName));
 		expect(reference.targetSHA).to(equal(testRefOID.SHA));
@@ -80,7 +80,7 @@ describe(@"transformations", ^{
 	it(@"should be able to change the target", ^{
 		NSString *newRefTarget = @"5b5b025afb0b4c913b4c338a42934a3863bf3644";
 
-		GTReference *updatedRef = [reference referenceByUpdatingTarget:newRefTarget committer:nil message:nil error:NULL];
+		GTReference *updatedRef = [reference referenceByUpdatingTarget:newRefTarget message:nil error:NULL];
 		expect(updatedRef).notTo(beNil());
 		expect(updatedRef.name).to(equal(testRefName));
 		expect(updatedRef.targetSHA).to(equal(newRefTarget));
@@ -154,7 +154,7 @@ describe(@"creating", ^{
 		expect(target).notTo(beNil());
 
 		NSError *error = nil;
-		GTReference *ref = [bareRepository createReferenceNamed:@"refs/heads/unit_test" fromReference:target committer:nil message:nil error:&error];
+		GTReference *ref = [bareRepository createReferenceNamed:@"refs/heads/unit_test" fromReference:target message:nil error:&error];
 		expect(error).to(beNil());
 		expect(ref).notTo(beNil());
 
@@ -166,7 +166,7 @@ describe(@"creating", ^{
 		GTOID *target = [[GTOID alloc] initWithSHA:@"36060c58702ed4c2a40832c51758d5344201d89a"];
 
 		NSError *error = nil;
-		GTReference *ref = [bareRepository createReferenceNamed:@"refs/heads/unit_test" fromOID:target committer:nil message:nil error:&error];
+		GTReference *ref = [bareRepository createReferenceNamed:@"refs/heads/unit_test" fromOID:target message:nil error:&error];
 		expect(error).to(beNil());
 		expect(ref).notTo(beNil());
 
@@ -179,7 +179,7 @@ describe(@"-deleteWithError:", ^{
 		GTOID *target = [[GTOID alloc] initWithSHA:@"36060c58702ed4c2a40832c51758d5344201d89a"];
 
 		NSError *error = nil;
-		GTReference *ref = [bareRepository createReferenceNamed:@"refs/heads/unit_test" fromOID:target committer:nil message:nil error:&error];
+		GTReference *ref = [bareRepository createReferenceNamed:@"refs/heads/unit_test" fromOID:target message:nil error:&error];
 
 		expect(error).to(beNil());
 		expect(ref).notTo(beNil());

--- a/ObjectiveGitTests/GTRemotePushSpec.m
+++ b/ObjectiveGitTests/GTRemotePushSpec.m
@@ -186,7 +186,7 @@ describe(@"pushing", ^{
 			GTBranch *branch1 = localBranchWithName(@"master", localRepo);
 
 			// Create refs/heads/new_master on local
-			[localRepo createReferenceNamed:@"refs/heads/new_master" fromReference:branch1.reference committer:localRepo.userSignatureForNow message:@"Create new_master branch" error:&error];
+			[localRepo createReferenceNamed:@"refs/heads/new_master" fromReference:branch1.reference message:@"Create new_master branch" error:&error];
 			GTBranch *branch2 = localBranchWithName(@"new_master", localRepo);
 
 			BOOL result = [localRepo pushBranches:@[ branch1, branch2 ] toRemote:remote withOptions:nil error:&error progress:NULL];

--- a/ObjectiveGitTests/GTRepositorySpec.m
+++ b/ObjectiveGitTests/GTRepositorySpec.m
@@ -276,7 +276,7 @@ describe(@"-createBranchNamed:fromOID:committer:message:error:", ^{
 		NSString *branchName = @"new-test-branch";
 
 		NSError *error = nil;
-		GTBranch *newBranch = [repository createBranchNamed:branchName fromOID:[[GTOID alloc] initWithSHA:currentBranch.SHA] committer:nil message:nil error:&error];
+		GTBranch *newBranch = [repository createBranchNamed:branchName fromOID:[[GTOID alloc] initWithSHA:currentBranch.SHA] message:nil error:&error];
 		expect(newBranch).notTo(beNil());
 		expect(error).to(beNil());
 


### PR DESCRIPTION
Bumps libgit2 to fix a crash enumerating status items (see below).

libgit2 has had some breaking API changes lately. I’ve followed these, and thus this PR also introduces breaking API changes.

**Backtrace:**

```
Exception Type:        EXC_ARITHMETIC (SIGFPE)
Exception Codes:       EXC_I386_DIV (divide by zero)

Thread 6 Crashed:: Dispatch queue: com.github.GitHub.GHGitConnection
0   org.libgit2.ObjectiveGit        0x00000001067d5228 hashsig_heap_compare + 376
1   org.libgit2.ObjectiveGit        0x00000001067d504d git_hashsig_compare + 45
2   org.libgit2.ObjectiveGit        0x00000001067c69fb git_diff_find_similar__calc_similarity + 43
3   org.libgit2.ObjectiveGit        0x00000001067c8a92 similarity_measure + 1026
4   org.libgit2.ObjectiveGit        0x00000001067c6f34 git_diff_find_similar + 1284
5   org.libgit2.ObjectiveGit        0x000000010684591a git_status_list_new + 1370
6   org.libgit2.ObjectiveGit        0x0000000106880ba9 -[GTRepository(Status) enumerateFileStatusWithOptions:error:usingBlock:] + 569
7   com.github.GitHub               0x0000000105e03cdd __45-[GHGitConnection statusItemsWithRepository:]_block_invoke_2 + 267
8   org.reactivecocoa.ReactiveCocoa 0x00000001064b9a7c -[RACScheduler performAsCurrentScheduler:] + 375
9   libdispatch.dylib               0x00007fff834a6323 _dispatch_call_block_and_release + 12
10  libdispatch.dylib               0x00007fff834a1c13 _dispatch_client_callout + 8
11  libdispatch.dylib               0x00007fff834a5365 _dispatch_queue_drain + 1100
12  libdispatch.dylib               0x00007fff834a6ecc _dispatch_queue_invoke + 202
13  libdispatch.dylib               0x00007fff834a46b7 _dispatch_root_queue_drain + 463
14  libdispatch.dylib               0x00007fff834b2fe4 _dispatch_worker_thread3 + 91
15  libsystem_pthread.dylib         0x00007fff8563a637 _pthread_wqthread + 729
16  libsystem_pthread.dylib         0x00007fff8563840d start_wqthread + 13
```