### PR TITLE
Support OIDs for ahead/behind count and enumeration

### DIFF
--- a/ObjectiveGit/GTBranch.h
+++ b/ObjectiveGit/GTBranch.h
@@ -43,7 +43,7 @@ typedef NS_ENUM(NSInteger, GTBranchType) {
 
 @property (nonatomic, readonly) NSString *name;
 @property (nonatomic, readonly) NSString *shortName;
-@property (nonatomic, readonly) NSString *SHA;
+@property (nonatomic, copy, readonly) GTOID *OID;
 @property (nonatomic, readonly) NSString *remoteName;
 @property (nonatomic, readonly) GTBranchType branchType;
 @property (nonatomic, readonly, strong) GTRepository *repository;

--- a/ObjectiveGit/GTReference.h
+++ b/ObjectiveGit/GTReference.h
@@ -79,8 +79,8 @@ typedef NS_OPTIONS(NSInteger, GTReferenceType) {
 /// The last direct reference in a chain
 @property (nonatomic, readonly, copy) GTReference *resolvedReference;
 
-/// The SHA of the target object
-@property (nonatomic, readonly, copy) NSString *targetSHA;
+/// The OID of the target object.
+@property (nonatomic, readonly, copy) GTOID *targetOID;
 
 /// Updates the on-disk reference to point to the target and returns the updated
 /// reference.

--- a/ObjectiveGit/GTReference.m
+++ b/ObjectiveGit/GTReference.m
@@ -169,8 +169,8 @@ static NSString *referenceTypeToString(GTReferenceType type) {
 	return [self.class referenceByResolvingSymbolicReference:self error:NULL];
 }
 
-- (NSString *)targetSHA {
-	return [self.resolvedTarget SHA];
+- (GTOID *)targetOID {
+	return [self.resolvedTarget OID];
 }
 
 - (GTReference *)referenceByUpdatingTarget:(NSString *)newTarget message:(NSString *)message error:(NSError **)error {

--- a/ObjectiveGit/GTRepository.h
+++ b/ObjectiveGit/GTRepository.h
@@ -498,4 +498,16 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 /// distinguished using the value of `success`.
 - (GTFilterList *)filterListWithPath:(NSString *)path blob:(GTBlob *)blob mode:(GTFilterSourceMode)mode options:(GTFilterListOptions)options success:(BOOL *)success error:(NSError **)error;
 
+/// Creates an enumerator for finding all commits in the history of `headOID`
+/// that do not exist in the history of `baseOID`.
+///
+/// Returns the created enumerator upon success, or `nil` if an error occurred.
+- (GTEnumerator *)enumerateUniqueCommitsUpToOID:(GTOID *)headOID relativeToOID:(GTOID *)baseOID error:(NSError **)error;
+
+/// Calculates how far ahead/behind the commit represented by `headOID` is,
+/// relative to the commit represented by `baseOID`.
+///
+/// Returns whether `ahead` and `behind` were successfully calculated.
+- (BOOL)calculateAhead:(size_t *)ahead behind:(size_t *)behind ofOID:(GTOID *)headOID relativeToOID:(GTOID *)baseOID error:(NSError **)error;
+
 @end

--- a/ObjectiveGitTests/GTEnumeratorSpec.m
+++ b/ObjectiveGitTests/GTEnumeratorSpec.m
@@ -31,7 +31,7 @@ it(@"should walk from repository HEAD", ^{
 	GTReference *HEADRef = [repo headReferenceWithError:NULL];
 	expect(HEADRef).notTo(beNil());
 
-	[enumerator pushSHA:HEADRef.targetSHA error:NULL];
+	[enumerator pushSHA:HEADRef.targetOID.SHA error:NULL];
 	NSUInteger count = [enumerator allObjects].count;
 	expect(@(count)).to(equal(@3));
 	expect(error).to(beNil());

--- a/ObjectiveGitTests/GTReferenceSpec.m
+++ b/ObjectiveGitTests/GTReferenceSpec.m
@@ -65,7 +65,7 @@ describe(@"transformations", ^{
 		reference = [repository createReferenceNamed:testRefName fromOID:testRefOID message:nil error:&error];
 		expect(reference).notTo(beNil());
 		expect(reference.name).to(equal(testRefName));
-		expect(reference.targetSHA).to(equal(testRefOID.SHA));
+		expect(reference.targetOID).to(equal(testRefOID.SHA));
 	});
 
 	it(@"should be able to be renamed", ^{
@@ -74,7 +74,7 @@ describe(@"transformations", ^{
 		GTReference *renamedRef = [reference referenceByRenaming:newRefName error:NULL];
 		expect(renamedRef).notTo(beNil());
 		expect(renamedRef.name).to(equal(newRefName));
-		expect(renamedRef.targetSHA).to(equal(testRefOID.SHA));
+		expect(renamedRef.targetOID).to(equal(testRefOID.SHA));
 	});
 
 	it(@"should be able to change the target", ^{
@@ -83,7 +83,7 @@ describe(@"transformations", ^{
 		GTReference *updatedRef = [reference referenceByUpdatingTarget:newRefTarget message:nil error:NULL];
 		expect(updatedRef).notTo(beNil());
 		expect(updatedRef.name).to(equal(testRefName));
-		expect(updatedRef.targetSHA).to(equal(newRefTarget));
+		expect(updatedRef.targetOID).to(equal(newRefTarget));
 	});
 });
 
@@ -119,7 +119,7 @@ __block GTRepository *bareRepository;
 
 void (^expectValidReference)(GTReference *ref, NSString *SHA, GTReferenceType type, NSString *name) = ^(GTReference *ref, NSString *SHA, GTReferenceType type, NSString *name) {
 	expect(ref).notTo(beNil());
-	expect(ref.targetSHA).to(equal(SHA));
+	expect(ref.targetOID).to(equal(SHA));
 	expect(@(ref.referenceType)).to(equal(@(type)));
 	expect(ref.name).to(equal(name));
 };

--- a/ObjectiveGitTests/GTReferenceSpec.m
+++ b/ObjectiveGitTests/GTReferenceSpec.m
@@ -65,7 +65,7 @@ describe(@"transformations", ^{
 		reference = [repository createReferenceNamed:testRefName fromOID:testRefOID message:nil error:&error];
 		expect(reference).notTo(beNil());
 		expect(reference.name).to(equal(testRefName));
-		expect(reference.targetOID).to(equal(testRefOID.SHA));
+		expect(reference.targetOID).to(equal(testRefOID));
 	});
 
 	it(@"should be able to be renamed", ^{
@@ -74,7 +74,7 @@ describe(@"transformations", ^{
 		GTReference *renamedRef = [reference referenceByRenaming:newRefName error:NULL];
 		expect(renamedRef).notTo(beNil());
 		expect(renamedRef.name).to(equal(newRefName));
-		expect(renamedRef.targetOID).to(equal(testRefOID.SHA));
+		expect(renamedRef.targetOID).to(equal(testRefOID));
 	});
 
 	it(@"should be able to change the target", ^{
@@ -83,7 +83,7 @@ describe(@"transformations", ^{
 		GTReference *updatedRef = [reference referenceByUpdatingTarget:newRefTarget message:nil error:NULL];
 		expect(updatedRef).notTo(beNil());
 		expect(updatedRef.name).to(equal(testRefName));
-		expect(updatedRef.targetOID).to(equal(newRefTarget));
+		expect(updatedRef.targetOID.SHA).to(equal(newRefTarget));
 	});
 });
 
@@ -119,7 +119,7 @@ __block GTRepository *bareRepository;
 
 void (^expectValidReference)(GTReference *ref, NSString *SHA, GTReferenceType type, NSString *name) = ^(GTReference *ref, NSString *SHA, GTReferenceType type, NSString *name) {
 	expect(ref).notTo(beNil());
-	expect(ref.targetOID).to(equal(SHA));
+	expect(ref.targetOID.SHA).to(equal(SHA));
 	expect(@(ref.referenceType)).to(equal(@(type)));
 	expect(ref.name).to(equal(name));
 };

--- a/ObjectiveGitTests/GTRemotePushSpec.m
+++ b/ObjectiveGitTests/GTRemotePushSpec.m
@@ -23,7 +23,7 @@ GTCommit *(^createCommitInRepository)(NSString *, NSData *, NSString *, GTReposi
 	GTReference *headReference = [repo headReferenceWithError:nil];
 
 	GTEnumerator *commitEnum = [[GTEnumerator alloc] initWithRepository:repo error:nil];
-	[commitEnum pushSHA:[headReference targetSHA] error:nil];
+	[commitEnum pushSHA:[headReference targetOID].SHA error:nil];
 	GTCommit *parent = [commitEnum nextObject];
 
 	GTCommit *testCommit = [repo createCommitWithTree:testTree message:message parents:@[ parent ] updatingReferenceNamed:headReference.name error:nil];

--- a/ObjectiveGitTests/GTRemoteSpec.m
+++ b/ObjectiveGitTests/GTRemoteSpec.m
@@ -144,7 +144,7 @@ describe(@"network operations", ^{
 		GTReference *headReference = [repo headReferenceWithError:nil];
 
 		GTEnumerator *commitEnum = [[GTEnumerator alloc] initWithRepository:repo error:nil];
-		[commitEnum pushSHA:[headReference targetSHA] error:nil];
+		[commitEnum pushSHA:headReference.targetOID.SHA error:nil];
 		GTCommit *parent = [commitEnum nextObject];
 
 		GTCommit *testCommit = [repo createCommitWithTree:testTree message:message parents:@[parent] updatingReferenceNamed:headReference.name error:nil];

--- a/ObjectiveGitTests/GTRepositoryResetSpec.m
+++ b/ObjectiveGitTests/GTRepositoryResetSpec.m
@@ -77,7 +77,7 @@ describe(@"-resetToCommit:resetType:error:", ^{
 
 		GTReference *head = [repository headReferenceWithError:&error];
 		expect(head).notTo(beNil());
-		expect(head.targetOID).to(equal(resetTargetSHA));
+		expect(head.targetOID.SHA).to(equal(resetTargetSHA));
 
 		success = [repository resetToCommit:originalHeadCommit resetType:GTRepositoryResetTypeSoft error:&error];
 		expect(@(success)).to(beTruthy());

--- a/ObjectiveGitTests/GTRepositoryResetSpec.m
+++ b/ObjectiveGitTests/GTRepositoryResetSpec.m
@@ -68,7 +68,7 @@ describe(@"-resetToCommit:resetType:error:", ^{
 
 		GTCommit *commit = [repository lookUpObjectBySHA:resetTargetSHA error:NULL];
 		expect(commit).notTo(beNil());
-		GTCommit *originalHeadCommit = [repository lookUpObjectBySHA:originalHead.targetSHA error:NULL];
+		GTCommit *originalHeadCommit = [repository lookUpObjectByOID:originalHead.targetOID error:NULL];
 		expect(originalHeadCommit).notTo(beNil());
 
 		BOOL success = [repository resetToCommit:commit resetType:GTRepositoryResetTypeSoft error:&error];
@@ -77,14 +77,14 @@ describe(@"-resetToCommit:resetType:error:", ^{
 
 		GTReference *head = [repository headReferenceWithError:&error];
 		expect(head).notTo(beNil());
-		expect(head.targetSHA).to(equal(resetTargetSHA));
+		expect(head.targetOID).to(equal(resetTargetSHA));
 
 		success = [repository resetToCommit:originalHeadCommit resetType:GTRepositoryResetTypeSoft error:&error];
 		expect(@(success)).to(beTruthy());
 		expect(error).to(beNil());
 
 		head = [repository headReferenceWithError:&error];
-		expect(head.targetSHA).to(equal(originalHead.targetSHA));
+		expect(head.targetOID).to(equal(originalHead.targetOID));
 	});
 });
 

--- a/ObjectiveGitTests/GTRepositorySpec.m
+++ b/ObjectiveGitTests/GTRepositorySpec.m
@@ -102,7 +102,7 @@ describe(@"+cloneFromURL:toWorkingDirectory:options:error:transferProgressBlock:
 			GTReference *head = [repository headReferenceWithError:&error];
 			expect(head).notTo(beNil());
 			expect(error).to(beNil());
-			expect(head.targetOID).to(equal(@"36060c58702ed4c2a40832c51758d5344201d89a"));
+			expect(head.targetOID.SHA).to(equal(@"36060c58702ed4c2a40832c51758d5344201d89a"));
 			expect(@(head.referenceType)).to(equal(@(GTReferenceTypeOid)));
 		});
 
@@ -120,7 +120,7 @@ describe(@"+cloneFromURL:toWorkingDirectory:options:error:transferProgressBlock:
 			GTReference *head = [repository headReferenceWithError:&error];
 			expect(head).notTo(beNil());
 			expect(error).to(beNil());
-			expect(head.targetOID).to(equal(@"36060c58702ed4c2a40832c51758d5344201d89a"));
+			expect(head.targetOID.SHA).to(equal(@"36060c58702ed4c2a40832c51758d5344201d89a"));
 			expect(@(head.referenceType)).to(equal(@(GTReferenceTypeOid)));
 		});
 
@@ -183,7 +183,7 @@ describe(@"-headReferenceWithError:", ^{
 		GTReference *head = [self.bareFixtureRepository headReferenceWithError:&error];
 		expect(head).notTo(beNil());
 		expect(error).to(beNil());
-		expect(head.targetOID).to(equal(@"36060c58702ed4c2a40832c51758d5344201d89a"));
+		expect(head.targetOID.SHA).to(equal(@"36060c58702ed4c2a40832c51758d5344201d89a"));
 		expect(@(head.referenceType)).to(equal(@(GTReferenceTypeOid)));
 	});
 
@@ -418,7 +418,7 @@ describe(@"-resetToCommit:withResetType:error:", ^{
 
 		GTReference *head = [repository headReferenceWithError:&error];
 		expect(head).notTo(beNil());
-		expect(head.targetOID).to(equal(resetTargetSHA));
+		expect(head.targetOID.SHA).to(equal(resetTargetSHA));
 
 		success = [repository resetToCommit:originalHeadCommit resetType:GTRepositoryResetTypeSoft error:&error];
 		expect(@(success)).to(beTruthy());

--- a/ObjectiveGitTests/GTRepositorySpec.m
+++ b/ObjectiveGitTests/GTRepositorySpec.m
@@ -102,7 +102,7 @@ describe(@"+cloneFromURL:toWorkingDirectory:options:error:transferProgressBlock:
 			GTReference *head = [repository headReferenceWithError:&error];
 			expect(head).notTo(beNil());
 			expect(error).to(beNil());
-			expect(head.targetSHA).to(equal(@"36060c58702ed4c2a40832c51758d5344201d89a"));
+			expect(head.targetOID).to(equal(@"36060c58702ed4c2a40832c51758d5344201d89a"));
 			expect(@(head.referenceType)).to(equal(@(GTReferenceTypeOid)));
 		});
 
@@ -120,7 +120,7 @@ describe(@"+cloneFromURL:toWorkingDirectory:options:error:transferProgressBlock:
 			GTReference *head = [repository headReferenceWithError:&error];
 			expect(head).notTo(beNil());
 			expect(error).to(beNil());
-			expect(head.targetSHA).to(equal(@"36060c58702ed4c2a40832c51758d5344201d89a"));
+			expect(head.targetOID).to(equal(@"36060c58702ed4c2a40832c51758d5344201d89a"));
 			expect(@(head.referenceType)).to(equal(@(GTReferenceTypeOid)));
 		});
 
@@ -183,7 +183,7 @@ describe(@"-headReferenceWithError:", ^{
 		GTReference *head = [self.bareFixtureRepository headReferenceWithError:&error];
 		expect(head).notTo(beNil());
 		expect(error).to(beNil());
-		expect(head.targetSHA).to(equal(@"36060c58702ed4c2a40832c51758d5344201d89a"));
+		expect(head.targetOID).to(equal(@"36060c58702ed4c2a40832c51758d5344201d89a"));
 		expect(@(head.referenceType)).to(equal(@(GTReferenceTypeOid)));
 	});
 
@@ -276,13 +276,13 @@ describe(@"-createBranchNamed:fromOID:committer:message:error:", ^{
 		NSString *branchName = @"new-test-branch";
 
 		NSError *error = nil;
-		GTBranch *newBranch = [repository createBranchNamed:branchName fromOID:[[GTOID alloc] initWithSHA:currentBranch.SHA] message:nil error:&error];
+		GTBranch *newBranch = [repository createBranchNamed:branchName fromOID:currentBranch.OID message:nil error:&error];
 		expect(newBranch).notTo(beNil());
 		expect(error).to(beNil());
 
 		expect(newBranch.shortName).to(equal(branchName));
 		expect(@(newBranch.branchType)).to(equal(@(GTBranchTypeLocal)));
-		expect(newBranch.SHA).to(equal(currentBranch.SHA));
+		expect(newBranch.OID).to(equal(currentBranch.OID));
 	});
 });
 
@@ -409,7 +409,7 @@ describe(@"-resetToCommit:withResetType:error:", ^{
 
 		GTCommit *commit = [repository lookUpObjectBySHA:resetTargetSHA error:NULL];
 		expect(commit).notTo(beNil());
-		GTCommit *originalHeadCommit = [repository lookUpObjectBySHA:originalHead.targetSHA error:NULL];
+		GTCommit *originalHeadCommit = [repository lookUpObjectByOID:originalHead.targetOID error:NULL];
 		expect(originalHeadCommit).notTo(beNil());
 
 		BOOL success = [repository resetToCommit:commit resetType:GTRepositoryResetTypeSoft error:&error];
@@ -418,14 +418,14 @@ describe(@"-resetToCommit:withResetType:error:", ^{
 
 		GTReference *head = [repository headReferenceWithError:&error];
 		expect(head).notTo(beNil());
-		expect(head.targetSHA).to(equal(resetTargetSHA));
+		expect(head.targetOID).to(equal(resetTargetSHA));
 
 		success = [repository resetToCommit:originalHeadCommit resetType:GTRepositoryResetTypeSoft error:&error];
 		expect(@(success)).to(beTruthy());
 		expect(error).to(beNil());
 
 		head = [repository headReferenceWithError:&error];
-		expect(head.targetSHA).to(equal(originalHead.targetSHA));
+		expect(head.targetOID).to(equal(originalHead.targetOID));
 	});
 });
 


### PR DESCRIPTION
Also changed `GTBranch` and `GTReference` to expose OIDs, not SHAs.