### PR TITLE
Support for Swift 1.2 (Spec dependencies) and new Objective-C nullability qualifiers

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
 github "jspahrsummers/xcconfigs" >= 0.7.1
-github "Quick/Quick" ~> 0.2
-github "Quick/Nimble" ~> 0.2
+github "Quick/Quick" ~> 0.3
+github "Quick/Nimble" ~> 0.4

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v0.4.1"
-github "Quick/Quick" "v0.3.0"
+github "Quick/Nimble" "v0.4.2"
+github "Quick/Quick" "v0.3.1"
 github "jspahrsummers/xcconfigs" "0.7.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v0.2.0"
-github "Quick/Quick" "v0.2.2"
-github "jspahrsummers/xcconfigs" "0.7.1"
+github "Quick/Nimble" "v0.4.0"
+github "Quick/Quick" "v0.3.0"
+github "jspahrsummers/xcconfigs" "0.7.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v0.4.0"
+github "Quick/Nimble" "v0.4.1"
 github "Quick/Quick" "v0.3.0"
 github "jspahrsummers/xcconfigs" "0.7.2"

--- a/ObjectiveGit/GTBlame.h
+++ b/ObjectiveGit/GTBlame.h
@@ -12,11 +12,17 @@
 @class GTBlameHunk;
 @class GTRepository;
 
-/// A `GTBlame` provides authorship info, through `GTBlameHunk` for each line of a file.
+NS_ASSUME_NONNULL_BEGIN
+
+/// A `GTBlame` provides authorship info, through `GTBlameHunk` for each line of a file. Analogous to `git_blame` in libgit2.
 @interface GTBlame : NSObject
 
 /// Designated initializer.
-- (instancetype)initWithGitBlame:(git_blame *)blame NS_DESIGNATED_INITIALIZER;
+///
+/// blame - A git_blame to wrap. May not be NULL.
+///
+/// Returns a blame, or nil if initialization failed.
+- (nullable instancetype)initWithGitBlame:(git_blame *)blame NS_DESIGNATED_INITIALIZER;
 
 /// Get all the hunks in the blame. A convenience wrapper around `enumerateHunksUsingBlock:`
 @property (nonatomic, strong, readonly) NSArray *hunks;
@@ -29,12 +35,13 @@
 /// index - The index to retrieve the hunk from.
 ///
 /// Returns a `GTBlameHunk` or nil if an error occurred.
-- (GTBlameHunk *)hunkAtIndex:(NSUInteger)index;
+- (nullable GTBlameHunk *)hunkAtIndex:(NSUInteger)index;
 
 /// Enumerate the hunks in the blame.
 ///
 /// block - A block invoked for every hunk in the blame.
 ///         Setting stop to `YES` instantly stops the enumeration.
+///         May not be NULL.
 ///
 - (void)enumerateHunksUsingBlock:(void (^)(GTBlameHunk *hunk, NSUInteger index, BOOL *stop))block;
 
@@ -43,10 +50,11 @@
 /// lineNumber - The (1 based) line number to find a hunk for.
 ///
 /// Returns a `GTBlameHunk` or nil if an error occurred.
-- (GTBlameHunk *)hunkAtLineNumber:(NSUInteger)lineNumber;
+- (nullable GTBlameHunk *)hunkAtLineNumber:(NSUInteger)lineNumber;
 
 /// The underlying `git_blame` object.
 - (git_blame *)git_blame __attribute__((objc_returns_inner_pointer));
 
 @end
 
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTBlameHunk.h
+++ b/ObjectiveGit/GTBlameHunk.h
@@ -15,6 +15,7 @@
 /// A `GTBlameHunk` is an object that provides authorship info for a set of lines in a `GTBlame`.
 @interface GTBlameHunk : NSObject
 
+/// Designated initializer.
 - (instancetype)initWithGitBlameHunk:(git_blame_hunk)hunk NS_DESIGNATED_INITIALIZER;
 
 /// A NSRange where `location` is the (1 based) starting line number,

--- a/ObjectiveGit/GTBlameHunk.h
+++ b/ObjectiveGit/GTBlameHunk.h
@@ -12,21 +12,27 @@
 @class GTOID;
 @class GTSignature;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A `GTBlameHunk` is an object that provides authorship info for a set of lines in a `GTBlame`.
 @interface GTBlameHunk : NSObject
 
 /// Designated initializer.
-- (instancetype)initWithGitBlameHunk:(git_blame_hunk)hunk NS_DESIGNATED_INITIALIZER;
+///
+/// hunk - A git_blame_hunk to wrap. May not be NULL.
+///
+/// Returns a blame hunk, or nil if initialization failed.
+- (nullable instancetype)initWithGitBlameHunk:(git_blame_hunk)hunk NS_DESIGNATED_INITIALIZER;
 
 /// A NSRange where `location` is the (1 based) starting line number,
 /// and `length` is the number of lines in the hunk.
 @property (nonatomic, readonly) NSRange lines;
 
 /// The OID of the commit where this hunk was last changed.
-@property (nonatomic, readonly, copy) GTOID *finalCommitOID;
+@property (nonatomic, readonly, copy, nullable) GTOID *finalCommitOID;
 
 /// The signature of the commit where this hunk was last changed.
-@property (nonatomic, readonly) GTSignature *finalSignature;
+@property (nonatomic, readonly, nullable) GTSignature *finalSignature;
 
 /// The path of the file in the original commit.
 @property (nonatomic, readonly, copy) NSString *originalPath;
@@ -39,3 +45,5 @@
 @property (nonatomic, readonly) git_blame_hunk git_blame_hunk;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTBlob.h
+++ b/ObjectiveGit/GTBlob.h
@@ -30,45 +30,82 @@
 
 #import "GTObject.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface GTBlob : GTObject
 
-/// Convenience class methods
-+ (instancetype)blobWithString:(NSString *)string inRepository:(GTRepository *)repository error:(NSError **)error;
-+ (instancetype)blobWithData:(NSData *)data inRepository:(GTRepository *)repository error:(NSError **)error;
-+ (instancetype)blobWithFile:(NSURL *)file inRepository:(GTRepository *)repository error:(NSError **)error;
+/// Creates a new blob from the given string.
+///
+/// This writes data to the repository's object database.
+///
+/// string     - The string to add. This must not be nil.
+/// repository - The repository to put the object in. This must not be nil.
+/// error      - Will be set if an error occurs. This may be nil.
+///
+/// Return a newly created blob object, or nil if an error occurs.
++ (nullable instancetype)blobWithString:(NSString *)string inRepository:(GTRepository *)repository error:(NSError **)error;
 
+/// Creates a new blob from the given data.
+///
+/// This writes data to the repository's object database.
+///
+/// data       - The data to add. This must not be nil.
+/// repository - The repository to put the object in. This must not be nil.
+/// error      - Will be set if an error occurs. This may be nil.
+///
+/// Return a newly created blob object, or nil if an error occurs.
++ (nullable instancetype)blobWithData:(NSData *)data inRepository:(GTRepository *)repository error:(NSError **)error;
+
+/// Creates a new blob given an NSURL to a file.
+///
+/// This copies the data from the file to the repository's object database.
+///
+/// file       - The NSURL of the file to add. This must not be nil.
+/// repository - The repository to put the object in. This must not be nil.
+/// error      - Will be set if an error occurs. This may be nil.
+///
+/// Return a newly created blob object, or nil if an error occurs.
++ (nullable instancetype)blobWithFile:(NSURL *)file inRepository:(GTRepository *)repository error:(NSError **)error;
+
+/// Creates a new blob from the given string.
+///
 /// Convenience wrapper around `-initWithData:inRepository:error` that converts the string to UTF8 data
-- (instancetype)initWithString:(NSString *)string inRepository:(GTRepository *)repository error:(NSError **)error;
+///
+/// string     - The string to add. This must not be nil.
+/// repository - The repository to put the object in. This must not be nil.
+/// error      - Will be set if an error occurs. This may be nil.
+///
+/// Return a newly created blob object, or nil if an error occurs.
+- (nullable instancetype)initWithString:(NSString *)string inRepository:(GTRepository *)repository error:(NSError **)error;
 
 /// Creates a new blob from the passed data.
 ///
 /// This writes data to the repository's object database.
 ///
-/// data       - The data to write.
-/// repository - The repository to put the object in.
-/// error      - Will be set if an error occurs.
+/// data       - The data to write. This must not be nil.
+/// repository - The repository to put the object in. This must not be nil.
+/// error      - Will be set if an error occurs. This may be nil.
 ///
 /// Returns a newly created blob object, or nil if an error occurs.
-- (instancetype)initWithData:(NSData *)data inRepository:(GTRepository *)repository error:(NSError **)error;
+- (nullable instancetype)initWithData:(NSData *)data inRepository:(GTRepository *)repository error:(NSError **)error;
 
 /// Creates a new blob from the specified file.
 ///
 /// This copies the data from the file to the repository's object database.
 ///
-/// data       - The file to copy contents from.
-/// repository - The repository to put the object in.
-/// error      - Will be set if an error occurs.
+/// file       - The file to copy contents from. This must not be nil.
+/// repository - The repository to put the object in. This must not be nil.
+/// error      - Will be set if an error occurs. This may be nil.
 ///
 /// Returns a newly created blob object, or nil if an error occurs.
-- (instancetype)initWithFile:(NSURL *)file inRepository:(GTRepository *)repository error:(NSError **)error;
+- (nullable instancetype)initWithFile:(NSURL *)file inRepository:(GTRepository *)repository error:(NSError **)error;
 
 /// The underlying `git_object` as a `git_blob` object.
 - (git_blob *)git_blob __attribute__((objc_returns_inner_pointer));
 
 - (git_off_t)size;
 - (NSString *)content;
-- (NSData *)data;
+- (nullable NSData *)data;
 
 /// Attempts to apply the filter list for `path` to the blob.
 ///
@@ -76,6 +113,8 @@
 /// error - If not NULL, set to any error that occurs.
 ///
 /// Returns the filtered data, or nil if an error occurs.
-- (NSData *)applyFiltersForPath:(NSString *)path error:(NSError **)error;
+- (nullable NSData *)applyFiltersForPath:(NSString *)path error:(NSError **)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTBlob.m
+++ b/ObjectiveGit/GTBlob.m
@@ -46,19 +46,19 @@
 
 #pragma mark API
 
-+ (id)blobWithString:(NSString *)string inRepository:(GTRepository *)repository error:(NSError **)error {
++ (instancetype)blobWithString:(NSString *)string inRepository:(GTRepository *)repository error:(NSError **)error {
 	return [[self alloc] initWithString:string inRepository:repository error:error];
 }
 
-+ (id)blobWithData:(NSData *)data inRepository:(GTRepository *)repository error:(NSError **)error {
++ (instancetype)blobWithData:(NSData *)data inRepository:(GTRepository *)repository error:(NSError **)error {
 	return [[self alloc] initWithData:data inRepository:repository error:error];
 }
 
-+ (id)blobWithFile:(NSURL *)file inRepository:(GTRepository *)repository error:(NSError **)error {
++ (instancetype)blobWithFile:(NSURL *)file inRepository:(GTRepository *)repository error:(NSError **)error {
 	return [[self alloc] initWithFile:file inRepository:repository error:error];
 }
 
-- (id)initWithOid:(const git_oid *)oid inRepository:(GTRepository *)repository error:(NSError **)error {
+- (instancetype)initWithOid:(const git_oid *)oid inRepository:(GTRepository *)repository error:(NSError **)error {
 	NSParameterAssert(oid != NULL);
 	NSParameterAssert(repository != nil);
 
@@ -74,12 +74,12 @@
     return [self initWithObj:obj inRepository:repository];
 }
 
-- (id)initWithString:(NSString *)string inRepository:(GTRepository *)repository error:(NSError **)error {
+- (instancetype)initWithString:(NSString *)string inRepository:(GTRepository *)repository error:(NSError **)error {
 	NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];
     return [self initWithData:data inRepository:repository error:error];
 }
 
-- (id)initWithData:(NSData *)data inRepository:(GTRepository *)repository error:(NSError **)error {
+- (instancetype)initWithData:(NSData *)data inRepository:(GTRepository *)repository error:(NSError **)error {
 	NSParameterAssert(data != nil);
 	NSParameterAssert(repository != nil);
 
@@ -95,7 +95,7 @@
     return [self initWithOid:&oid inRepository:repository error:error];
 }
 
-- (id)initWithFile:(NSURL *)file inRepository:(GTRepository *)repository error:(NSError **)error {
+- (instancetype)initWithFile:(NSURL *)file inRepository:(GTRepository *)repository error:(NSError **)error {
 	NSParameterAssert(file != nil);
 	NSParameterAssert(repository != nil);
 

--- a/ObjectiveGit/GTBranch.h
+++ b/ObjectiveGit/GTBranch.h
@@ -52,6 +52,7 @@ typedef NS_ENUM(NSInteger, GTBranchType) {
 + (NSString *)localNamePrefix;
 + (NSString *)remoteNamePrefix;
 
+/// Designated initializer.
 - (id)initWithReference:(GTReference *)ref repository:(GTRepository *)repo NS_DESIGNATED_INITIALIZER;
 + (id)branchWithReference:(GTReference *)ref repository:(GTRepository *)repo;
 

--- a/ObjectiveGit/GTBranch.h
+++ b/ObjectiveGit/GTBranch.h
@@ -84,7 +84,13 @@ NS_ASSUME_NONNULL_BEGIN
 /// returns number of commits in the branch or NSNotFound if an error occurred
 - (NSUInteger)numberOfCommitsWithError:(NSError **)error;
 
-- (NSArray *)uniqueCommitsRelativeToBranch:(GTBranch *)otherBranch error:(NSError **)error;
+/// Get unique commits
+///
+/// otherBranch -
+/// error       - If not NULL, set to any error that occurs.
+///
+/// Returns a (possibly empty) array of GTCommits, or nil if an error occurs.
+- (nullable NSArray *)uniqueCommitsRelativeToBranch:(GTBranch *)otherBranch error:(NSError **)error;
 
 /// Deletes the local branch and nils out the reference.
 - (BOOL)deleteWithError:(NSError **)error;

--- a/ObjectiveGit/GTBranch.h
+++ b/ObjectiveGit/GTBranch.h
@@ -35,16 +35,18 @@ typedef NS_ENUM(NSInteger, GTBranchType) {
     GTBranchTypeRemote = GIT_BRANCH_REMOTE,
 };
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A git branch object.
 ///
-/// Branches are considered to be equivalent iff both their `name` and `SHA` are
+/// Branches are considered to be equivalent if both their `name` and `SHA` are
 /// equal.
 @interface GTBranch : NSObject
 
-@property (nonatomic, readonly) NSString *name;
-@property (nonatomic, readonly) NSString *shortName;
-@property (nonatomic, copy, readonly) GTOID *OID;
-@property (nonatomic, readonly) NSString *remoteName;
+@property (nonatomic, readonly, nullable) NSString *name;
+@property (nonatomic, readonly, nullable) NSString *shortName;
+@property (nonatomic, copy, readonly, nullable) GTOID *OID;
+@property (nonatomic, readonly, nullable) NSString *remoteName;
 @property (nonatomic, readonly) GTBranchType branchType;
 @property (nonatomic, readonly, strong) GTRepository *repository;
 @property (nonatomic, readonly, strong) GTReference *reference;
@@ -53,15 +55,27 @@ typedef NS_ENUM(NSInteger, GTBranchType) {
 + (NSString *)remoteNamePrefix;
 
 /// Designated initializer.
-- (id)initWithReference:(GTReference *)ref repository:(GTRepository *)repo NS_DESIGNATED_INITIALIZER;
-+ (id)branchWithReference:(GTReference *)ref repository:(GTRepository *)repo;
+///
+/// ref  - The branch reference to wrap. Must not be nil.
+/// repo - The repository containing the branch. Must not be nil.
+///
+/// Returns the initialized receiver.
+- (nullable instancetype)initWithReference:(GTReference *)ref repository:(GTRepository *)repo NS_DESIGNATED_INITIALIZER;
+
+/// Convenience class initializer.
+///
+/// ref  - The branch reference to wrap. Must not be nil.
+/// repo - The repository containing the branch. Must not be nil.
+///
+/// Returns an initialized instance.
++ (nullable instancetype)branchWithReference:(GTReference *)ref repository:(GTRepository *)repo;
 
 /// Get the target commit for this branch
 ///
 /// error(out) - will be filled if an error occurs
 ///
 /// returns a GTCommit object or nil if an error occurred
-- (GTCommit *)targetCommitAndReturnError:(NSError **)error;
+- (nullable GTCommit *)targetCommitAndReturnError:(NSError **)error;
 
 /// Count all commits in this branch
 ///
@@ -78,7 +92,7 @@ typedef NS_ENUM(NSInteger, GTBranchType) {
 /// If the receiver is a local branch, looks up and returns its tracking branch.
 /// If the receiver is a remote branch, returns self. If no tracking branch was
 /// found, returns nil and sets `success` to YES.
-- (GTBranch *)trackingBranchWithError:(NSError **)error success:(BOOL *)success;
+- (nullable GTBranch *)trackingBranchWithError:(NSError **)error success:(nullable BOOL *)success;
 
 /// Update the tracking branch.
 ///
@@ -87,7 +101,7 @@ typedef NS_ENUM(NSInteger, GTBranchType) {
 /// error          - The error if one occurred.
 ///
 /// Returns whether it was successful.
-- (BOOL)updateTrackingBranch:(GTBranch *)trackingBranch error:(NSError **)error;
+- (BOOL)updateTrackingBranch:(nullable GTBranch *)trackingBranch error:(NSError **)error;
 
 /// Reloads the branch's reference and creates a new branch based off that newly
 /// loaded reference.
@@ -97,7 +111,7 @@ typedef NS_ENUM(NSInteger, GTBranchType) {
 /// error - The error if one occurred.
 ///
 /// Returns the reloaded branch, or nil if an error occurred.
-- (GTBranch *)reloadedBranchWithError:(NSError **)error;
+- (nullable GTBranch *)reloadedBranchWithError:(NSError **)error;
 
 /// Calculate the ahead/behind count from this branch to the given branch.
 ///
@@ -111,3 +125,5 @@ typedef NS_ENUM(NSInteger, GTBranchType) {
 - (BOOL)calculateAhead:(size_t *)ahead behind:(size_t *)behind relativeTo:(GTBranch *)branch error:(NSError **)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTBranch.m
+++ b/ObjectiveGit/GTBranch.m
@@ -65,11 +65,11 @@
 	return @"refs/remotes/";
 }
 
-+ (id)branchWithReference:(GTReference *)ref repository:(GTRepository *)repo {
++ (nullable instancetype)branchWithReference:(GTReference *)ref repository:(GTRepository *)repo {
 	return [[self alloc] initWithReference:ref repository:repo];
 }
 
-- (id)initWithReference:(GTReference *)ref repository:(GTRepository *)repo {
+- (nullable instancetype)initWithReference:(GTReference *)ref repository:(GTRepository *)repo {
 	NSParameterAssert(ref != nil);
 	NSParameterAssert(repo != nil);
 

--- a/ObjectiveGit/GTCommit.h
+++ b/ObjectiveGit/GTCommit.h
@@ -34,17 +34,19 @@
 @class GTTree;
 @class GTOID;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GTCommit : GTObject {}
 
-@property (nonatomic, readonly, strong) GTSignature *author;
-@property (nonatomic, readonly, strong) GTSignature *committer;
+@property (nonatomic, readonly, strong, nullable) GTSignature *author;
+@property (nonatomic, readonly, strong, nullable) GTSignature *committer;
 @property (nonatomic, readonly, copy) NSArray *parents;
-@property (nonatomic, readonly) NSString *message;
+@property (nonatomic, readonly, nullable) NSString *message;
 @property (nonatomic, readonly) NSString *messageDetails;
 @property (nonatomic, readonly) NSString *messageSummary;
 @property (nonatomic, readonly) NSDate *commitDate;
 @property (nonatomic, readonly) NSTimeZone *commitTimeZone;
-@property (nonatomic, readonly) GTTree *tree;
+@property (nonatomic, readonly, nullable) GTTree *tree;
 
 /// Is this a merge commit?
 @property (nonatomic, readonly, assign, getter = isMerge) BOOL merge;
@@ -53,3 +55,5 @@
 - (git_commit *)git_commit __attribute__((objc_returns_inner_pointer));
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTConfiguration+Private.h
+++ b/ObjectiveGit/GTConfiguration+Private.h
@@ -12,7 +12,7 @@
 
 @interface GTConfiguration ()
 
-/// Initializes the receiver.
+/// Designated initializer.
 ///
 /// config     - The libgit2 config. Cannot be NULL.
 /// repository - The repository in which the config resides. May be nil.

--- a/ObjectiveGit/GTConfiguration+Private.h
+++ b/ObjectiveGit/GTConfiguration+Private.h
@@ -18,6 +18,6 @@
 /// repository - The repository in which the config resides. May be nil.
 ///
 /// Returns the initialized object.
-- (id)initWithGitConfig:(git_config *)config repository:(GTRepository *)repository NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithGitConfig:(git_config *)config repository:(nullable GTRepository *)repository NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/ObjectiveGit/GTConfiguration.h
+++ b/ObjectiveGit/GTConfiguration.h
@@ -12,24 +12,26 @@
 @class GTRepository;
 @class GTSignature;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GTConfiguration : NSObject
 
-@property (nonatomic, readonly, strong) GTRepository *repository;
+@property (nonatomic, readonly, strong, nullable) GTRepository *repository;
 @property (nonatomic, readonly, copy) NSArray *configurationKeys;
 
 /// The GTRemotes in the config. If the configuration isn't associated with any
 /// repository, this will always be nil.
-@property (nonatomic, readonly, copy) NSArray *remotes;
+@property (nonatomic, readonly, copy, nullable) NSArray *remotes;
 
 /// Creates and returns a configuration which includes the global, XDG, and
 /// system configurations.
-+ (instancetype)defaultConfiguration;
++ (nullable instancetype)defaultConfiguration;
 
 /// The underlying `git_config` object.
 - (git_config *)git_config __attribute__((objc_returns_inner_pointer));
 
 - (void)setString:(NSString *)s forKey:(NSString *)key;
-- (NSString *)stringForKey:(NSString *)key;
+- (nullable NSString *)stringForKey:(NSString *)key;
 
 - (void)setBool:(BOOL)b forKey:(NSString *)key;
 - (BOOL)boolForKey:(NSString *)key;
@@ -43,3 +45,5 @@
 - (BOOL)deleteValueForKey:(NSString *)key error:(NSError **)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTConfiguration.m
+++ b/ObjectiveGit/GTConfiguration.m
@@ -33,7 +33,7 @@
 	}
 }
 
-- (id)initWithGitConfig:(git_config *)config repository:(GTRepository *)repository {
+- (instancetype)initWithGitConfig:(git_config *)config repository:(GTRepository *)repository {
 	NSParameterAssert(config != NULL);
 
 	self = [super init];

--- a/ObjectiveGit/GTCredential.h
+++ b/ObjectiveGit/GTCredential.h
@@ -17,6 +17,8 @@ typedef NS_ENUM(NSInteger, GTCredentialType) {
     GTCredentialTypeSSHCustom = GIT_CREDTYPE_SSH_CUSTOM,
 };
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class GTCredential;
 
 /// The GTCredentialProvider acts as a proxy for GTCredential requests.
@@ -29,6 +31,7 @@ typedef NS_ENUM(NSInteger, GTCredentialType) {
 /// Creates a provider from a block.
 ///
 /// credentialBlock - a block that will be called when credentials are requested.
+///                   Must not be nil.
 + (instancetype)providerWithBlock:(GTCredential *(^)(GTCredentialType type, NSString *URL, NSString *userName))credentialBlock;
 
 /// Default credential provider method.
@@ -43,7 +46,7 @@ typedef NS_ENUM(NSInteger, GTCredentialType) {
 /// type     - the credential types allowed by the operation.
 /// URL      - the URL the operation is authenticating against.
 /// userName - the user name provided by the operation. Can be nil, and might be ignored.
-- (GTCredential *)credentialForType:(GTCredentialType)type URL:(NSString *)URL userName:(NSString *)userName;
+- (GTCredential *)credentialForType:(GTCredentialType)type URL:(NSString *)URL userName:(nullable NSString *)userName;
 @end
 
 /// The GTCredential class is used to provide authentication data.
@@ -57,21 +60,23 @@ typedef NS_ENUM(NSInteger, GTCredentialType) {
 /// error    - If not NULL, set to any errors that occur.
 ///
 /// Return a new GTCredential instance, or nil if an error occurred
-+ (instancetype)credentialWithUserName:(NSString *)userName password:(NSString *)password error:(NSError **)error;
++ (nullable instancetype)credentialWithUserName:(NSString *)userName password:(NSString *)password error:(NSError **)error;
 
 /// Create a credential object from a SSH keyfile
 ///
-/// userName      - The username to authenticate as.
+/// userName      - The username to authenticate as. Must not be nil.
 /// publicKeyURL  - The URL to the public key for that user.
 ///                  Can be omitted to reconstruct the public key from the private key.
-/// privateKeyURL - The URL to the private key for that user.
+/// privateKeyURL - The URL to the private key for that user. Must not be nil.
 /// passphrase    - The passPhrase for the private key. Optional if the private key has no password.
 /// error         - If not NULL, set to any errors that occur.
 ///
 /// Return a new GTCredential instance, or nil if an error occurred
-+ (instancetype)credentialWithUserName:(NSString *)userName publicKeyURL:(NSURL *)publicKeyURL privateKeyURL:(NSURL *)privateKeyURL passphrase:(NSString *)passphrase error:(NSError **)error;
++ (nullable instancetype)credentialWithUserName:(NSString *)userName publicKeyURL:(nullable NSURL *)publicKeyURL privateKeyURL:(NSURL *)privateKeyURL passphrase:(nullable NSString *)passphrase error:(NSError **)error;
 
 /// The underlying `git_cred` object.
 - (git_cred *)git_cred __attribute__((objc_returns_inner_pointer));
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTCredential.m
+++ b/ObjectiveGit/GTCredential.m
@@ -19,6 +19,7 @@ typedef GTCredential *(^GTCredentialProviderBlock)(GTCredentialType allowedTypes
 @end
 
 @implementation GTCredentialProvider
+
 + (instancetype)providerWithBlock:(GTCredentialProviderBlock)credentialBlock {
 	NSParameterAssert(credentialBlock != nil);
 

--- a/ObjectiveGit/GTDiff+Private.h
+++ b/ObjectiveGit/GTDiff+Private.h
@@ -14,6 +14,6 @@
 /// provides a pointer to that structure to the given `block`.
 ///
 /// Returns the result of invoking `block`.
-+ (int)handleParsedOptionsDictionary:(NSDictionary *)dictionary usingBlock:(int (^)(git_diff_options *optionsStruct))block;
++ (int)handleParsedOptionsDictionary:(nullable NSDictionary *)dictionary usingBlock:(int (^)(git_diff_options *optionsStruct))block;
 
 @end

--- a/ObjectiveGit/GTDiff.h
+++ b/ObjectiveGit/GTDiff.h
@@ -172,6 +172,8 @@ typedef NS_OPTIONS(NSInteger, GTDiffFindOptionsFlags) {
 	GTDiffFindOptionsFlagsBreakRewritesForRenamesOnly = GIT_DIFF_BREAK_REWRITES_FOR_RENAMES_ONLY,
 };
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A class representing a single "diff".
 ///
 /// Analagous to `git_diff_list` in libgit2, this object represents a list of
@@ -196,7 +198,7 @@ typedef NS_OPTIONS(NSInteger, GTDiffFindOptionsFlags) {
 ///              available.
 ///
 /// Returns a newly created `GTDiff` object or nil on error.
-+ (instancetype)diffOldTree:(GTTree *)oldTree withNewTree:(GTTree *)newTree inRepository:(GTRepository *)repository options:(NSDictionary *)options error:(NSError **)error;
++ (nullable instancetype)diffOldTree:(nullable GTTree *)oldTree withNewTree:(nullable GTTree *)newTree inRepository:(GTRepository *)repository options:(nullable NSDictionary *)options error:(NSError **)error;
 
 /// Create a diff between a repository's current index.
 ///
@@ -216,46 +218,46 @@ typedef NS_OPTIONS(NSInteger, GTDiffFindOptionsFlags) {
 ///              available.
 ///
 /// Returns a newly created `GTDiff` object or nil on error.
-+ (instancetype)diffIndexFromTree:(GTTree *)tree inRepository:(GTRepository *)repository options:(NSDictionary *)options error:(NSError **)error;
++ (nullable instancetype)diffIndexFromTree:(nullable GTTree *)tree inRepository:(nullable GTRepository *)repository options:(nullable NSDictionary *)options error:(NSError **)error;
 
 /// Create a diff between the index and working directory in a given repository.
 ///
 /// This matches the `git diff` command.
 ///
-/// repository - The repository to be used for the diff.
+/// repository - The repository to be used for the diff. May not be nil.
 /// options    - A dictionary containing any of the above options key constants,
 ///              or nil to use the defaults.
 /// error      - Populated with an `NSError` object on error, if information is
 ///              available.
 ///
 /// Returns a newly created `GTDiff` object or nil on error.
-+ (instancetype)diffIndexToWorkingDirectoryInRepository:(GTRepository *)repository options:(NSDictionary *)options error:(NSError **)error;
++ (nullable instancetype)diffIndexToWorkingDirectoryInRepository:(GTRepository *)repository options:(NSDictionary *)options error:(NSError **)error;
 
 /// Create a diff between a repository's working directory and a tree.
 ///
 /// tree       - The tree to be diffed. The tree will be the left side of the diff.
 ///              May be nil to represent an empty tree.
-/// repository - The repository to be used for the diff.
+/// repository - The repository to be used for the diff. May not be nil.
 /// options    - A dictionary containing any of the above options key constants, or
 ///              nil to use the defaults.
 /// error      - Populated with an `NSError` object on error, if information is
 ///              available.
 ///
 /// Returns a newly created `GTDiff` object or nil on error.
-+ (instancetype)diffWorkingDirectoryFromTree:(GTTree *)tree inRepository:(GTRepository *)repository options:(NSDictionary *)options error:(NSError **)error;
++ (nullable instancetype)diffWorkingDirectoryFromTree:(nullable GTTree *)tree inRepository:(GTRepository *)repository options:(nullable NSDictionary *)options error:(NSError **)error;
 
 /// Create a diff between the working directory and HEAD.
 ///
 /// If the repository does not have a HEAD commit yet, this will create a diff of
 /// the working directory as if everything would be part of the initial commit.
 ///
-/// repository - The repository to be used for the diff.
+/// repository - The repository to be used for the diff. May not be nil.
 /// options    - A dictionary containing any of the above options key constants,
 ///              or nil to use the defaults.
 /// error      - Populated if an error occurs.
 ///
 /// Returns a newly created GTDiff, or nil if an error occurred.
-+ (instancetype)diffWorkingDirectoryToHEADInRepository:(GTRepository *)repository options:(NSDictionary *)options error:(NSError **)error;
++ (nullable instancetype)diffWorkingDirectoryToHEADInRepository:(GTRepository *)repository options:(nullable NSDictionary *)options error:(NSError **)error;
 
 /// Designated initialiser.
 ///
@@ -263,7 +265,7 @@ typedef NS_OPTIONS(NSInteger, GTDiffFindOptionsFlags) {
 /// repository - The repository in which the diff lives. Cannot be nil.
 ///
 /// Returns the initialized object.
-- (instancetype)initWithGitDiff:(git_diff *)diff repository:(GTRepository *)repository NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithGitDiff:(git_diff *)diff repository:(GTRepository *)repository NS_DESIGNATED_INITIALIZER;
 
 /// The libgit2 diff object.
 - (git_diff *)git_diff __attribute__((objc_returns_inner_pointer));
@@ -281,14 +283,14 @@ typedef NS_OPTIONS(NSInteger, GTDiffFindOptionsFlags) {
 /// Also note that this method blocks during the enumeration.
 ///
 /// block - A block to be executed for each delta. Setting `stop` to `YES`
-///         immediately stops the enumeration.
+///         immediately stops the enumeration. May not be nil.
 - (void)enumerateDeltasUsingBlock:(void (^)(GTDiffDelta *delta, BOOL *stop))block;
 
 /// Modify the diff list to combine similar changes using the given options.
 ///
 /// options - A dictionary containing any of the above find options key constants
 ///           or nil to use the defaults.
-- (void)findSimilarWithOptions:(NSDictionary *)options;
+- (void)findSimilarWithOptions:(nullable NSDictionary *)options;
 
 /// Merge a diff with another diff.
 ///
@@ -299,3 +301,5 @@ typedef NS_OPTIONS(NSInteger, GTDiffFindOptionsFlags) {
 - (BOOL)mergeDiffWithDiff:(GTDiff *)diff error:(NSError **)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTDiff.h
+++ b/ObjectiveGit/GTDiff.h
@@ -231,7 +231,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///              available.
 ///
 /// Returns a newly created `GTDiff` object or nil on error.
-+ (nullable instancetype)diffIndexToWorkingDirectoryInRepository:(GTRepository *)repository options:(NSDictionary *)options error:(NSError **)error;
++ (nullable instancetype)diffIndexToWorkingDirectoryInRepository:(GTRepository *)repository options:(nullable NSDictionary *)options error:(NSError **)error;
 
 /// Create a diff between a repository's working directory and a tree.
 ///

--- a/ObjectiveGit/GTDiffDelta.h
+++ b/ObjectiveGit/GTDiffDelta.h
@@ -40,6 +40,8 @@ typedef NS_ENUM(NSInteger, GTDiffDeltaType) {
 	GTDiffFileDeltaTypeChange = GIT_DELTA_TYPECHANGE,
 };
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A class representing a single change within a diff.
 ///
 /// The change may not be simply a change of text within a given file, it could
@@ -81,7 +83,7 @@ typedef NS_ENUM(NSInteger, GTDiffDeltaType) {
 /// error       - If not NULL, set to any error that occurs.
 ///
 /// Returns a diff delta, or nil if an error occurs.
-+ (instancetype)diffDeltaFromBlob:(GTBlob *)oldBlob forPath:(NSString *)oldBlobPath toBlob:(GTBlob *)newBlob forPath:(NSString *)newBlobPath options:(NSDictionary *)options error:(NSError **)error;
++ (nullable instancetype)diffDeltaFromBlob:(nullable GTBlob *)oldBlob forPath:(nullable NSString *)oldBlobPath toBlob:(nullable GTBlob *)newBlob forPath:(nullable NSString *)newBlobPath options:(nullable NSDictionary *)options error:(NSError **)error;
 
 /// Diffs the given blob and data buffer.
 ///
@@ -96,7 +98,7 @@ typedef NS_ENUM(NSInteger, GTDiffDeltaType) {
 /// error    - If not NULL, set to any error that occurs.
 ///
 /// Returns a diff delta, or nil if an error occurs.
-+ (instancetype)diffDeltaFromBlob:(GTBlob *)blob forPath:(NSString *)blobPath toData:(NSData *)data forPath:(NSString *)dataPath options:(NSDictionary *)options error:(NSError **)error;
++ (nullable instancetype)diffDeltaFromBlob:(nullable GTBlob *)blob forPath:(nullable NSString *)blobPath toData:(nullable NSData *)data forPath:(nullable NSString *)dataPath options:(nullable NSDictionary *)options error:(NSError **)error;
 
 /// Diffs the given data buffers.
 ///
@@ -111,10 +113,15 @@ typedef NS_ENUM(NSInteger, GTDiffDeltaType) {
 /// error       - If not NULL, set to any error that occurs.
 ///
 /// Returns a diff delta, or nil if an error occurs.
-+ (instancetype)diffDeltaFromData:(NSData *)oldData forPath:(NSString *)oldDataPath toData:(NSData *)newData forPath:(NSString *)newDataPath options:(NSDictionary *)options error:(NSError **)error;
++ (nullable instancetype)diffDeltaFromData:(nullable NSData *)oldData forPath:(nullable NSString *)oldDataPath toData:(nullable NSData *)newData forPath:(nullable NSString *)newDataPath options:(nullable NSDictionary *)options error:(NSError **)error;
 
 /// Initializes the receiver to wrap the delta at the given index.
-- (instancetype)initWithDiff:(GTDiff *)diff deltaIndex:(NSUInteger)deltaIndex;
+///
+/// diff       - The diff which contains the delta to wrap. Must not be nil.
+/// deltaIndex - The index of the delta within the diff.
+///
+/// Returns a diff delta, or nil if an error occurs.
+- (nullable instancetype)initWithDiff:(GTDiff *)diff deltaIndex:(NSUInteger)deltaIndex;
 
 /// Creates a patch from a text delta.
 ///
@@ -123,6 +130,8 @@ typedef NS_ENUM(NSInteger, GTDiffDeltaType) {
 /// error - If not NULL, set to any error that occurs.
 ///
 /// Returns a new patch, or nil if an error occurs.
-- (GTDiffPatch *)generatePatch:(NSError **)error;
+- (nullable GTDiffPatch *)generatePatch:(NSError **)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTDiffFile.h
+++ b/ObjectiveGit/GTDiffFile.h
@@ -46,7 +46,7 @@ typedef NS_OPTIONS(NSInteger, GTDiffFileFlag) {
 /// The git_diff_file represented by the receiver.
 @property (nonatomic, readonly) git_diff_file git_diff_file;
 
-/// Initializes the receiver with the provided libgit2 object.
+/// Initializes the receiver with the provided libgit2 object. Designated initializer.
 ///
 /// file - The git_diff_file wrapped by the receiver.
 ///

--- a/ObjectiveGit/GTDiffFile.h
+++ b/ObjectiveGit/GTDiffFile.h
@@ -25,6 +25,8 @@ typedef NS_OPTIONS(NSInteger, GTDiffFileFlag) {
 
 @class GTOID;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A class representing a file on one side of a diff.
 @interface GTDiffFile : NSObject
 
@@ -41,7 +43,7 @@ typedef NS_OPTIONS(NSInteger, GTDiffFileFlag) {
 @property (nonatomic, readonly) mode_t mode;
 
 /// The OID for the file.
-@property (nonatomic, readonly, copy) GTOID *OID;
+@property (nonatomic, readonly, copy, nullable) GTOID *OID;
 
 /// The git_diff_file represented by the receiver.
 @property (nonatomic, readonly) git_diff_file git_diff_file;
@@ -51,6 +53,8 @@ typedef NS_OPTIONS(NSInteger, GTDiffFileFlag) {
 /// file - The git_diff_file wrapped by the receiver.
 ///
 /// Returns an initialized GTDiffFile.
-- (instancetype)initWithGitDiffFile:(git_diff_file)file NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithGitDiffFile:(git_diff_file)file NS_DESIGNATED_INITIALIZER;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTDiffHunk.h
+++ b/ObjectiveGit/GTDiffHunk.h
@@ -11,6 +11,8 @@
 @class GTDiffLine;
 @class GTDiffPatch;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A class representing a hunk within a diff patch.
 @interface GTDiffHunk : NSObject
 
@@ -24,7 +26,12 @@
 ///
 /// The contents of a hunk are lazily loaded, therefore we initialise the object
 /// simply with the patch it originates from and which hunk index it represents.
-- (instancetype)initWithPatch:(GTDiffPatch *)patch hunkIndex:(NSUInteger)hunkIndex NS_DESIGNATED_INITIALIZER;
+///
+/// patch     - The patch the hunk originates from. Must not be nil.
+/// hunkIndex - The hunk's index within the patch.
+///
+/// Returns the initialized instance.
+- (nullable instancetype)initWithPatch:(GTDiffPatch *)patch hunkIndex:(NSUInteger)hunkIndex NS_DESIGNATED_INITIALIZER;
 
 /// Perfoms the given block on each line in the hunk.
 ///
@@ -32,9 +39,12 @@
 ///
 /// error - A pointer to an NSError that will be set if one occurs.
 /// block - A block to execute on each line. Setting `stop` to `NO` will
-///         immediately stop the enumeration and return from the method.
+///         immediately stop the enumeration and return from the method. Must not
+///         be nil.
 /// Return YES if the enumeration was successful, NO otherwise (and an error will
 /// be set in `error`).
 - (BOOL)enumerateLinesInHunk:(NSError **)error usingBlock:(void (^)(GTDiffLine *line, BOOL *stop))block;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTDiffLine.h
+++ b/ObjectiveGit/GTDiffLine.h
@@ -21,6 +21,8 @@ typedef NS_ENUM(char, GTDiffLineOrigin) {
 	GTDiffLineOriginDeleteEOFNewLine = GIT_DIFF_LINE_DEL_EOFNL,
 };
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Represents an individual line in a diff hunk.
 @interface GTDiffLine : NSObject
 
@@ -44,6 +46,12 @@ typedef NS_ENUM(char, GTDiffLineOrigin) {
 @property (nonatomic, readonly) NSInteger lineCount;
 
 /// Designated initialiser.
-- (instancetype)initWithGitLine:(const git_diff_line *)line NS_DESIGNATED_INITIALIZER;
+///
+/// line - The diff line to wrap. May not be NULL.
+///
+/// Returns a diff line, or nil if an error occurs.
+- (nullable instancetype)initWithGitLine:(const git_diff_line *)line NS_DESIGNATED_INITIALIZER;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTDiffPatch.h
+++ b/ObjectiveGit/GTDiffPatch.h
@@ -12,6 +12,8 @@
 @class GTDiffHunk;
 @class GTDiffDelta;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Represents one or more text changes to a single file within a diff.
 @interface GTDiffPatch : NSObject
 
@@ -36,7 +38,7 @@
 ///         automatically be freed when the receiver is deallocated. Must not be
 ///         NULL.
 /// delta - The diff delta corresponding to this patch. Must not be nil.
-- (instancetype)initWithGitPatch:(git_patch *)patch delta:(GTDiffDelta *)delta NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithGitPatch:(git_patch *)patch delta:(GTDiffDelta *)delta NS_DESIGNATED_INITIALIZER;
 
 /// Returns the underlying patch object.
 - (git_patch *)git_patch __attribute__((objc_returns_inner_pointer));
@@ -59,10 +61,12 @@
 /// generating hunk content.
 ///
 /// block - A block to be executed for each hunk. Setting `stop` to `YES`
-///         will stop the enumeration after the block returns.
+///         will stop the enumeration after the block returns. May not be nil.
 ///
 /// Returns whether enumeration was successful, or terminated early. If `NO`, an
 /// error occurred during enumeration.
 - (BOOL)enumerateHunksUsingBlock:(void (^)(GTDiffHunk *hunk, BOOL *stop))block;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTDiffPatch.h
+++ b/ObjectiveGit/GTDiffPatch.h
@@ -30,7 +30,7 @@
 /// The number of hunks in this patch.
 @property (nonatomic, readonly) NSUInteger hunkCount;
 
-/// Initializes the receiver to wrap the given patch.
+/// Initializes the receiver to wrap the given patch. Designated initializer.
 ///
 /// patch - The patch object to wrap and take ownership of. This will
 ///         automatically be freed when the receiver is deallocated. Must not be

--- a/ObjectiveGit/GTEnumerator.h
+++ b/ObjectiveGit/GTEnumerator.h
@@ -49,6 +49,8 @@ typedef NS_OPTIONS(unsigned int, GTEnumeratorOptions) {
 @class GTRepository;
 @class GTCommit;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Enumerates the commits in a repository.
 @interface GTEnumerator : NSEnumerator
 
@@ -66,7 +68,7 @@ typedef NS_OPTIONS(unsigned int, GTEnumeratorOptions) {
 /// error - If not NULL, set to any error that occurs.
 ///
 /// Returns an initialized enumerator, or nil if an error occurs.
-- (id)initWithRepository:(GTRepository *)repo error:(NSError **)error;
+- (nullable id)initWithRepository:(GTRepository *)repo error:(NSError **)error;
 
 /// Marks a commit to start traversal from.
 ///
@@ -111,7 +113,7 @@ typedef NS_OPTIONS(unsigned int, GTEnumeratorOptions) {
 /// error - If not NULL, set to any error that occurs during traversal.
 ///
 /// Returns a (possibly empty) array of GTCommits, or nil if an error occurs.
-- (NSArray *)allObjectsWithError:(NSError **)error;
+- (nullable NSArray *)allObjectsWithError:(NSError **)error;
 
 /// Gets the next commit.
 ///
@@ -121,7 +123,7 @@ typedef NS_OPTIONS(unsigned int, GTEnumeratorOptions) {
 /// error   - If not NULL, set to any error that occurs during traversal.
 ///
 /// Returns nil if an error occurs or the receiver is exhausted.
-- (GTCommit *)nextObjectWithSuccess:(BOOL *)success error:(NSError **)error;
+- (nullable GTCommit *)nextObjectWithSuccess:(nullable BOOL *)success error:(NSError **)error;
 
 /// Counts the number of commits that were not enumerated, completely exhausting
 /// the receiver.
@@ -132,3 +134,5 @@ typedef NS_OPTIONS(unsigned int, GTEnumeratorOptions) {
 - (NSUInteger)countRemainingObjects:(NSError **)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTEnumerator.h
+++ b/ObjectiveGit/GTEnumerator.h
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// To set new options, use -resetWithOptions:.
 @property (nonatomic, assign, readonly) GTEnumeratorOptions options;
 
-/// Initializes the receiver to enumerate the commits in the given repository.
+/// Initializes the receiver to enumerate the commits in the given repository. Designated initializer.
 ///
 /// repo  - The repository to enumerate the commits of. This must not be nil.
 /// error - If not NULL, set to any error that occurs.

--- a/ObjectiveGit/GTEnumerator.m
+++ b/ObjectiveGit/GTEnumerator.m
@@ -48,7 +48,7 @@
 
 #pragma mark Lifecycle
 
-- (id)initWithRepository:(GTRepository *)repo error:(NSError **)error {
+- (instancetype)initWithRepository:(GTRepository *)repo error:(NSError **)error {
 	NSParameterAssert(repo != nil);
 
 	self = [super init];

--- a/ObjectiveGit/GTFetchHeadEntry.h
+++ b/ObjectiveGit/GTFetchHeadEntry.h
@@ -12,6 +12,8 @@
 @class GTOID;
 @class GTReference;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A class representing an entry on the FETCH_HEAD file, as returned by the callback of git_repository_fetchhead_foreach.
 @interface GTFetchHeadEntry : NSObject
 
@@ -33,6 +35,10 @@
 /// remoteURLString - URL String where this was originally fetched from. Cannot be nil.
 /// targetOID       - Target OID. Cannot be nil.
 /// merge           - Indicates if this is pending a merge.
-- (instancetype)initWithReference:(GTReference *)reference remoteURLString:(NSString *)remoteURLString targetOID:(GTOID *)targetOID isMerge:(BOOL)merge NS_DESIGNATED_INITIALIZER;
+///
+/// Returns an initialized fetch head entry, or nil if an error occurred.
+- (nullable instancetype)initWithReference:(GTReference *)reference remoteURLString:(NSString *)remoteURLString targetOID:(GTOID *)targetOID isMerge:(BOOL)merge NS_DESIGNATED_INITIALIZER;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTFetchHeadEntry.h
+++ b/ObjectiveGit/GTFetchHeadEntry.h
@@ -27,7 +27,7 @@
 /// Flag indicating if we need to merge this entry or not.
 @property (nonatomic, getter = isMerge, readonly) BOOL merge;
 
-/// Initializes a GTFetchHeadEntry.
+/// Initializes a GTFetchHeadEntry. Designated initializer.
 ///
 /// reference       - Reference on the repository. Cannot be nil.
 /// remoteURLString - URL String where this was originally fetched from. Cannot be nil.

--- a/ObjectiveGit/GTFilter.h
+++ b/ObjectiveGit/GTFilter.h
@@ -17,6 +17,8 @@ extern NSString * const GTFilterErrorDomain;
 /// A filter with that name has already been registered.
 extern const NSInteger GTFilterErrorNameAlreadyRegistered;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Git filter abstraction.
 ///
 /// **Note**: GTFilter is *not* thread safe. Registration and unregistration
@@ -45,15 +47,17 @@ extern const NSInteger GTFilterErrorNameAlreadyRegistered;
 /// applyBlock - The block to use to apply the filter. Cannot be nil.
 ///
 /// Returns the initialized object.
-- (id)initWithName:(NSString *)name attributes:(NSString *)attributes applyBlock:(NSData * (^)(void **payload, NSData *from, GTFilterSource *source, BOOL *applied))applyBlock NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithName:(NSString *)name attributes:(nullable NSString *)attributes applyBlock:(NSData * (^)(void **payload, NSData *from, GTFilterSource *source, BOOL *applied))applyBlock NS_DESIGNATED_INITIALIZER;
 
 /// Look up a filter based on its name.
 ///
 /// Note that this will only find filters registered through
 /// -registerWithName:priority:error:.
 ///
+/// name - The name of the filter to retrieve. Must not be nil.
+///
 /// Returns the filter, or nil if none was found.
-+ (GTFilter *)filterForName:(NSString *)name;
++ (nullable GTFilter *)filterForName:(NSString *)name;
 
 /// Registers the filter with the given priority.
 ///
@@ -73,3 +77,5 @@ extern const NSInteger GTFilterErrorNameAlreadyRegistered;
 - (BOOL)unregister:(NSError **)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTFilter.h
+++ b/ObjectiveGit/GTFilter.h
@@ -38,7 +38,7 @@ extern const NSInteger GTFilterErrorNameAlreadyRegistered;
 /// chance to clean up the `payload`.
 @property (nonatomic, copy) void (^cleanupBlock)(void *payload);
 
-/// Initializes the object with the given name and attributes.
+/// Initializes the object with the given name and attributes. Designated initializer.
 ///
 /// name       - The name for the filter. Cannot be nil.
 /// attributes - The attributes to which this filter applies. May be nil.

--- a/ObjectiveGit/GTFilter.m
+++ b/ObjectiveGit/GTFilter.m
@@ -42,7 +42,7 @@ static NSMutableDictionary *GTFiltersGitFilterToRegisteredFilters = nil;
 	GTFiltersGitFilterToRegisteredFilters = [[NSMutableDictionary alloc] init];
 }
 
-- (id)initWithName:(NSString *)name attributes:(NSString *)attributes applyBlock:(NSData * (^)(void **payload, NSData *from, GTFilterSource *source, BOOL *applied))applyBlock {
+- (instancetype)initWithName:(NSString *)name attributes:(NSString *)attributes applyBlock:(NSData * (^)(void **payload, NSData *from, GTFilterSource *source, BOOL *applied))applyBlock {
 	NSParameterAssert(name != nil);
 	NSParameterAssert(applyBlock != NULL);
 

--- a/ObjectiveGit/GTFilterList.h
+++ b/ObjectiveGit/GTFilterList.h
@@ -21,7 +21,7 @@ typedef NS_OPTIONS(NSInteger, GTFilterListOptions) {
 /// An opaque list of filters that apply to a given path.
 @interface GTFilterList : NSObject
 
-/// Initializes the receiver to wrap the given `git_filter_list`.
+/// Initializes the receiver to wrap the given `git_filter_list`. Designated initializer.
 ///
 /// filterList - The filter list to wrap and take ownership of. This filter list
 ///              will be automatically disposed when the receiver deallocates.

--- a/ObjectiveGit/GTFilterList.h
+++ b/ObjectiveGit/GTFilterList.h
@@ -18,6 +18,8 @@ typedef NS_OPTIONS(NSInteger, GTFilterListOptions) {
 	GTFilterListOptionsAllowUnsafe = GIT_FILTER_ALLOW_UNSAFE,
 };
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// An opaque list of filters that apply to a given path.
 @interface GTFilterList : NSObject
 
@@ -26,7 +28,9 @@ typedef NS_OPTIONS(NSInteger, GTFilterListOptions) {
 /// filterList - The filter list to wrap and take ownership of. This filter list
 ///              will be automatically disposed when the receiver deallocates.
 ///              Must not be NULL.
-- (instancetype)initWithGitFilterList:(git_filter_list *)filterList NS_DESIGNATED_INITIALIZER;
+///
+/// Returns an initialized filter list, or nil if an error occurred.
+- (nullable instancetype)initWithGitFilterList:(git_filter_list *)filterList NS_DESIGNATED_INITIALIZER;
 
 /// Returns the underlying `git_filter_list`.
 - (git_filter_list *)git_filter_list __attribute__((objc_returns_inner_pointer));
@@ -37,7 +41,7 @@ typedef NS_OPTIONS(NSInteger, GTFilterListOptions) {
 /// error     - If not NULL, set to any error that occurs.
 ///
 /// Returns the filtered data, or nil if an error occurs.
-- (NSData *)applyToData:(NSData *)inputData error:(NSError **)error;
+- (nullable NSData *)applyToData:(NSData *)inputData error:(NSError **)error;
 
 /// Attempts to apply the filter list to a file in the given repository.
 ///
@@ -47,7 +51,7 @@ typedef NS_OPTIONS(NSInteger, GTFilterListOptions) {
 /// error        - If not NULL, set to any error that occurs.
 ///
 /// Returns the filtered data, or nil if an error occurs.
-- (NSData *)applyToPath:(NSString *)relativePath inRepository:(GTRepository *)repository error:(NSError **)error;
+- (nullable NSData *)applyToPath:(NSString *)relativePath inRepository:(GTRepository *)repository error:(NSError **)error;
 
 /// Attempts to apply the filter list to a blob.
 ///
@@ -55,6 +59,8 @@ typedef NS_OPTIONS(NSInteger, GTFilterListOptions) {
 /// error - If not NULL, set to any error that occurs.
 ///
 /// Returns the filtered data, or nil if an error occurs.
-- (NSData *)applyToBlob:(GTBlob *)blob error:(NSError **)error;
+- (nullable NSData *)applyToBlob:(GTBlob *)blob error:(NSError **)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTFilterSource.h
+++ b/ObjectiveGit/GTFilterSource.h
@@ -22,6 +22,8 @@ typedef NS_ENUM(NSInteger, GTFilterSourceMode) {
 	GTFilterSourceModeClean = GIT_FILTER_CLEAN,
 };
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A source item for a filter.
 @interface GTFilterSource : NSObject
 
@@ -33,7 +35,7 @@ typedef NS_ENUM(NSInteger, GTFilterSourceMode) {
 
 /// The OID of the source. Will be nil if the source doesn't exist in the object
 /// database.
-@property (nonatomic, readonly, strong) GTOID *OID;
+@property (nonatomic, readonly, strong, nullable) GTOID *OID;
 
 /// The filter mode.
 @property (nonatomic, readonly, assign) GTFilterSourceMode mode;
@@ -43,6 +45,8 @@ typedef NS_ENUM(NSInteger, GTFilterSourceMode) {
 /// source - The filter source. Cannot be NULL.
 ///
 /// Returns the initialized object.
-- (id)initWithGitFilterSource:(const git_filter_source *)source NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithGitFilterSource:(const git_filter_source *)source NS_DESIGNATED_INITIALIZER;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTFilterSource.h
+++ b/ObjectiveGit/GTFilterSource.h
@@ -38,7 +38,7 @@ typedef NS_ENUM(NSInteger, GTFilterSourceMode) {
 /// The filter mode.
 @property (nonatomic, readonly, assign) GTFilterSourceMode mode;
 
-/// Intializes the receiver with the given filter source.
+/// Intializes the receiver with the given filter source. Designated initializer.
 ///
 /// source - The filter source. Cannot be NULL.
 ///

--- a/ObjectiveGit/GTFilterSource.m
+++ b/ObjectiveGit/GTFilterSource.m
@@ -16,7 +16,7 @@
 
 #pragma mark Lifecycle
 
-- (id)initWithGitFilterSource:(const git_filter_source *)source {
+- (instancetype)initWithGitFilterSource:(const git_filter_source *)source {
 	NSParameterAssert(source != NULL);
 
 	self = [super init];

--- a/ObjectiveGit/GTIndex.h
+++ b/ObjectiveGit/GTIndex.h
@@ -69,7 +69,7 @@
 /// Returns the loaded index, or nil if an error occurred.
 + (instancetype)indexWithFileURL:(NSURL *)fileURL repository:(GTRepository *)repository error:(NSError **)error;
 
-/// Initializes the receiver with the given libgit2 index.
+/// Initializes the receiver with the given libgit2 index. Designated initializer.
 ///
 /// index      - The libgit2 index from which the index should be created. Cannot
 ///              be NULL.

--- a/ObjectiveGit/GTIndex.h
+++ b/ObjectiveGit/GTIndex.h
@@ -34,14 +34,16 @@
 @class GTRepository;
 @class GTTree;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GTIndex : NSObject
 
 /// The repository in which the index resides. This may be nil if the index was
 /// created with -initWithFileURL:error:.
-@property (nonatomic, readonly, strong) GTRepository *repository;
+@property (nonatomic, readonly, strong, nullable) GTRepository *repository;
 
-/// The file URL for the index if it exists on disk.
-@property (nonatomic, readonly, copy) NSURL *fileURL;
+/// The file URL for the index if it exists on disk; nil otherwise.
+@property (nonatomic, readonly, copy, nullable) NSURL *fileURL;
 
 /// The number of entries in the index.
 @property (nonatomic, readonly) NSUInteger entryCount;
@@ -58,7 +60,7 @@
 /// error      - If not NULL, set to any error that occurs.
 ///
 /// Returns the newly created index, or nil if an error occurred.
-+ (instancetype)inMemoryIndexWithRepository:(GTRepository *)repository error:(NSError **)error;
++ (nullable instancetype)inMemoryIndexWithRepository:(GTRepository *)repository error:(NSError **)error;
 
 /// Loads the index at the given file URL.
 ///
@@ -101,7 +103,7 @@
 /// index - The index of the entry to get. Must be within 0 and self.entryCount.
 ///
 /// Returns a new GTIndexEntry, or nil if an error occurred.
-- (GTIndexEntry *)entryAtIndex:(NSUInteger)index;
+- (nullable GTIndexEntry *)entryAtIndex:(NSUInteger)index;
 
 /// Get the entry with the given name.
 - (GTIndexEntry *)entryWithName:(NSString *)name;
@@ -112,13 +114,13 @@
 /// error - The error if one occurred.
 ///
 /// Returns a new GTIndexEntry, or nil if an error occurred.
-- (GTIndexEntry *)entryWithName:(NSString *)name error:(NSError **)error;
+- (nullable GTIndexEntry *)entryWithName:(NSString *)name error:(NSError **)error;
 
 /// Add an entry to the index.
 ///
 /// Note that this *cannot* add submodules. See -[GTSubmodule addToIndex:].
 ///
-/// entry - The entry to add.
+/// entry - The entry to add. Must not be nil.
 /// error - The error if one occurred.
 ///
 /// Returns YES if successful, NO otherwise.
@@ -167,7 +169,7 @@
 /// error - The error if one occurred.
 ///
 /// Returns a new GTTree, or nil if an error occurred.
-- (GTTree *)writeTree:(NSError **)error;
+- (nullable GTTree *)writeTree:(NSError **)error;
 
 /// Write the index to the given repository as a tree.
 /// Will fail if the receiver's index has conflicts.
@@ -176,7 +178,7 @@
 /// error      - The error if one occurred.
 ///
 /// Returns a new GTTree or nil if an error occurred.
-- (GTTree *)writeTreeToRepository:(GTRepository *)repository error:(NSError **)error;
+- (nullable GTTree *)writeTreeToRepository:(GTRepository *)repository error:(NSError **)error;
 
 /// Enumerate through any conflicts in the index, running the provided block each
 /// time.
@@ -209,3 +211,5 @@
 - (BOOL)updatePathspecs:(NSArray *)pathspecs error:(NSError **)error passingTest:(BOOL (^)(NSString *matchedPathspec, NSString *path, BOOL *stop))block;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTIndex.h
+++ b/ObjectiveGit/GTIndex.h
@@ -199,16 +199,18 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// pathspecs - An `NSString` array of path patterns. (E.g: *.c)
 ///             If nil is passed in, all index entries will be updated.
-/// block     - A block run each time a pathspec is matched; before the index is updated.
-///             The `matchedPathspec` parameter is a string indicating what the pathspec (from `pathspecs`) matched.
-///             If you pass in NULL in to the `pathspecs` parameter this parameter will be empty.
-///             The `path` parameter is a repository relative path to the file about to be updated.
+/// block     - A block run each time a pathspec is matched; before the index is
+///             updated. The `matchedPathspec` parameter is a string indicating
+///             what the pathspec (from `pathspecs`) matched. If you pass in NULL
+///             in to the `pathspecs` parameter this parameter will be empty.
+///             The `path` parameter is a repository relative path to the file
+///             about to be updated.
 ///             The `stop` parameter can be set to `YES` to abort the operation.
 ///             Return `YES` to update the given path, or `NO` to skip it. May be nil.
 /// error     - When something goes wrong, this parameter is set. Optional.
 ///
 /// Returns `YES` in the event that everything has gone smoothly. Otherwise, `NO`.
-- (BOOL)updatePathspecs:(NSArray *)pathspecs error:(NSError **)error passingTest:(BOOL (^)(NSString *matchedPathspec, NSString *path, BOOL *stop))block;
+- (BOOL)updatePathspecs:(nullable NSArray *)pathspecs error:(NSError **)error passingTest:(nullable BOOL (^)(NSString *matchedPathspec, NSString *path, BOOL *stop))block;
 
 @end
 

--- a/ObjectiveGit/GTIndexEntry.h
+++ b/ObjectiveGit/GTIndexEntry.h
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// error - will be filled if an error occurs
 ///
 /// Returns the initialized object.
-- (instancetype)initWithGitIndexEntry:(const git_index_entry *)entry index:(GTIndex *)index error:(NSError **)error NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithGitIndexEntry:(const git_index_entry *)entry index:(nullable GTIndex *)index error:(NSError **)error NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithGitIndexEntry:(const git_index_entry *)entry;
 
 /// The underlying `git_index_entry` object.

--- a/ObjectiveGit/GTIndexEntry.h
+++ b/ObjectiveGit/GTIndexEntry.h
@@ -49,7 +49,7 @@ typedef NS_ENUM(NSInteger, GTIndexEntryStatus) {
 /// What is the entry's status?
 @property (nonatomic, readonly) GTIndexEntryStatus status;
 
-/// Initializes the receiver with the given libgit2 index entry.
+/// Initializes the receiver with the given libgit2 index entry. Designated initializer.
 ///
 /// entry - The libgit2 index entry. Cannot be NULL.
 ///

--- a/ObjectiveGit/GTIndexEntry.h
+++ b/ObjectiveGit/GTIndexEntry.h
@@ -38,6 +38,8 @@ typedef NS_ENUM(NSInteger, GTIndexEntryStatus) {
 	GTIndexEntryStatusUpToDate,
 };
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GTIndexEntry : NSObject
 
 /// The repository-relative path for the entry.
@@ -54,9 +56,11 @@ typedef NS_ENUM(NSInteger, GTIndexEntryStatus) {
 /// entry - The libgit2 index entry. Cannot be NULL.
 ///
 /// Returns the initialized object.
-- (id)initWithGitIndexEntry:(const git_index_entry *)entry NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithGitIndexEntry:(const git_index_entry *)entry NS_DESIGNATED_INITIALIZER;
 
 /// The underlying `git_index_entry` object.
 - (const git_index_entry *)git_index_entry __attribute__((objc_returns_inner_pointer));
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTIndexEntry.m
+++ b/ObjectiveGit/GTIndexEntry.m
@@ -45,7 +45,7 @@
 
 #pragma mark Lifecycle
 
-- (id)initWithGitIndexEntry:(const git_index_entry *)entry {
+- (instancetype)initWithGitIndexEntry:(const git_index_entry *)entry {
 	NSParameterAssert(entry != NULL);
 
 	self = [super init];

--- a/ObjectiveGit/GTOID.h
+++ b/ObjectiveGit/GTOID.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// inserted into the ODB yet.
 @property (nonatomic, readonly, assign, getter = isZero) BOOL zero;
 
-/// Initializes the receiver with the given git_oid.
+/// Initializes the receiver with the given git_oid. Designated initializer.
 ///
 /// git_oid - The underlying git_oid. Cannot be NULL.
 ///

--- a/ObjectiveGit/GTOID.h
+++ b/ObjectiveGit/GTOID.h
@@ -10,11 +10,13 @@
 #import "git2/oid.h"
 #import "GTObject.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Represents an object ID.
 @interface GTOID : NSObject <NSCopying>
 
 /// The SHA pointed to by the OID.
-@property (nonatomic, readonly, copy) NSString *SHA;
+@property (nonatomic, readonly, copy, nullable) NSString *SHA;
 
 /// Is the OID all zero? This usually indicates that the object has not been
 /// inserted into the ODB yet.
@@ -25,14 +27,14 @@
 /// git_oid - The underlying git_oid. Cannot be NULL.
 ///
 /// Returns the initialized receiver.
-- (id)initWithGitOid:(const git_oid *)git_oid;
+- (nullable id)initWithGitOid:(const git_oid *)git_oid;
 
 /// Initializes the receiver by converting the given SHA to an OID.
 ///
 /// SHA - The to convert to an OID. Cannot be nil.
 ///
 /// Returns the initialized receiver.
-- (id)initWithSHA:(NSString *)SHA;
+- (nullable id)initWithSHA:(NSString *)SHA;
 
 /// Initializes the receiver by converting the given SHA to an OID
 /// optionally returning a NSError instance on failure.
@@ -41,14 +43,14 @@
 /// error - Will be filled with an error object in if the SHA cannot be parsed
 ///
 /// Returns the initialized receiver or nil if an error occured.
-- (id)initWithSHA:(NSString *)SHA error:(NSError **)error;
+- (nullable id)initWithSHA:(NSString *)SHA error:(NSError **)error;
 
 /// Initializes the receiver by converting the given SHA C string to an OID.
 ///
 /// string - The C string to convert. Cannot be NULL.
 ///
 /// Returns the initialized receiver.
-- (id)initWithSHACString:(const char *)string;
+- (nullable id)initWithSHACString:(const char *)string;
 
 /// Initializes the receiver by converting the given SHA C string to an OID
 /// optionally returning a NSError instance on failure.
@@ -57,16 +59,16 @@
 /// error  - Will be filled with an error object in if the SHA cannot be parsed
 ///
 /// Returns the initialized receiver.
-- (id)initWithSHACString:(const char *)string error:(NSError **)error;
+- (nullable id)initWithSHACString:(const char *)string error:(NSError **)error;
 
 /// Creates a new instance with the given git_oid using initWithGitOid:
-+ (instancetype)oidWithGitOid:(const git_oid *)git_oid;
++ (nullable instancetype)oidWithGitOid:(const git_oid *)git_oid;
 
 /// Creates a new instance from the given SHA string using initWithSHAString:
-+ (instancetype)oidWithSHA:(NSString *)SHA;
++ (nullable instancetype)oidWithSHA:(NSString *)SHA;
 
 /// Creates a new instance from the given SHA C string using initWithSHACString:
-+ (instancetype)oidWithSHACString:(const char *)SHA;
++ (nullable instancetype)oidWithSHACString:(const char *)SHA;
 
 /// Returns the underlying git_oid struct.
 - (const git_oid *)git_oid __attribute__((objc_returns_inner_pointer));
@@ -81,6 +83,8 @@
 /// type - The type of the git object.
 ///
 /// Returns a new OID, or nil if an error occurred.
-+ (instancetype)OIDByHashingData:(NSData *)data type:(GTObjectType)type error:(NSError **)error;
++ (nullable instancetype)OIDByHashingData:(NSData *)data type:(GTObjectType)type error:(NSError **)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTOID.h
+++ b/ObjectiveGit/GTOID.h
@@ -27,14 +27,14 @@ NS_ASSUME_NONNULL_BEGIN
 /// git_oid - The underlying git_oid. Cannot be NULL.
 ///
 /// Returns the initialized receiver.
-- (nullable id)initWithGitOid:(const git_oid *)git_oid NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithGitOid:(const git_oid *)git_oid NS_DESIGNATED_INITIALIZER;
 
 /// Initializes the receiver by converting the given SHA to an OID.
 ///
 /// SHA - The to convert to an OID. Cannot be nil.
 ///
 /// Returns the initialized receiver.
-- (nullable id)initWithSHA:(NSString *)SHA;
+- (nullable instancetype)initWithSHA:(NSString *)SHA;
 
 /// Initializes the receiver by converting the given SHA to an OID
 /// optionally returning a NSError instance on failure.
@@ -43,14 +43,14 @@ NS_ASSUME_NONNULL_BEGIN
 /// error - Will be filled with an error object in if the SHA cannot be parsed
 ///
 /// Returns the initialized receiver or nil if an error occured.
-- (nullable id)initWithSHA:(NSString *)SHA error:(NSError **)error;
+- (nullable instancetype)initWithSHA:(NSString *)SHA error:(NSError **)error;
 
 /// Initializes the receiver by converting the given SHA C string to an OID.
 ///
 /// string - The C string to convert. Cannot be NULL.
 ///
 /// Returns the initialized receiver.
-- (nullable id)initWithSHACString:(const char *)string;
+- (nullable instancetype)initWithSHACString:(const char *)string;
 
 /// Initializes the receiver by converting the given SHA C string to an OID
 /// optionally returning a NSError instance on failure.
@@ -59,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// error  - Will be filled with an error object in if the SHA cannot be parsed
 ///
 /// Returns the initialized receiver.
-- (nullable id)initWithSHACString:(const char *)string error:(NSError **)error NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithSHACString:(const char *)string error:(NSError **)error NS_DESIGNATED_INITIALIZER;
 
 /// Creates a new instance with the given git_oid using initWithGitOid:
 + (nullable instancetype)oidWithGitOid:(const git_oid *)git_oid;

--- a/ObjectiveGit/GTOID.m
+++ b/ObjectiveGit/GTOID.m
@@ -39,7 +39,7 @@
 
 #pragma mark Lifecycle
 
-- (id)initWithGitOid:(const git_oid *)oid {
+- (instancetype)initWithGitOid:(const git_oid *)oid {
 	NSParameterAssert(oid != NULL);
 
 	self = [super init];
@@ -50,16 +50,16 @@
 	return self;
 }
 
-- (id)initWithSHA:(NSString *)SHA error:(NSError **)error {
+- (instancetype)initWithSHA:(NSString *)SHA error:(NSError **)error {
 	NSParameterAssert(SHA != nil);
 	return [self initWithSHACString:SHA.UTF8String error:error];
 }
 
-- (id)initWithSHA:(NSString *)SHA {
+- (instancetype)initWithSHA:(NSString *)SHA {
 	return [self initWithSHA:SHA error:NULL];
 }
 
-- (id)initWithSHACString:(const char *)string error:(NSError **)error {
+- (instancetype)initWithSHACString:(const char *)string error:(NSError **)error {
 	NSParameterAssert(string != NULL);
 	
 	self = [super init];
@@ -76,7 +76,7 @@
 	return self;
 }
 
-- (id)initWithSHACString:(const char *)string {
+- (instancetype)initWithSHACString:(const char *)string {
 	return [self initWithSHACString:string error:NULL];
 }
 

--- a/ObjectiveGit/GTObject.h
+++ b/ObjectiveGit/GTObject.h
@@ -57,8 +57,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, strong) GTRepository *repository;
 @property (nonatomic, readonly, nullable) GTOID *OID;
 
-/// Convenience initializers
+/// Designated initializer.
 - (nullable id)initWithObj:(git_object *)theObject inRepository:(GTRepository *)theRepo NS_DESIGNATED_INITIALIZER;
+
+/// Class convenience initializer
 + (nullable id)objectWithObj:(git_object *)theObject inRepository:(GTRepository *)theRepo;
 
 /// The underlying `git_object`.

--- a/ObjectiveGit/GTObject.h
+++ b/ObjectiveGit/GTObject.h
@@ -47,17 +47,19 @@ typedef NS_ENUM(int, GTObjectType) {
 @class GTOdbObject;
 @class GTOID;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GTObject : NSObject
 
 @property (nonatomic, readonly) NSString *type;
-@property (nonatomic, readonly) NSString *SHA;
-@property (nonatomic, readonly) NSString *shortSHA;
+@property (nonatomic, readonly, nullable) NSString *SHA;
+@property (nonatomic, readonly, nullable) NSString *shortSHA;
 @property (nonatomic, readonly, strong) GTRepository *repository;
-@property (nonatomic, readonly) GTOID *OID;
+@property (nonatomic, readonly, nullable) GTOID *OID;
 
 /// Convenience initializers
-- (id)initWithObj:(git_object *)theObject inRepository:(GTRepository *)theRepo;
-+ (id)objectWithObj:(git_object *)theObject inRepository:(GTRepository *)theRepo;
+- (nullable id)initWithObj:(git_object *)theObject inRepository:(GTRepository *)theRepo;
++ (nullable id)objectWithObj:(git_object *)theObject inRepository:(GTRepository *)theRepo;
 
 /// The underlying `git_object`.
 - (git_object *)git_object __attribute__((objc_returns_inner_pointer));
@@ -67,7 +69,7 @@ typedef NS_ENUM(int, GTObjectType) {
 /// error(out) - will be filled if an error occurs
 ///
 /// returns a GTOdbObject or nil if an error occurred.
-- (GTOdbObject *)odbObjectWithError:(NSError **)error;
+- (nullable GTOdbObject *)odbObjectWithError:(NSError **)error;
 
 /// Recursively peel an object until an object of the specified type is met.
 ///
@@ -78,6 +80,8 @@ typedef NS_ENUM(int, GTObjectType) {
 ///         May be NULL.
 ///
 /// Returns the found object or nil on error.
-- (id)objectByPeelingToType:(GTObjectType)type error:(NSError **)error;
+- (nullable id)objectByPeelingToType:(GTObjectType)type error:(NSError **)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTObjectDatabase.h
+++ b/ObjectiveGit/GTObjectDatabase.h
@@ -27,6 +27,8 @@
 
 @class GTOID;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GTObjectDatabase : NSObject
 
 @property (nonatomic, readonly, strong) GTRepository *repository;
@@ -38,13 +40,13 @@
 /// error - The error if one occurred.
 ///
 /// Returns the initialized object.
-- (id)initWithRepository:(GTRepository *)repo error:(NSError **)error;
+- (nullable id)initWithRepository:(GTRepository *)repo error:(NSError **)error;
 
 /// The underlying `git_odb` object.
 - (git_odb *)git_odb __attribute__((objc_returns_inner_pointer));
 
-- (GTOdbObject *)objectWithOID:(GTOID *)OID error:(NSError **)error;
-- (GTOdbObject *)objectWithSHA:(NSString *)SHA error:(NSError **)error;
+- (nullable GTOdbObject *)objectWithOID:(GTOID *)OID error:(NSError **)error;
+- (nullable GTOdbObject *)objectWithSHA:(NSString *)SHA error:(NSError **)error;
 
 /// Writes the data into the object database.
 ///
@@ -54,7 +56,7 @@
 ///
 /// Returns the OID for the object which was written, or nil if an error
 /// occurred.
-- (GTOID *)writeData:(NSData *)data type:(GTObjectType)type error:(NSError **)error;
+- (nullable GTOID *)writeData:(NSData *)data type:(GTObjectType)type error:(NSError **)error;
 
 - (BOOL)containsObjectWithSHA:(NSString *)SHA error:(NSError **)error;
 
@@ -66,3 +68,5 @@
 - (BOOL)containsObjectWithOID:(GTOID *)oid;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTObjectDatabase.h
+++ b/ObjectiveGit/GTObjectDatabase.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, strong) GTRepository *repository;
 
-/// Initializes the object database with the given repository.
+/// Initializes the object database with the given repository. Designated initializer.
 ///
 /// repo  - The repository from which the object database should be created.
 ///         Cannot be nil.

--- a/ObjectiveGit/GTObjectDatabase.h
+++ b/ObjectiveGit/GTObjectDatabase.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// error - The error if one occurred.
 ///
 /// Returns the initialized object.
-- (nullable id)initWithRepository:(GTRepository *)repo error:(NSError **)error NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithRepository:(GTRepository *)repo error:(NSError **)error NS_DESIGNATED_INITIALIZER;
 
 /// The underlying `git_odb` object.
 - (git_odb *)git_odb __attribute__((objc_returns_inner_pointer));

--- a/ObjectiveGit/GTObjectDatabase.m
+++ b/ObjectiveGit/GTObjectDatabase.m
@@ -56,7 +56,7 @@
 
 #pragma mark API
 
-- (id)initWithRepository:(GTRepository *)repo error:(NSError **)error {
+- (instancetype)initWithRepository:(GTRepository *)repo error:(NSError **)error {
 	NSParameterAssert(repo != nil);
 
 	self = [super init];

--- a/ObjectiveGit/GTOdbObject.h
+++ b/ObjectiveGit/GTOdbObject.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// The repository in which the object resides.
 @property (nonatomic, readonly, strong) GTRepository *repository;
 
-/// Initializes the object with the underlying libgit2 object and repository.
+/// Initializes the object with the underlying libgit2 object and repository. Designated initializer.
 ///
 /// object     - The underlying libgit2 object. Cannot be NULL.
 /// repository - The repository in which the object resides. Cannot be nil.

--- a/ObjectiveGit/GTOdbObject.h
+++ b/ObjectiveGit/GTOdbObject.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// repository - The repository in which the object resides. Cannot be nil.
 ///
 /// Returns the initialized object.
-- (nullable id)initWithOdbObj:(git_odb_object *)object repository:(GTRepository *)repository NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithOdbObj:(git_odb_object *)object repository:(GTRepository *)repository NS_DESIGNATED_INITIALIZER;
 
 /// The underlying `git_odb_object`.
 - (git_odb_object *)git_odb_object __attribute__((objc_returns_inner_pointer));

--- a/ObjectiveGit/GTOdbObject.h
+++ b/ObjectiveGit/GTOdbObject.h
@@ -6,9 +6,9 @@
 //  Copyright 2011 GitHub, Inc. All rights reserved.
 //
 
-
 #import "GTObject.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface GTOdbObject : NSObject
 
@@ -21,17 +21,19 @@
 /// repository - The repository in which the object resides. Cannot be nil.
 ///
 /// Returns the initialized object.
-- (id)initWithOdbObj:(git_odb_object *)object repository:(GTRepository *)repository;
+- (nullable id)initWithOdbObj:(git_odb_object *)object repository:(GTRepository *)repository;
 
 /// The underlying `git_odb_object`.
 - (git_odb_object *)git_odb_object __attribute__((objc_returns_inner_pointer));
 
-- (NSString *)shaHash;
+- (nullable NSString *)shaHash;
 - (GTObjectType)type;
 - (size_t)length;
-- (NSData *)data;
+- (nullable NSData *)data;
 
 /// The object ID of this object.
-@property (nonatomic, readonly) GTOID *OID;
+@property (nonatomic, readonly, nullable) GTOID *OID;
 	
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTOdbObject.m
+++ b/ObjectiveGit/GTOdbObject.m
@@ -31,7 +31,7 @@
 
 #pragma mark API
 
-- (id)initWithOdbObj:(git_odb_object *)object repository:(GTRepository *)repository {
+- (instancetype)initWithOdbObj:(git_odb_object *)object repository:(GTRepository *)repository {
 	NSParameterAssert(object != NULL);
 	NSParameterAssert(repository != nil);
 

--- a/ObjectiveGit/GTReference.h
+++ b/ObjectiveGit/GTReference.h
@@ -61,8 +61,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, strong) GTReflog *reflog;
 
 /// Convenience initializers
-+ (id)referenceByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error;
-- (id)initByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error;
++ (nullable instancetype)referenceByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error;
+- (nullable instancetype)initByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error;
 
 /// Designated initializer.
 ///

--- a/ObjectiveGit/GTReference.h
+++ b/ObjectiveGit/GTReference.h
@@ -39,6 +39,8 @@ typedef NS_OPTIONS(NSInteger, GTReferenceType) {
 	GTReferenceTypeSymbolic =   GIT_REF_SYMBOLIC, /** A reference which points at another reference */
 };
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class GTRepository;
 
 /// A git reference object
@@ -65,7 +67,13 @@ typedef NS_OPTIONS(NSInteger, GTReferenceType) {
 + (id)referenceByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error;
 - (id)initByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error;
 
-- (id)initWithGitReference:(git_reference *)ref repository:(GTRepository *)repository NS_DESIGNATED_INITIALIZER;
+/// Designated initializer.
+///
+/// ref        - The reference to wrap. Must not be nil.
+/// repository - The repository containing the reference. Must not be nil.
+///
+/// Returns the initialized receiver.
+- (nullable id)initWithGitReference:(git_reference *)ref repository:(GTRepository *)repository NS_DESIGNATED_INITIALIZER;
 
 /// The underlying `git_reference` object.
 - (git_reference *)git_reference __attribute__((objc_returns_inner_pointer));
@@ -93,10 +101,10 @@ typedef NS_OPTIONS(NSInteger, GTReferenceType) {
 /// error     - The error if one occurred.
 ///
 /// Returns the updated reference, or nil if an error occurred.
-- (GTReference *)referenceByUpdatingTarget:(NSString *)newTarget message:(NSString *)message error:(NSError **)error;
+- (nullable GTReference *)referenceByUpdatingTarget:(NSString *)newTarget message:(nullable NSString *)message error:(NSError **)error;
 
 /// The name of the reference.
-@property (nonatomic, readonly, copy) NSString *name;
+@property (nonatomic, readonly, copy, nullable) NSString *name;
 
 /// Updates the on-disk reference to the name and returns the renamed reference.
 ///
@@ -106,7 +114,7 @@ typedef NS_OPTIONS(NSInteger, GTReferenceType) {
 /// error   - The error if one occurred.
 ///
 /// Returns the renamed reference, or nil if an error occurred.
-- (GTReference *)referenceByRenaming:(NSString *)newName error:(NSError **)error;
+- (nullable GTReference *)referenceByRenaming:(NSString *)newName error:(NSError **)error;
 
 /// Delete this reference.
 ///
@@ -120,14 +128,14 @@ typedef NS_OPTIONS(NSInteger, GTReferenceType) {
 /// error(out) - will be filled if an error occurs
 ///
 /// returns the peeled GTReference or nil if an error occurred.
-- (GTReference *)resolvedReferenceWithError:(NSError **)error;
+- (nullable GTReference *)resolvedReferenceWithError:(NSError **)error;
 
 /// Reload the reference from disk.
 ///
 /// error - The error if one occurred.
 ///
 /// Returns the reloaded reference, or nil if an error occurred.
-- (GTReference *)reloadedReferenceWithError:(NSError **)error;
+- (nullable GTReference *)reloadedReferenceWithError:(NSError **)error;
 
 /// An error indicating that the git_reference is no longer valid.
 + (NSError *)invalidReferenceError;
@@ -140,3 +148,5 @@ typedef NS_OPTIONS(NSInteger, GTReferenceType) {
 + (BOOL)isValidReferenceName:(NSString *)refName;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTReference.h
+++ b/ObjectiveGit/GTReference.h
@@ -61,11 +61,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, strong) GTReflog *reflog;
 
 /// Convenience initializers
-+ (id)referenceByLookingUpReferencedNamed:(NSString *)refName inRepository:(GTRepository *)theRepo error:(NSError **)error;
-- (id)initByLookingUpReferenceNamed:(NSString *)refName inRepository:(GTRepository *)theRepo error:(NSError **)error;
++ (instancetype)referenceByLookingUpReferencedNamed:(NSString *)refName inRepository:(GTRepository *)theRepo error:(NSError **)error;
+- (instancetype)initByLookingUpReferenceNamed:(NSString *)refName inRepository:(GTRepository *)theRepo error:(NSError **)error;
 
-+ (id)referenceByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error;
-- (id)initByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error;
++ (instancetype)referenceByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error;
+- (instancetype)initByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error;
 
 /// Designated initializer.
 ///
@@ -73,7 +73,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// repository - The repository containing the reference. Must not be nil.
 ///
 /// Returns the initialized receiver.
-- (nullable id)initWithGitReference:(git_reference *)ref repository:(GTRepository *)repository NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithGitReference:(git_reference *)ref repository:(GTRepository *)repository NS_DESIGNATED_INITIALIZER;
 
 /// The underlying `git_reference` object.
 - (git_reference *)git_reference __attribute__((objc_returns_inner_pointer));

--- a/ObjectiveGit/GTReference.m
+++ b/ObjectiveGit/GTReference.m
@@ -70,11 +70,11 @@ static NSString *referenceTypeToString(GTReferenceType type) {
 	return git_reference_is_remote(self.git_reference) != 0;
 }
 
-+ (id)referenceByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error {
++ (instancetype)referenceByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error {
 	return [[self alloc] initByResolvingSymbolicReference:symbolicRef error:error];
 }
 
-- (id)initByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error {
+- (instancetype)initByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error {
 	NSParameterAssert(symbolicRef != nil);
 
 	git_reference *ref = NULL;

--- a/ObjectiveGit/GTReference.m
+++ b/ObjectiveGit/GTReference.m
@@ -69,15 +69,15 @@ static NSString *referenceTypeToString(GTReferenceType type) {
 	return git_reference_is_remote(self.git_reference) != 0;
 }
 
-+ (id)referenceByLookingUpReferencedNamed:(NSString *)refName inRepository:(GTRepository *)theRepo error:(NSError **)error {
++ (instancetype)referenceByLookingUpReferencedNamed:(NSString *)refName inRepository:(GTRepository *)theRepo error:(NSError **)error {
 	return [[self alloc] initByLookingUpReferenceNamed:refName inRepository:theRepo error:error];
 }
 
-+ (id)referenceByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error {
++ (instancetype)referenceByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error {
 	return [[self alloc] initByResolvingSymbolicReference:symbolicRef error:error];
 }
 
-- (id)initByLookingUpReferenceNamed:(NSString *)refName inRepository:(GTRepository *)repo error:(NSError **)error {
+- (instancetype)initByLookingUpReferenceNamed:(NSString *)refName inRepository:(GTRepository *)repo error:(NSError **)error {
 	NSParameterAssert(refName != nil);
 	NSParameterAssert(repo != nil);
 
@@ -91,7 +91,7 @@ static NSString *referenceTypeToString(GTReferenceType type) {
 	return [self initWithGitReference:ref repository:repo];
 }
 
-- (id)initByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error {
+- (instancetype)initByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error {
 	NSParameterAssert(symbolicRef != nil);
 
 	git_reference *ref = NULL;
@@ -104,7 +104,7 @@ static NSString *referenceTypeToString(GTReferenceType type) {
 	return [self initWithGitReference:ref repository:symbolicRef.repository];
 }
 
-- (id)initWithGitReference:(git_reference *)ref repository:(GTRepository *)repo {
+- (instancetype)initWithGitReference:(git_reference *)ref repository:(GTRepository *)repo {
 	NSParameterAssert(ref != NULL);
 	NSParameterAssert(repo != nil);
 

--- a/ObjectiveGit/GTReflog+Private.h
+++ b/ObjectiveGit/GTReflog+Private.h
@@ -12,7 +12,7 @@
 
 @interface GTReflog ()
 
-/// Initializes the receiver with a reference.
+/// Initializes the receiver with a reference. Designated initializer.
 ///
 /// reference - The reference whose reflog is being represented. Cannot be nil.
 ///

--- a/ObjectiveGit/GTReflog+Private.h
+++ b/ObjectiveGit/GTReflog+Private.h
@@ -17,6 +17,6 @@
 /// reference - The reference whose reflog is being represented. Cannot be nil.
 ///
 /// Returns the initialized object.
-- (id)initWithReference:(GTReference *)reference NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithReference:(GTReference *)reference NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/ObjectiveGit/GTReflog.h
+++ b/ObjectiveGit/GTReflog.h
@@ -11,6 +11,8 @@
 @class GTSignature;
 @class GTReflogEntry;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A reflog for a reference. Reflogs should not be created manually. Use
 /// -[GTReference reflog] to get the reflog for a reference.
 @interface GTReflog : NSObject
@@ -32,7 +34,9 @@
 /// index - The reflog entry to get. 0 is the most recent entry. If it is greater
 ///         than `entryCount`, it will assert.
 ///
-/// Returns the entry at that index.
-- (GTReflogEntry *)entryAtIndex:(NSUInteger)index;
+/// Returns the entry at that index or nil if not found.
+- (nullable GTReflogEntry *)entryAtIndex:(NSUInteger)index;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTReflog.m
+++ b/ObjectiveGit/GTReflog.m
@@ -33,7 +33,7 @@
 	if (_git_reflog != NULL) git_reflog_free(_git_reflog);
 }
 
-- (id)initWithReference:(GTReference *)reference {
+- (instancetype)initWithReference:(GTReference *)reference {
 	NSParameterAssert(reference != nil);
 	NSParameterAssert(reference.name != nil);
 

--- a/ObjectiveGit/GTReflogEntry+Private.h
+++ b/ObjectiveGit/GTReflogEntry+Private.h
@@ -11,7 +11,7 @@
 
 @interface GTReflogEntry ()
 
-/// Initializes the receiver with the underlying reflog entry.
+/// Initializes the receiver with the underlying reflog entry. Designated initializer.
 ///
 /// entry  - The reflog entry. Cannot be NULL.
 /// reflog - The reflog in which the entry resides. Cannot be nil.

--- a/ObjectiveGit/GTReflogEntry+Private.h
+++ b/ObjectiveGit/GTReflogEntry+Private.h
@@ -9,6 +9,8 @@
 #import "GTReflogEntry.h"
 #import "git2/types.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GTReflogEntry ()
 
 /// Initializes the receiver with the underlying reflog entry. Designated initializer.
@@ -17,6 +19,8 @@
 /// reflog - The reflog in which the entry resides. Cannot be nil.
 ///
 /// Returns the initialized object.
-- (id)initWithGitReflogEntry:(const git_reflog_entry *)entry reflog:(GTReflog *)reflog NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithGitReflogEntry:(const git_reflog_entry *)entry reflog:(GTReflog *)reflog NS_DESIGNATED_INITIALIZER;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTReflogEntry.h
+++ b/ObjectiveGit/GTReflogEntry.h
@@ -15,15 +15,15 @@
 @interface GTReflogEntry : NSObject
 
 /// The OID of the ref before the entry.
-@property (nonatomic, readonly, strong) GTOID *previousOID;
+@property (nonatomic, readonly, strong, nullable) GTOID *previousOID;
 
 /// The OID of the ref when the entry was made.
-@property (nonatomic, readonly, strong) GTOID *updatedOID;
+@property (nonatomic, readonly, strong, nullable) GTOID *updatedOID;
 
 /// The person who committed the entry.
-@property (nonatomic, readonly, strong) GTSignature *committer;
+@property (nonatomic, readonly, strong, nullable) GTSignature *committer;
 
 /// The message associated with the entry.
-@property (nonatomic, readonly, copy) NSString *message;
+@property (nonatomic, readonly, copy, nullable) NSString *message;
 
 @end

--- a/ObjectiveGit/GTReflogEntry.m
+++ b/ObjectiveGit/GTReflogEntry.m
@@ -27,7 +27,7 @@
 
 #pragma mark Lifecycle
 
-- (id)initWithGitReflogEntry:(const git_reflog_entry *)entry reflog:(GTReflog *)reflog {
+- (instancetype)initWithGitReflogEntry:(const git_reflog_entry *)entry reflog:(GTReflog *)reflog {
 	NSParameterAssert(entry != NULL);
 	NSParameterAssert(reflog != nil);
 

--- a/ObjectiveGit/GTRemote.h
+++ b/ObjectiveGit/GTRemote.h
@@ -23,6 +23,8 @@ typedef enum {
 	GTRemoteDownloadTagsAll = GIT_REMOTE_DOWNLOAD_TAGS_ALL,
 } GTRemoteAutoTagOption;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A class representing a remote for a git repository.
 ///
 /// Analogous to `git_remote` in libgit2.
@@ -32,13 +34,13 @@ typedef enum {
 @property (nonatomic, readonly, strong) GTRepository *repository;
 
 /// The name of the remote.
-@property (nonatomic, readonly, copy) NSString *name;
+@property (nonatomic, readonly, copy, nullable) NSString *name;
 
 /// The URL string for the remote.
-@property (nonatomic, readonly, copy) NSString *URLString;
+@property (nonatomic, readonly, copy, nullable) NSString *URLString;
 
 /// The push URL for the remote, if provided.
-@property (nonatomic, copy) NSString *pushURLString;
+@property (nonatomic, copy, nullable) NSString *pushURLString;
 
 /// Whether the remote is connected or not.
 @property (nonatomic, readonly, getter=isConnected) BOOL connected;
@@ -54,13 +56,13 @@ typedef enum {
 ///
 /// This array will contain NSStrings of the form
 /// `+refs/heads/*:refs/remotes/REMOTE/*`.
-@property (nonatomic, readonly, copy) NSArray *fetchRefspecs;
+@property (nonatomic, readonly, copy, nullable) NSArray *fetchRefspecs;
 
 /// The push refspecs for this remote.
 ///
 /// This array will contain NSStrings of the form
 /// `+refs/heads/*:refs/remotes/REMOTE/*`.
-@property (nonatomic, readonly, copy) NSArray *pushRefspecs;
+@property (nonatomic, readonly, copy, nullable) NSArray *pushRefspecs;
 
 /// Tests if a name is valid
 + (BOOL)isValidRemoteName:(NSString *)name;
@@ -73,7 +75,7 @@ typedef enum {
 /// error     - Will be set if an error occurs.
 ///
 /// Returns a new remote, or nil if an error occurred
-+ (instancetype)createRemoteWithName:(NSString *)name URLString:(NSString *)URLString inRepository:(GTRepository *)repo error:(NSError **)error;
++ (nullable instancetype)createRemoteWithName:(NSString *)name URLString:(NSString *)URLString inRepository:(GTRepository *)repo error:(NSError **)error;
 
 /// Load a remote from a repository.
 ///
@@ -82,13 +84,15 @@ typedef enum {
 /// error - Will be set if an error occurs.
 ///
 /// Returns the loaded remote, or nil if an error occurred.
-+ (instancetype)remoteWithName:(NSString *)name inRepository:(GTRepository *)repo error:(NSError **)error;
++ (nullable instancetype)remoteWithName:(NSString *)name inRepository:(GTRepository *)repo error:(NSError **)error;
 
 /// Initialize a remote from a `git_remote`. Designated initializer.
 ///
 /// remote - The underlying `git_remote` object. Cannot be nil.
 /// repo   - The repository the remote belongs to. Cannot be nil.
-- (instancetype)initWithGitRemote:(git_remote *)remote inRepository:(GTRepository *)repo NS_DESIGNATED_INITIALIZER;
+///
+/// Returns the initialized receiver, or nil if an error occurred.
+- (nullable instancetype)initWithGitRemote:(git_remote *)remote inRepository:(GTRepository *)repo NS_DESIGNATED_INITIALIZER;
 
 /// The underlying `git_remote` object.
 - (git_remote *)git_remote __attribute__((objc_returns_inner_pointer));
@@ -125,3 +129,5 @@ typedef enum {
 - (BOOL)addFetchRefspec:(NSString *)fetchRefspec error:(NSError **)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTRemote.h
+++ b/ObjectiveGit/GTRemote.h
@@ -84,7 +84,7 @@ typedef enum {
 /// Returns the loaded remote, or nil if an error occurred.
 + (instancetype)remoteWithName:(NSString *)name inRepository:(GTRepository *)repo error:(NSError **)error;
 
-/// Initialize a remote from a `git_remote`.
+/// Initialize a remote from a `git_remote`. Designated initializer.
 ///
 /// remote - The underlying `git_remote` object. Cannot be nil.
 /// repo   - The repository the remote belongs to. Cannot be nil.

--- a/ObjectiveGit/GTRepository+Attributes.h
+++ b/ObjectiveGit/GTRepository+Attributes.h
@@ -8,6 +8,8 @@
 
 #import "GTRepository.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GTRepository (Attributes)
 
 /// Look up the value for the attribute of the given name for the given path.
@@ -16,6 +18,8 @@
 /// path - The path to use for the lookup. Cannot be nil.
 ///
 /// Returns the value of the attribute or nil.
-- (NSString *)attributeWithName:(NSString *)name path:(NSString *)path;
+- (nullable NSString *)attributeWithName:(NSString *)name path:(NSString *)path;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTRepository+Committing.h
+++ b/ObjectiveGit/GTRepository+Committing.h
@@ -8,6 +8,8 @@
 
 #import "GTRepository.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GTRepository (Committing)
 
 /// Creates a new commit.
@@ -23,10 +25,12 @@
 /// error     - The error if one occurred.
 ///
 /// Returns the newly created commit, or nil if an error occurred.
-- (GTCommit *)createCommitWithTree:(GTTree *)tree message:(NSString *)message author:(GTSignature *)author committer:(GTSignature *)committer parents:(NSArray *)parents updatingReferenceNamed:(NSString *)refName error:(NSError **)error;
+- (nullable GTCommit *)createCommitWithTree:(GTTree *)tree message:(NSString *)message author:(GTSignature *)author committer:(GTSignature *)committer parents:(nullable NSArray *)parents updatingReferenceNamed:(nullable NSString *)refName error:(NSError **)error;
 
 /// Creates a new commit using +createCommitWithTree:message:author:committer:parents:updatingReferenceNamed:error:
 /// with -userSignatureForNow as both the author and committer.
-- (GTCommit *)createCommitWithTree:(GTTree *)tree message:(NSString *)message parents:(NSArray *)parents updatingReferenceNamed:(NSString *)refName error:(NSError **)error;
+- (nullable GTCommit *)createCommitWithTree:(GTTree *)tree message:(NSString *)message parents:(nullable NSArray *)parents updatingReferenceNamed:(nullable NSString *)refName error:(NSError **)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTRepository+Private.h
+++ b/ObjectiveGit/GTRepository+Private.h
@@ -8,7 +8,13 @@
 
 #import "GTRepository.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GTRepository ()
-- (id)lookUpObjectByGitOid:(const git_oid *)oid objectType:(GTObjectType)type error:(NSError **)error;
-- (id)lookUpObjectByGitOid:(const git_oid *)oid error:(NSError **)error;
+
+- (nullable id)lookUpObjectByGitOid:(const git_oid *)oid objectType:(GTObjectType)type error:(NSError **)error;
+- (nullable id)lookUpObjectByGitOid:(const git_oid *)oid error:(NSError **)error;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTRepository+References.h
+++ b/ObjectiveGit/GTRepository+References.h
@@ -8,6 +8,8 @@
 
 #import "GTrepository.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class GTReference;
 
 @interface GTRepository (References)
@@ -18,6 +20,8 @@
 /// error - The error if one occurs. May be NULL.
 ///
 /// Returns the reference or nil if look up failed.
-- (GTReference *)lookUpReferenceWithName:(NSString *)name error:(NSError **)error;
+- (nullable GTReference *)lookUpReferenceWithName:(NSString *)name error:(NSError **)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTRepository+RemoteOperations.h
+++ b/ObjectiveGit/GTRepository+RemoteOperations.h
@@ -13,27 +13,32 @@
 /// A `GTCredentialProvider`, that will be used to authenticate against the remote.
 extern NSString *const GTRepositoryRemoteOptionsCredentialProvider;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GTRepository (RemoteOperations)
 
 #pragma mark - Fetch
 
 /// Fetch a remote.
 ///
-/// remote  - The remote to fetch from.
-/// options - Options applied to the fetch operation.
+/// remote  - The remote to fetch from. Must not be nil.
+/// options - Options applied to the fetch operation. May be nil.
 ///           Recognized options are :
 ///           `GTRepositoryRemoteOptionsCredentialProvider`
 /// error   - The error if one occurred. Can be NULL.
+/// progressBlock - Optional callback to receive fetch progress stats during the
+///                 transfer. May be nil.
 ///
 /// Returns YES if the fetch was successful, NO otherwise (and `error`, if provided,
 /// will point to an error describing what happened).
-- (BOOL)fetchRemote:(GTRemote *)remote withOptions:(NSDictionary *)options error:(NSError **)error progress:(void (^)(const git_transfer_progress *stats, BOOL *stop))progressBlock;
+- (BOOL)fetchRemote:(GTRemote *)remote withOptions:(nullable NSDictionary *)options error:(NSError **)error progress:(nullable void (^)(const git_transfer_progress *stats, BOOL *stop))progressBlock;
 
 /// Enumerate all available fetch head entries.
 ///
 /// error - The error if one ocurred. Can be NULL.
-/// block - A block to execute for each FETCH_HEAD entry. `fetchHeadEntry` will be the current
-///         fetch head entry. Setting `stop` to YES will cause enumeration to stop after the block returns.
+/// block - A block to execute for each FETCH_HEAD entry. `fetchHeadEntry` will
+///         be the current fetch head entry. Setting `stop` to YES will cause
+///         enumeration to stop after the block returns. Must not be nil.
 ///
 /// Returns YES if the operation succedded, NO otherwise.
 - (BOOL)enumerateFetchHeadEntriesWithError:(NSError **)error usingBlock:(void (^)(GTFetchHeadEntry *fetchHeadEntry, BOOL *stop))block;
@@ -42,7 +47,7 @@ extern NSString *const GTRepositoryRemoteOptionsCredentialProvider;
 ///
 /// error - The error if one ocurred. Can be NULL.
 ///
-/// Retruns an array with GTFetchHeadEntry objects
+/// Retruns a (possibly empty) array with GTFetchHeadEntry objects. Will not be nil.
 - (NSArray *)fetchHeadEntriesWithError:(NSError **)error;
 
 #pragma mark - Push
@@ -55,11 +60,11 @@ extern NSString *const GTRepositoryRemoteOptionsCredentialProvider;
 ///                 Recognized options are:
 ///                 `GTRepositoryRemoteOptionsCredentialProvider`
 /// error         - The error if one occurred. Can be NULL.
-/// progressBlock - An optional callback for monitoring progress.
+/// progressBlock - An optional callback for monitoring progress. May be NULL.
 ///
 /// Returns YES if the push was successful, NO otherwise (and `error`, if provided,
 /// will point to an error describing what happened).
-- (BOOL)pushBranch:(GTBranch *)branch toRemote:(GTRemote *)remote withOptions:(NSDictionary *)options error:(NSError **)error progress:(void (^)(unsigned int current, unsigned int total, size_t bytes, BOOL *stop))progressBlock;
+- (BOOL)pushBranch:(GTBranch *)branch toRemote:(GTRemote *)remote withOptions:(nullable NSDictionary *)options error:(NSError **)error progress:(nullable void (^)(unsigned int current, unsigned int total, size_t bytes, BOOL *stop))progressBlock;
 
 /// Push an array of branches to a remote.
 ///
@@ -69,10 +74,12 @@ extern NSString *const GTRepositoryRemoteOptionsCredentialProvider;
 ///                 Recognized options are:
 ///                 `GTRepositoryRemoteOptionsCredentialProvider`
 /// error         - The error if one occurred. Can be NULL.
-/// progressBlock - An optional callback for monitoring progress.
+/// progressBlock - An optional callback for monitoring progress. May be NULL.
 ///
 /// Returns YES if the push was successful, NO otherwise (and `error`, if provided,
 /// will point to an error describing what happened).
-- (BOOL)pushBranches:(NSArray *)branches toRemote:(GTRemote *)remote withOptions:(NSDictionary *)options error:(NSError **)error progress:(void (^)(unsigned int current, unsigned int total, size_t bytes, BOOL *stop))progressBlock;
+- (BOOL)pushBranches:(NSArray *)branches toRemote:(GTRemote *)remote withOptions:(nullable NSDictionary *)options error:(NSError **)error progress:(nullable void (^)(unsigned int current, unsigned int total, size_t bytes, BOOL *stop))progressBlock;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTRepository+RemoteOperations.h
+++ b/ObjectiveGit/GTRepository+RemoteOperations.h
@@ -91,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// Returns YES if the push was successful, NO otherwise (and `error`, if provided,
 /// will point to an error describing what happened).
-- (BOOL)deleteBranch:(GTBranch *)branch fromRemote:(GTRemote *)remote withOptions:(NSDictionary *)options error:(NSError **)error;
+- (BOOL)deleteBranch:(GTBranch *)branch fromRemote:(GTRemote *)remote withOptions:(nullable NSDictionary *)options error:(NSError **)error;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTRepository+Reset.h
+++ b/ObjectiveGit/GTRepository+Reset.h
@@ -17,6 +17,8 @@ typedef NS_ENUM(NSInteger, GTRepositoryResetType) {
 	GTRepositoryResetTypeHard = GIT_RESET_HARD,
 };
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GTRepository (Reset)
 
 /// Reset the repository's HEAD to the given commit.
@@ -38,3 +40,5 @@ typedef NS_ENUM(NSInteger, GTRepositoryResetType) {
 - (BOOL)resetPathspecs:(NSArray *)pathspecs toCommit:(GTCommit *)commit error:(NSError **)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTRepository+Stashing.h
+++ b/ObjectiveGit/GTRepository+Stashing.h
@@ -19,6 +19,8 @@ typedef NS_OPTIONS(NSInteger, GTRepositoryStashFlag) {
 	GTRepositoryStashFlagIncludeIgnored = GIT_STASH_INCLUDE_IGNORED
 };
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GTRepository (Stashing)
 
 /// Stash the repository's changes.
@@ -30,14 +32,14 @@ typedef NS_OPTIONS(NSInteger, GTRepositoryStashFlag) {
 ///
 /// Returns a commit representing the stashed changes if successful, or nil
 /// otherwise.
-- (GTCommit *)stashChangesWithMessage:(NSString *)message flags:(GTRepositoryStashFlag)flags error:(NSError **)error;
+- (nullable GTCommit *)stashChangesWithMessage:(nullable NSString *)message flags:(GTRepositoryStashFlag)flags error:(NSError **)error;
 
 /// Enumerate over all the stashes in the repository, from most recent to oldest.
 ///
 /// block - A block to execute for each stash found. `index` will be the zero-based
 ///         stash index (where 0 is the most recent stash). Setting `stop` to YES
-///         will cause enumeration to stop after the block returns.
-- (void)enumerateStashesUsingBlock:(void (^)(NSUInteger index, NSString *message, GTOID *oid, BOOL *stop))block;
+///         will cause enumeration to stop after the block returns. Must not be nil.
+- (void)enumerateStashesUsingBlock:(void (^)(NSUInteger index, NSString * __nullable message, GTOID * __nullable oid, BOOL *stop))block;
 
 /// Drop a stash from the repository's list of stashes.
 ///
@@ -48,3 +50,5 @@ typedef NS_OPTIONS(NSInteger, GTRepositoryStashFlag) {
 - (BOOL)dropStashAtIndex:(NSUInteger)index error:(NSError **)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTRepository+Status.h
+++ b/ObjectiveGit/GTRepository+Status.h
@@ -81,6 +81,8 @@ typedef enum {
 /// Defaults to including all files.
 extern NSString *const GTRepositoryStatusOptionsPathSpecArrayKey;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GTRepository (Status)
 
 /// `YES` if the working directory has no modified, new, or deleted files.
@@ -111,12 +113,26 @@ extern NSString *const GTRepositoryStatusOptionsPathSpecArrayKey;
 ///
 /// Returns `NO` in case of a failure or `YES` if the enumeration completed
 /// successfully.
-- (BOOL)enumerateFileStatusWithOptions:(NSDictionary *)options error:(NSError **)error usingBlock:(void (^)(GTStatusDelta *headToIndex, GTStatusDelta *indexToWorkingDirectory, BOOL *stop))block;
+- (BOOL)enumerateFileStatusWithOptions:(nullable NSDictionary *)options error:(NSError **)error usingBlock:(nullable void (^)(GTStatusDelta * __nullable headToIndex, GTStatusDelta * __nullable indexToWorkingDirectory, BOOL *stop))block;
 
 /// Query the status of one file
-- (GTFileStatusFlags)statusForFile:(NSString *)filePath success:(BOOL *)success error:(NSError **)error;
+///
+/// filePath - A string path relative to the working copy. The must not be nil.
+/// success  - If not NULL, will be set to indicate success or fail.
+/// error    - If not nil, set to any error that occurs.
+///
+/// Returns the combined GTFileStatusFlags for the file.
+- (GTFileStatusFlags)statusForFile:(NSString *)filePath success:(nullable BOOL *)success error:(NSError **)error;
 
-/// Should the file be considered as ignored ?
-- (BOOL)shouldFileBeIgnored:(NSURL *)fileURL success:(BOOL *)success error:(NSError **)error;
+/// Tests the ignore rules to see if the file should be considered as ignored.
+///
+/// fileURL  - A string path relative to the working copy. Must not be nil.
+/// success  - If not NULL, will be set to indicate success or fail.
+/// error    - If not nil, set to any error that occurs.
+///
+/// Returns YES if the file should be ignored; NO otherwise.
+- (BOOL)shouldFileBeIgnored:(NSURL *)fileURL success:(nullable BOOL *)success error:(NSError **)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTRepository.h
+++ b/ObjectiveGit/GTRepository.h
@@ -148,12 +148,14 @@ extern NSString * const GTRepositoryInitOptionsInitialHEAD;
 /// initialization.
 extern NSString * const GTRepositoryInitOptionsOriginURLString;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GTRepository : NSObject
 
 /// The file URL for the repository's working directory.
 @property (nonatomic, readonly, strong) NSURL *fileURL;
 /// The file URL for the repository's .git directory.
-@property (nonatomic, readonly, strong) NSURL *gitDirectoryURL;
+@property (nonatomic, readonly, strong, nullable) NSURL *gitDirectoryURL;
 
 /// Is this a bare repository (one without a working directory)?
 @property (nonatomic, readonly, getter = isBare) BOOL bare;
@@ -175,27 +177,40 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 /// error   - The error if one occurs.
 ///
 /// Returns the initialized repository, or nil if an error occurred.
-+ (instancetype)initializeEmptyRepositoryAtFileURL:(NSURL *)fileURL options:(NSDictionary *)options error:(NSError **)error;
++ (nullable instancetype)initializeEmptyRepositoryAtFileURL:(NSURL *)fileURL options:(nullable NSDictionary *)options error:(NSError **)error;
 
-+ (id)repositoryWithURL:(NSURL *)localFileURL error:(NSError **)error;
-- (id)initWithURL:(NSURL *)localFileURL error:(NSError **)error;
+/// Convenience class initializer which uses the default options.
+///
+/// localFileURL - The file URL for the new repository. Cannot be nil.
+/// error        - The error if one occurs.
+///
+/// Returns the initialized repository, or nil if an error occurred.
++ (nullable instancetype)repositoryWithURL:(NSURL *)localFileURL error:(NSError **)error;
 
-/// Initializes the receiver to wrap the given repository object.
+/// Convenience initializer which uses the default options.
+///
+/// localFileURL - The file URL for the new repository. Cannot be nil.
+/// error        - The error if one occurs.
+///
+/// Returns the initialized repository, or nil if an error occurred.
+- (nullable instancetype)initWithURL:(NSURL *)localFileURL error:(NSError **)error;
+
+/// Initializes the receiver to wrap the given repository object. Designated initializer.
 ///
 /// repository - The repository to wrap. The receiver will take over memory
 ///              management of this object, so it must not be freed elsewhere
 ///              after this method is invoked. This must not be nil.
 ///
-/// Returns an initialized GTRepository.
-- (id)initWithGitRepository:(git_repository *)repository NS_DESIGNATED_INITIALIZER;
+/// Returns an initialized GTRepository, or nil if an erroe occurred.
+- (nullable instancetype)initWithGitRepository:(git_repository *)repository NS_DESIGNATED_INITIALIZER;
 
 /// The underlying `git_repository` object.
 - (git_repository *)git_repository __attribute__((objc_returns_inner_pointer));
 
 /// Clone a repository
 ///
-/// originURL             - The URL to clone from.
-/// workdirURL            - A URL to the desired working directory on the local machine.
+/// originURL             - The URL to clone from. Must not be nil.
+/// workdirURL            - A URL to the desired working directory on the local machine. Must not be nil.
 /// options               - A dictionary consisting of the options:
 ///                         `GTRepositoryCloneOptionsTransportFlags`,
 ///                         `GTRepositoryCloneOptionsBare`,
@@ -205,20 +220,22 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 ///                         `GTRepositoryCloneOptionsServerCertificateURL`
 /// error                 - A pointer to fill in case of trouble.
 /// transferProgressBlock - This block is called with network transfer updates.
+///                         May be NULL.
 /// checkoutProgressBlock - This block is called with checkout updates
 ///                         (if `GTRepositoryCloneOptionsCheckout` is YES).
+///                         May be NULL.
 ///
 /// returns nil (and fills the error parameter) if an error occurred, or a GTRepository object if successful.
-+ (id)cloneFromURL:(NSURL *)originURL toWorkingDirectory:(NSURL *)workdirURL options:(NSDictionary *)options error:(NSError **)error transferProgressBlock:(void (^)(const git_transfer_progress *, BOOL *stop))transferProgressBlock checkoutProgressBlock:(void (^)(NSString *path, NSUInteger completedSteps, NSUInteger totalSteps))checkoutProgressBlock;
++ (nullable instancetype)cloneFromURL:(NSURL *)originURL toWorkingDirectory:(NSURL *)workdirURL options:(nullable NSDictionary *)options error:(NSError **)error transferProgressBlock:(nullable void (^)(const git_transfer_progress *, BOOL *stop))transferProgressBlock checkoutProgressBlock:(nullable void (^) (NSString *path, NSUInteger completedSteps, NSUInteger totalSteps))checkoutProgressBlock;
 
 /// Lookup objects in the repo by oid or sha1
-- (id)lookUpObjectByOID:(GTOID *)oid objectType:(GTObjectType)type error:(NSError **)error;
-- (id)lookUpObjectByOID:(GTOID *)oid error:(NSError **)error;
-- (id)lookUpObjectBySHA:(NSString *)sha objectType:(GTObjectType)type error:(NSError **)error;
-- (id)lookUpObjectBySHA:(NSString *)sha error:(NSError **)error;
+- (nullable id)lookUpObjectByOID:(GTOID *)oid objectType:(GTObjectType)type error:(NSError **)error;
+- (nullable id)lookUpObjectByOID:(GTOID *)oid error:(NSError **)error;
+- (nullable id)lookUpObjectBySHA:(NSString *)sha objectType:(GTObjectType)type error:(NSError **)error;
+- (nullable id)lookUpObjectBySHA:(NSString *)sha error:(NSError **)error;
 
 /// Lookup an object in the repo using a revparse spec
-- (id)lookUpObjectByRevParse:(NSString *)spec error:(NSError **)error;
+- (nullable id)lookUpObjectByRevParse:(NSString *)spec error:(NSError **)error;
 
 /// Finds the branch with the given name and type.
 ///
@@ -232,7 +249,7 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 ///
 /// Returns the matching branch, or nil if no match was found or an error occurs.
 /// The latter two cases can be distinguished by checking `success`.
-- (GTBranch *)lookUpBranchWithName:(NSString *)branchName type:(GTBranchType)branchType success:(BOOL *)success error:(NSError **)error;
+- (nullable GTBranch *)lookUpBranchWithName:(NSString *)branchName type:(GTBranchType)branchType success:(nullable BOOL *)success error:(NSError **)error;
 
 /// List all references in the repository
 ///
@@ -241,31 +258,58 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 ///
 /// returns an array of NSStrings holding the names of the references
 /// returns nil if an error occurred and fills the error parameter
-- (NSArray *)referenceNamesWithError:(NSError **)error;
+- (nullable NSArray *)referenceNamesWithError:(NSError **)error;
 
-- (GTReference *)headReferenceWithError:(NSError **)error;
+/// Get the HEAD reference.
+///
+/// error - If not NULL, set to any error that occurs.
+///
+/// Returns a GTReference or nil if an error occurs.
+- (nullable GTReference *)headReferenceWithError:(NSError **)error;
 
-- (NSArray *)localBranchesWithError:(NSError **)error;
-- (NSArray *)remoteBranchesWithError:(NSError **)error;
-- (NSArray *)branchesWithPrefix:(NSString *)prefix error:(NSError **)error;
+/// Get the local branches.
+///
+/// error - If not NULL, set to any error that occurs.
+///
+/// Returns an array of GTBranches or nil if an error occurs.
+- (nullable NSArray *)localBranchesWithError:(NSError **)error;
+
+/// Get the remote branches.
+///
+/// error - If not NULL, set to any error that occurs.
+///
+/// Returns an array of GTBranches or nil if an error occurs.
+- (nullable NSArray *)remoteBranchesWithError:(NSError **)error;
+
+/// Get branches with names sharing a given prefix.
+///
+/// prefix - The prefix to use for filtering. Must not be nil.
+/// error - If not NULL, set to any error that occurs.
+///
+/// Returns an array of GTBranches or nil if an error occurs.
+- (nullable NSArray *)branchesWithPrefix:(NSString *)prefix error:(NSError **)error;
 
 /// Get the local and remote branches and merge them together by combining local
 /// branches with their remote branch, if they have one.
 ///
-/// error - The error if one occurs.
+/// error - If not NULL, set to any error that occurs.
 ///
-/// Returns the branches or nil if an error occurs.
-- (NSArray *)branches:(NSError **)error;
+/// Returns an array of GTBranches or nil if an error occurs.
+- (nullable NSArray *)branches:(NSError **)error;
 
 /// List all remotes in the repository
 ///
 /// error - will be filled if an error occurs
 ///
 /// returns an array of NSStrings holding the names of the remotes, or nil if an error occurred
-- (NSArray *)remoteNamesWithError:(NSError **)error;
+- (nullable NSArray *)remoteNamesWithError:(NSError **)error;
 
-/// Convenience method to return all tags in the repository
-- (NSArray *)allTagsWithError:(NSError **)error;
+/// Get all tags in the repository.
+///
+/// error - If not NULL, set to any error that occurs.
+///
+/// Returns an array of GTTag or nil if an error occurs.
+- (nullable NSArray *)allTagsWithError:(NSError **)error;
 
 /// Count all commits in the current branch (HEAD)
 ///
@@ -283,7 +327,7 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 /// error     - If not NULL, set to any error that occurs.
 ///
 /// Returns the created ref, or nil if an error occurred.
-- (GTReference *)createReferenceNamed:(NSString *)name fromOID:(GTOID *)targetOID message:(NSString *)message error:(NSError **)error;
+- (nullable GTReference *)createReferenceNamed:(NSString *)name fromOID:(GTOID *)targetOID message:(nullable NSString *)message error:(NSError **)error;
 
 /// Creates a symbolic reference to another ref.
 ///
@@ -294,7 +338,7 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 /// error     - If not NULL, set to any error that occurs.
 ///
 /// Returns the created ref, or nil if an error occurred.
-- (GTReference *)createReferenceNamed:(NSString *)name fromReference:(GTReference *)targetRef message:(NSString *)message error:(NSError **)error;
+- (nullable GTReference *)createReferenceNamed:(NSString *)name fromReference:(GTReference *)targetRef message:(nullable NSString *)message error:(NSError **)error;
 
 /// Create a new local branch pointing to the given OID.
 ///
@@ -306,21 +350,22 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 /// error     - If not NULL, set to any error that occurs.
 ///
 /// Returns the new branch, or nil if an error occurred.
-- (GTBranch *)createBranchNamed:(NSString *)name fromOID:(GTOID *)targetOID message:(NSString *)message error:(NSError **)error;
+- (nullable GTBranch *)createBranchNamed:(NSString *)name fromOID:(GTOID *)targetOID message:(nullable NSString *)message error:(NSError **)error;
 
 /// Get the current branch.
 ///
 /// error(out) - will be filled if an error occurs
 ///
 /// returns the current branch or nil if an error occurred.
-- (GTBranch *)currentBranchWithError:(NSError **)error;
+- (nullable GTBranch *)currentBranchWithError:(NSError **)error;
 
 /// Find the commits that are on our local branch but not on the remote branch.
 ///
-/// error(out) - will be filled if an error occurs
+/// remoteBranch - The remote branch to use as a reference. Must not be nil.
+/// error(out)   - will be filled if an error occurs
 ///
 /// returns the local commits, an empty array if there is no remote branch, or nil if an error occurred
-- (NSArray *)localCommitsRelativeToRemoteBranch:(GTBranch *)remoteBranch error:(NSError **)error;
+- (nullable NSArray *)localCommitsRelativeToRemoteBranch:(GTBranch *)remoteBranch error:(NSError **)error;
 
 /// Retrieves git's "prepared message" for the next commit, like the default
 /// message pre-filled when committing after a conflicting merge.
@@ -329,7 +374,7 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 ///
 /// Returns the message from disk, or nil if no prepared message exists or an
 /// error occurred.
-- (NSString *)preparedMessageWithError:(NSError **)error;
+- (nullable NSString *)preparedMessageWithError:(NSError **)error;
 
 /// The signature for the user at the current time, based on the repository and
 /// system configs. If the user's name or email have not been set, reasonable
@@ -356,7 +401,7 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 ///             `error` will contain the error information. Setting `stop` to YES
 ///             will cause enumeration to stop after the block returns. This must
 ///             not be nil.
-- (void)enumerateSubmodulesRecursively:(BOOL)recursive usingBlock:(void (^)(GTSubmodule *submodule, NSError *error, BOOL *stop))block;
+- (void)enumerateSubmodulesRecursively:(BOOL)recursive usingBlock:(void (^)(GTSubmodule * __nullable submodule, NSError *error, BOOL *stop))block;
 
 /// Looks up the top-level submodule with the given name. This will not recurse
 /// into submodule repositories.
@@ -366,7 +411,7 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 ///
 /// Returns the first submodule that matches the given name, or nil if an error
 /// occurred locating or instantiating the GTSubmodule.
-- (GTSubmodule *)submoduleWithName:(NSString *)name error:(NSError **)error;
+- (nullable GTSubmodule *)submoduleWithName:(NSString *)name error:(NSError **)error;
 
 /// Finds the merge base between the commits pointed at by the given OIDs.
 ///
@@ -375,36 +420,36 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 /// error     - If not NULL, set to any error that occurs.
 ///
 /// Returns the merge base, or nil if none is found or an error occurred.
-- (GTCommit *)mergeBaseBetweenFirstOID:(GTOID *)firstOID secondOID:(GTOID *)secondOID error:(NSError **)error;
+- (nullable GTCommit *)mergeBaseBetweenFirstOID:(GTOID *)firstOID secondOID:(GTOID *)secondOID error:(NSError **)error;
 
 /// The object database backing the repository.
 ///
 /// error - The error if one occurred.
 ///
 /// Returns the object database, or nil if an error occurred.
-- (GTObjectDatabase *)objectDatabaseWithError:(NSError **)error;
+- (nullable GTObjectDatabase *)objectDatabaseWithError:(NSError **)error;
 
 /// The configuration for the repository.
 ///
 /// error - The error if one occurred.
 ///
 /// Returns the configuration, or nil if an error occurred.
-- (GTConfiguration *)configurationWithError:(NSError **)error;
+- (nullable GTConfiguration *)configurationWithError:(NSError **)error;
 
 /// The index for the repository.
 ///
 /// error - The error if one occurred.
 ///
 /// Returns the index, or nil if an error occurred.
-- (GTIndex *)indexWithError:(NSError **)error;
+- (nullable GTIndex *)indexWithError:(NSError **)error;
 
 /// Creates a new lightweight tag in this repository.
 ///
 /// name   - Name for the tag; this name is validated
 ///          for consistency. It should also not conflict with an
-///          already existing tag name
+///          already existing tag name. Must not be nil.
 /// target - Object to which this tag points. This object
-///          must belong to this repository.
+///          must belong to this repository. Must not be nil.
 /// error  - Will be filled with a NSError instance on failuer.
 ///          May be NULL.
 ///
@@ -425,7 +470,7 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 ///             May be NULL.
 ///
 /// Returns the object ID of the newly created tag or nil on error.
-- (GTOID *)OIDByCreatingTagNamed:(NSString *)tagName target:(GTObject *)theTarget tagger:(GTSignature *)theTagger message:(NSString *)theMessage error:(NSError **)error;
+- (nullable GTOID *)OIDByCreatingTagNamed:(NSString *)tagName target:(GTObject *)theTarget tagger:(GTSignature *)theTagger message:(NSString *)theMessage error:(NSError **)error;
 
 /// Creates an annotated tag in this repo. Existing tags are not overwritten.
 ///
@@ -441,11 +486,11 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 ///             May be NULL.
 ///
 /// Returns the newly created tag or nil on error.
-- (GTTag *)createTagNamed:(NSString *)tagName target:(GTObject *)theTarget tagger:(GTSignature *)theTagger message:(NSString *)theMessage error:(NSError **)error;
+- (nullable GTTag *)createTagNamed:(NSString *)tagName target:(GTObject *)theTarget tagger:(GTSignature *)theTagger message:(NSString *)theMessage error:(NSError **)error;
 
 /// Checkout a commit
 ///
-/// targetCommit  - The commit to checkout.
+/// targetCommit  - The commit to checkout. Must not be nil.
 /// strategy      - The checkout strategy to use.
 /// notifyFlags   - Flags that indicate which notifications should cause `notifyBlock`
 ///                 to be called.
@@ -454,7 +499,7 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 /// progressBlock - The block to call back for progress updates. Can be nil.
 ///
 /// Returns YES if operation was successful, NO otherwise
-- (BOOL)checkoutCommit:(GTCommit *)targetCommit strategy:(GTCheckoutStrategyType)strategy notifyFlags:(GTCheckoutNotifyFlags)notifyFlags error:(NSError **)error progressBlock:(void (^)(NSString *path, NSUInteger completedSteps, NSUInteger totalSteps))progressBlock notifyBlock:(int (^)(GTCheckoutNotifyFlags why, NSString *path, GTDiffFile *baseline, GTDiffFile *target, GTDiffFile *workdir))notifyBlock;
+- (BOOL)checkoutCommit:(GTCommit *)targetCommit strategy:(GTCheckoutStrategyType)strategy notifyFlags:(GTCheckoutNotifyFlags)notifyFlags error:(NSError **)error progressBlock:(nullable void (^)(NSString *path, NSUInteger completedSteps, NSUInteger totalSteps))progressBlock notifyBlock:(nullable int (^)(GTCheckoutNotifyFlags why, NSString *path, GTDiffFile *baseline, GTDiffFile *target, GTDiffFile *workdir))notifyBlock;
 
 /// Checkout a reference
 ///
@@ -467,13 +512,13 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 /// progressBlock - The block to call back for progress updates. Can be nil.
 ///
 /// Returns YES if operation was successful, NO otherwise
-- (BOOL)checkoutReference:(GTReference *)targetReference strategy:(GTCheckoutStrategyType)strategy notifyFlags:(GTCheckoutNotifyFlags)notifyFlags error:(NSError **)error progressBlock:(void (^)(NSString *path, NSUInteger completedSteps, NSUInteger totalSteps))progressBlock notifyBlock:(int (^)(GTCheckoutNotifyFlags why, NSString *path, GTDiffFile *baseline, GTDiffFile *target, GTDiffFile *workdir))notifyBlock;
+- (BOOL)checkoutReference:(GTReference *)targetReference strategy:(GTCheckoutStrategyType)strategy notifyFlags:(GTCheckoutNotifyFlags)notifyFlags error:(NSError **)error progressBlock:(nullable void (^)(NSString *path, NSUInteger completedSteps, NSUInteger totalSteps))progressBlock notifyBlock:(nullable int (^)(GTCheckoutNotifyFlags why, NSString *path, GTDiffFile *baseline, GTDiffFile *target, GTDiffFile *workdir))notifyBlock;
 
 /// Convenience wrapper for checkoutCommit:strategy:notifyFlags:error:notifyBlock:progressBlock without notifications
-- (BOOL)checkoutCommit:(GTCommit *)target strategy:(GTCheckoutStrategyType)strategy error:(NSError **)error progressBlock:(void (^)(NSString *path, NSUInteger completedSteps, NSUInteger totalSteps))progressBlock;
+- (BOOL)checkoutCommit:(GTCommit *)target strategy:(GTCheckoutStrategyType)strategy error:(NSError **)error progressBlock:(nullable void (^)(NSString *path, NSUInteger completedSteps, NSUInteger totalSteps))progressBlock;
 
 /// Convenience wrapper for checkoutReference:strategy:notifyFlags:error:notifyBlock:progressBlock without notifications
-- (BOOL)checkoutReference:(GTReference *)target strategy:(GTCheckoutStrategyType)strategy error:(NSError **)error progressBlock:(void (^)(NSString *path, NSUInteger completedSteps, NSUInteger totalSteps))progressBlock;
+- (BOOL)checkoutReference:(GTReference *)target strategy:(GTCheckoutStrategyType)strategy error:(NSError **)error progressBlock:(nullable void (^)(NSString *path, NSUInteger completedSteps, NSUInteger totalSteps))progressBlock;
 
 /// Flush the gitattributes cache.
 - (void)flushAttributesCache;
@@ -496,18 +541,30 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 /// Returns the loaded filter list, or nil if an error occurs or there are no
 /// filters to apply to the given path. The latter two cases can be
 /// distinguished using the value of `success`.
-- (GTFilterList *)filterListWithPath:(NSString *)path blob:(GTBlob *)blob mode:(GTFilterSourceMode)mode options:(GTFilterListOptions)options success:(BOOL *)success error:(NSError **)error;
+- (nullable GTFilterList *)filterListWithPath:(NSString *)path blob:(nullable GTBlob *)blob mode:(GTFilterSourceMode)mode options:(GTFilterListOptions)options success:(nullable BOOL *)success error:(NSError **)error;
 
 /// Creates an enumerator for finding all commits in the history of `headOID`
 /// that do not exist in the history of `baseOID`.
 ///
+/// headOID - Must not be nil.
+/// baseOID - Must not be nil.
+/// error   - If not NULL, set to any error that occurs.
+///
 /// Returns the created enumerator upon success, or `nil` if an error occurred.
-- (GTEnumerator *)enumerateUniqueCommitsUpToOID:(GTOID *)headOID relativeToOID:(GTOID *)baseOID error:(NSError **)error;
+- (nullable GTEnumerator *)enumerateUniqueCommitsUpToOID:(GTOID *)headOID relativeToOID:(GTOID *)baseOID error:(NSError **)error;
 
 /// Calculates how far ahead/behind the commit represented by `headOID` is,
 /// relative to the commit represented by `baseOID`.
+///
+/// ahead   - Must not be NULL.
+/// behind  - Must not be NULL.
+/// headOID - Must not be nil.
+/// baseOID - Must not be nil.
+/// error   - If not NULL, set to any error that occurs.
 ///
 /// Returns whether `ahead` and `behind` were successfully calculated.
 - (BOOL)calculateAhead:(size_t *)ahead behind:(size_t *)behind ofOID:(GTOID *)headOID relativeToOID:(GTOID *)baseOID error:(NSError **)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTRepository.m
+++ b/ObjectiveGit/GTRepository.m
@@ -152,11 +152,11 @@ typedef struct {
 	return [[self alloc] initWithGitRepository:repository];
 }
 
-+ (id)repositoryWithURL:(NSURL *)localFileURL error:(NSError **)error {
++ (instancetype)repositoryWithURL:(NSURL *)localFileURL error:(NSError **)error {
 	return [[self alloc] initWithURL:localFileURL error:error];
 }
 
-- (id)initWithGitRepository:(git_repository *)repository {
+- (instancetype)initWithGitRepository:(git_repository *)repository {
 	NSParameterAssert(repository != nil);
 
 	self = [super init];
@@ -167,7 +167,7 @@ typedef struct {
 	return self;
 }
 
-- (id)initWithURL:(NSURL *)localFileURL error:(NSError **)error {
+- (instancetype)initWithURL:(NSURL *)localFileURL error:(NSError **)error {
 	if (![localFileURL isFileURL] || localFileURL.path == nil) {
 		if (error != NULL) *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnsupportedSchemeError userInfo:@{ NSLocalizedDescriptionKey: NSLocalizedString(@"Invalid file path URL to open.", @"") }];
 		return nil;
@@ -224,7 +224,7 @@ struct GTRemoteCreatePayload {
 	git_remote_callbacks remoteCallbacks;
 };
 
-+ (id)cloneFromURL:(NSURL *)originURL toWorkingDirectory:(NSURL *)workdirURL options:(NSDictionary *)options error:(NSError **)error transferProgressBlock:(void (^)(const git_transfer_progress *, BOOL *stop))transferProgressBlock checkoutProgressBlock:(void (^)(NSString *path, NSUInteger completedSteps, NSUInteger totalSteps))checkoutProgressBlock {
++ (instancetype)cloneFromURL:(NSURL *)originURL toWorkingDirectory:(NSURL *)workdirURL options:(NSDictionary *)options error:(NSError **)error transferProgressBlock:(void (^)(const git_transfer_progress *, BOOL *stop))transferProgressBlock checkoutProgressBlock:(void (^)(NSString *path, NSUInteger completedSteps, NSUInteger totalSteps))checkoutProgressBlock {
 
 	git_clone_options cloneOptions = GIT_CLONE_OPTIONS_INIT;
 

--- a/ObjectiveGit/GTSignature.h
+++ b/ObjectiveGit/GTSignature.h
@@ -30,14 +30,16 @@
 
 #import "GTObject.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A git signature.
 @interface GTSignature : NSObject
 
 /// The name of the person.
-@property (nonatomic, readonly, copy) NSString *name;
+@property (nonatomic, readonly, copy, nullable) NSString *name;
 
 /// The email of the person.
-@property (nonatomic, readonly, copy) NSString *email;
+@property (nonatomic, readonly, copy, nullable) NSString *email;
 
 /// The time when the action happened.
 @property (nonatomic, readonly, strong) NSDate *time;
@@ -50,7 +52,7 @@
 /// git_signature - The signature to wrap. This must not be NULL.
 ///
 /// Returns an initialized GTSignature, or nil if an error occurs.
-- (id)initWithGitSignature:(const git_signature *)git_signature;
+- (nullable id)initWithGitSignature:(const git_signature *)git_signature;
 
 /// Initializes the receiver with the given information.
 ///
@@ -60,9 +62,11 @@
 ///         zone. This may be nil.
 ///
 /// Returns an initialized GTSignature, or nil if an error occurs.
-- (id)initWithName:(NSString *)name email:(NSString *)email time:(NSDate *)time;
+- (nullable id)initWithName:(NSString *)name email:(NSString *)email time:(nullable NSDate *)time;
 
 /// The underlying `git_signature` object.
 - (const git_signature *)git_signature __attribute__((objc_returns_inner_pointer));
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTSignature.h
+++ b/ObjectiveGit/GTSignature.h
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// git_signature - The signature to wrap. This must not be NULL.
 ///
 /// Returns an initialized GTSignature, or nil if an error occurs.
-- (nullable id)initWithGitSignature:(const git_signature *)git_signature;
+- (nullable instancetype)initWithGitSignature:(const git_signature *)git_signature;
 
 /// Initializes the receiver with the given information.
 ///
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///         zone. This may be nil.
 ///
 /// Returns an initialized GTSignature, or nil if an error occurs.
-- (nullable id)initWithName:(NSString *)name email:(NSString *)email time:(nullable NSDate *)time;
+- (nullable instancetype)initWithName:(NSString *)name email:(NSString *)email time:(nullable NSDate *)time;
 
 /// The underlying `git_signature` object.
 - (const git_signature *)git_signature __attribute__((objc_returns_inner_pointer));

--- a/ObjectiveGit/GTSignature.m
+++ b/ObjectiveGit/GTSignature.m
@@ -48,7 +48,7 @@
 	}
 }
 
-- (id)initWithGitSignature:(const git_signature *)git_signature {
+- (instancetype)initWithGitSignature:(const git_signature *)git_signature {
 	NSParameterAssert(git_signature != NULL);
 
 	self = [super init];
@@ -60,7 +60,7 @@
 	return self;
 }
 
-- (id)initWithName:(NSString *)name email:(NSString *)email time:(NSDate *)time {
+- (instancetype)initWithName:(NSString *)name email:(NSString *)email time:(NSDate *)time {
 	NSParameterAssert(name != nil);
 	NSParameterAssert(email != nil);
 

--- a/ObjectiveGit/GTSignature.m
+++ b/ObjectiveGit/GTSignature.m
@@ -111,10 +111,14 @@
 }
 
 - (NSDate *)time {
+	if (self.git_signature == NULL) return nil;
+
 	return [NSDate gt_dateFromGitTime:self.git_signature->when];
 }
 
 - (NSTimeZone *)timeZone {
+	if (self.git_signature == NULL) return nil;
+
 	return [NSTimeZone gt_timeZoneFromGitTime:self.git_signature->when];
 }
 

--- a/ObjectiveGit/GTStatusDelta.h
+++ b/ObjectiveGit/GTStatusDelta.h
@@ -26,14 +26,16 @@ typedef NS_ENUM(NSInteger, GTStatusDeltaStatus) {
 	GTStatusDeltaStatusTypeChange = GIT_DELTA_TYPECHANGE,
 };
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Represents the status of a file in a repository.
 @interface GTStatusDelta : NSObject
 
 /// The file as it was prior to the change represented by this status delta.
-@property (nonatomic, readonly, copy) GTDiffFile *oldFile;
+@property (nonatomic, readonly, copy, nullable) GTDiffFile *oldFile;
 
 /// The file after the change represented by this status delta
-@property (nonatomic, readonly, copy) GTDiffFile *newFile __attribute__((ns_returns_not_retained));
+@property (nonatomic, readonly, copy, nullable) GTDiffFile *newFile __attribute__((ns_returns_not_retained));
 
 /// The status of the file.
 @property (nonatomic, readonly) GTStatusDeltaStatus status;
@@ -46,6 +48,8 @@ typedef NS_ENUM(NSInteger, GTStatusDeltaStatus) {
 @property (nonatomic, readonly) double similarity;
 
 /// Designated initializer.
-- (instancetype)initWithGitDiffDelta:(const git_diff_delta *)delta;
+- (nullable instancetype)initWithGitDiffDelta:(const git_diff_delta *)delta;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTSubmodule.h
+++ b/ObjectiveGit/GTSubmodule.h
@@ -88,7 +88,7 @@ typedef NS_OPTIONS(NSInteger, GTSubmoduleStatus) {
 /// `.git/config` or `.gitmodules` file.
 @property (nonatomic, copy, readonly) NSString *URLString;
 
-/// Initializes the receiver to wrap the given submodule object.
+/// Initializes the receiver to wrap the given submodule object. Designated initializer.
 ///
 /// submodule  - The submodule to wrap. The receiver will not own this object, so
 ///              it must not be freed while the GTSubmodule is alive. This must

--- a/ObjectiveGit/GTSubmodule.h
+++ b/ObjectiveGit/GTSubmodule.h
@@ -51,6 +51,8 @@ typedef NS_OPTIONS(NSInteger, GTSubmoduleStatus) {
 	GTSubmoduleStatusUntrackedFilesInWorkingDirectory = GIT_SUBMODULE_STATUS_WD_UNTRACKED
 };
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Represents a submodule within its parent repository.
 @interface GTSubmodule : NSObject
 
@@ -65,28 +67,28 @@ typedef NS_OPTIONS(NSInteger, GTSubmoduleStatus) {
 /// The OID that the submodule is pinned to in the parent repository's index.
 ///
 /// If the submodule is not in the index, this will be nil.
-@property (nonatomic, strong, readonly) GTOID *indexOID;
+@property (nonatomic, strong, readonly, nullable) GTOID *indexOID;
 
 /// The OID that the submodule is pinned to in the parent repository's HEAD
 /// commit.
 ///
 /// If the submodule is not in HEAD, this will be nil.
-@property (nonatomic, strong, readonly) GTOID *HEADOID;
+@property (nonatomic, strong, readonly, nullable) GTOID *HEADOID;
 
 /// The OID that is checked out in the submodule repository.
 ///
 /// If the submodule is not checked out, this will be nil.
-@property (nonatomic, strong, readonly) GTOID *workingDirectoryOID;
+@property (nonatomic, strong, readonly, nullable) GTOID *workingDirectoryOID;
 
 /// The name of this submodule.
-@property (nonatomic, copy, readonly) NSString *name;
+@property (nonatomic, copy, readonly, nullable) NSString *name;
 
 /// The path to this submodule, relative to its parent repository's root.
-@property (nonatomic, copy, readonly) NSString *path;
+@property (nonatomic, copy, readonly, nullable) NSString *path;
 
 /// The remote URL provided for this submodule, read from the parent repository's
 /// `.git/config` or `.gitmodules` file.
-@property (nonatomic, copy, readonly) NSString *URLString;
+@property (nonatomic, copy, readonly, nullable) NSString *URLString;
 
 /// Initializes the receiver to wrap the given submodule object. Designated initializer.
 ///
@@ -97,7 +99,7 @@ typedef NS_OPTIONS(NSInteger, GTSubmoduleStatus) {
 ///              nil.
 ///
 /// Returns an initialized GTSubmodule, or nil if an error occurs.
-- (id)initWithGitSubmodule:(git_submodule *)submodule parentRepository:(GTRepository *)repository NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithGitSubmodule:(git_submodule *)submodule parentRepository:(GTRepository *)repository NS_DESIGNATED_INITIALIZER;
 
 /// The underlying `git_submodule` object.
 - (git_submodule *)git_submodule __attribute__((objc_returns_inner_pointer));
@@ -120,7 +122,7 @@ typedef NS_OPTIONS(NSInteger, GTSubmoduleStatus) {
 /// If the submodule is not currently checked out, this will fail.
 ///
 /// Returns the opened repository, or nil if an error occurs.
-- (GTRepository *)submoduleRepository:(NSError **)error;
+- (nullable GTRepository *)submoduleRepository:(NSError **)error;
 
 /// Determines the status for the submodule.
 ///
@@ -148,3 +150,5 @@ typedef NS_OPTIONS(NSInteger, GTSubmoduleStatus) {
 - (BOOL)addToIndex:(NSError **)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTSubmodule.m
+++ b/ObjectiveGit/GTSubmodule.m
@@ -79,7 +79,7 @@
 	}
 }
 
-- (id)initWithGitSubmodule:(git_submodule *)submodule parentRepository:(GTRepository *)repository {
+- (instancetype)initWithGitSubmodule:(git_submodule *)submodule parentRepository:(GTRepository *)repository {
 	NSParameterAssert(submodule != NULL);
 	NSParameterAssert(repository != nil);
 

--- a/ObjectiveGit/GTTag.h
+++ b/ObjectiveGit/GTTag.h
@@ -32,10 +32,12 @@
 @class GTSignature;
 @class GTRepository;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GTTag : GTObject {}
 
 /// The author of the tag.
-@property (nonatomic, readonly, strong) GTSignature *tagger;
+@property (nonatomic, readonly, strong, nullable) GTSignature *tagger;
 
 /// The description given when the tag was created.
 @property (nonatomic, readonly, strong) NSString *message;
@@ -44,20 +46,22 @@
 @property (nonatomic, readonly, strong) NSString *name;
 
 /// The 'tagged' object.
-@property (nonatomic, readonly, strong) GTObject *target;
+@property (nonatomic, readonly, strong, nullable) GTObject *target;
 
 /// The type of the 'tagged' object.
 @property (nonatomic, readonly) GTObjectType targetType;
 
 /// Recursively peel a tag until a non tag GTObject is found
 ///
-/// errro - Will be filled with a NSError object on failure.
+/// error - Will be filled with a NSError object on failure.
 ///         May be NULL.
 ///
 /// Returns the found object or nil on error.
-- (id)objectByPeelingTagError:(NSError **)error;
+- (nullable id)objectByPeelingTagError:(NSError **)error;
 
 /// The underlying `git_object` as a `git_tag` object.
 - (git_tag *)git_tag __attribute__((objc_returns_inner_pointer));
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTTree.h
+++ b/ObjectiveGit/GTTree.h
@@ -39,13 +39,15 @@ typedef NS_ENUM(NSInteger, GTTreeEnumerationOptions) {
 	GTTreeEnumerationOptionPost = GIT_TREEWALK_POST, // Walk the tree in post-order (subdirectories come last)
 };
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GTTree : GTObject
 
 /// The number of entries in the tree.
 @property (nonatomic, readonly) NSUInteger entryCount;
 
 /// The contents of the tree, as an array of whose objects are of type `GTTreeEntry`
-@property (nonatomic, strong, readonly) NSArray *entries;
+@property (nonatomic, strong, readonly, nullable) NSArray *entries;
 
 /// The underlying `git_object` as a `git_tree` object.
 - (git_tree *)git_tree __attribute__((objc_returns_inner_pointer));
@@ -55,21 +57,21 @@ typedef NS_ENUM(NSInteger, GTTreeEnumerationOptions) {
 /// index - index to retreive entry from
 ///
 /// returns a GTTreeEntry or nil if there is nothing at the index
-- (GTTreeEntry *)entryAtIndex:(NSUInteger)index;
+- (nullable GTTreeEntry *)entryAtIndex:(NSUInteger)index;
 
 /// Get an entry by name
 ///
 /// name - the name of the entry
 ///
 /// returns a GTTreeEntry or nil if there is nothing with the specified name
-- (GTTreeEntry *)entryWithName:(NSString *)name;
+- (nullable GTTreeEntry *)entryWithName:(NSString *)name;
 
 /// Get an entry by path
 ///
 /// path - the path of the entry relative to the repository root
 ///
 /// returns a GTTreeEntry or nil if there is nothing with the specified path
-- (GTTreeEntry *)entryWithPath:(NSString *)path error:(NSError **)error;
+- (nullable GTTreeEntry *)entryWithPath:(NSString *)path error:(NSError **)error;
 
 /// Enumerates the contents of the tree
 ///
@@ -96,6 +98,8 @@ typedef NS_ENUM(NSInteger, GTTreeEnumerationOptions) {
 ///
 /// Returns an index which represents the result of the merge, or nil if an error
 /// occurred.
-- (GTIndex *)merge:(GTTree *)otherTree ancestor:(GTTree *)ancestorTree error:(NSError **)error;
+- (nullable GTIndex *)merge:(GTTree *)otherTree ancestor:(nullable GTTree *)ancestorTree error:(NSError **)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTTreeBuilder.h
+++ b/ObjectiveGit/GTTreeBuilder.h
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// error      - The error if one occurred.
 ///
 /// Returns the initialized object, or nil if an error occurred.
-- (nullable id)initWithTree:(nullable GTTree *)treeOrNil repository:(GTRepository *)repository error:(NSError **)error NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithTree:(nullable GTTree *)treeOrNil repository:(GTRepository *)repository error:(NSError **)error NS_DESIGNATED_INITIALIZER;
 
 /// The underlying `git_treebuilder` object.
 - (git_treebuilder *)git_treebuilder __attribute__((objc_returns_inner_pointer));

--- a/ObjectiveGit/GTTreeBuilder.h
+++ b/ObjectiveGit/GTTreeBuilder.h
@@ -52,7 +52,7 @@ typedef NS_ENUM(NSInteger, GTFileMode) {
 /// Get the number of entries listed in a treebuilder.
 @property (nonatomic, readonly) NSUInteger entryCount;
 
-/// Initializes the receiver, optionally from an existing tree.
+/// Initializes the receiver, optionally from an existing tree. Designated initializer.
 ///
 /// treeOrNil  - Source tree (or nil)
 /// repository - The repository in which to build the tree. Must not be nil.

--- a/ObjectiveGit/GTTreeBuilder.h
+++ b/ObjectiveGit/GTTreeBuilder.h
@@ -45,6 +45,8 @@ typedef NS_ENUM(NSInteger, GTFileMode) {
 @class GTRepository;
 @class GTOID;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A tree builder is used to create or modify trees in memory and write them as
 /// tree objects to a repository.
 @interface GTTreeBuilder : NSObject
@@ -59,7 +61,7 @@ typedef NS_ENUM(NSInteger, GTFileMode) {
 /// error      - The error if one occurred.
 ///
 /// Returns the initialized object, or nil if an error occurred.
-- (id)initWithTree:(GTTree *)treeOrNil repository:(GTRepository *)repository error:(NSError **)error NS_DESIGNATED_INITIALIZER;
+- (nullable id)initWithTree:(nullable GTTree *)treeOrNil repository:(GTRepository *)repository error:(NSError **)error NS_DESIGNATED_INITIALIZER;
 
 /// The underlying `git_treebuilder` object.
 - (git_treebuilder *)git_treebuilder __attribute__((objc_returns_inner_pointer));
@@ -70,7 +72,7 @@ typedef NS_ENUM(NSInteger, GTFileMode) {
 /// Filter the entries in the tree.
 ///
 /// filterBlock - A block which returns YES for entries which should be filtered
-///               from the index.
+///               from the index. Must not be nil.
 - (void)filter:(BOOL (^)(const git_tree_entry *entry))filterBlock;
 
 /// Get an entry from the builder from its file name.
@@ -78,7 +80,7 @@ typedef NS_ENUM(NSInteger, GTFileMode) {
 /// fileName - File name for the object in the index. Cannot be nil.
 ///
 /// Returns the matching entry or nil if it doesn't exist.
-- (GTTreeEntry *)entryWithFileName:(NSString *)fileName;
+- (nullable GTTreeEntry *)entryWithFileName:(NSString *)fileName;
 
 /// Adds or updates the entry for the file name with the given data. When the
 /// tree is written, a blob will be inserted into the object database containing
@@ -90,7 +92,7 @@ typedef NS_ENUM(NSInteger, GTFileMode) {
 /// error    - The error if one occurred.
 ///
 /// Returns the added entry, or nil if an error occurred
-- (GTTreeEntry *)addEntryWithData:(NSData *)data fileName:(NSString *)fileName fileMode:(GTFileMode)fileMode error:(NSError **)error;
+- (nullable GTTreeEntry *)addEntryWithData:(NSData *)data fileName:(NSString *)fileName fileMode:(GTFileMode)fileMode error:(NSError **)error;
 
 /// Add or update an entry to the builder.
 ///
@@ -107,11 +109,11 @@ typedef NS_ENUM(NSInteger, GTFileMode) {
 /// the type of the pointed at object.
 ///
 /// Returns the added entry, or nil if an error occurred.
-- (GTTreeEntry *)addEntryWithOID:(GTOID *)oid fileName:(NSString *)fileName fileMode:(GTFileMode)fileMode error:(NSError **)error;
+- (nullable GTTreeEntry *)addEntryWithOID:(GTOID *)oid fileName:(NSString *)fileName fileMode:(GTFileMode)fileMode error:(NSError **)error;
 
 /// Remove an entry from the builder by its file name.
 ///
-/// fileName - File name for the object in the tree.
+/// fileName - File name for the object in the tree. Must not be nil.
 /// error    - The error if one occurred.
 ///
 /// Returns YES if the entry was removed, or NO if an error occurred.
@@ -122,6 +124,8 @@ typedef NS_ENUM(NSInteger, GTFileMode) {
 /// error - The error if one occurred.
 ///
 /// Returns the written tree, or nil if an error occurred.
-- (GTTree *)writeTree:(NSError **)error;
+- (nullable GTTree *)writeTree:(NSError **)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTTreeBuilder.m
+++ b/ObjectiveGit/GTTreeBuilder.m
@@ -62,7 +62,7 @@
 
 #pragma mark Lifecycle
 
-- (id)initWithTree:(GTTree *)treeOrNil repository:(GTRepository *)repository error:(NSError **)error {
+- (instancetype)initWithTree:(GTTree *)treeOrNil repository:(GTRepository *)repository error:(NSError **)error {
 	NSParameterAssert(repository != nil);
 
 	self = [super init];

--- a/ObjectiveGit/GTTreeEntry.h
+++ b/ObjectiveGit/GTTreeEntry.h
@@ -31,17 +31,21 @@
 
 @class GTTree;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GTTreeEntry : NSObject
 
-/// Initializer and convience methods.
-- (instancetype)initWithEntry:(const git_tree_entry *)theEntry parentTree:(GTTree *)parent error:(NSError **)error;
-+ (instancetype)entryWithEntry:(const git_tree_entry *)theEntry parentTree:(GTTree *)parent error:(NSError **)error;
+/// Initializes the receiver.
+- (nullable instancetype)initWithEntry:(const git_tree_entry *)theEntry parentTree:(nullable GTTree *)parent error:(NSError **)error;
+
+/// Convience class initializer.
++ (nullable instancetype)entryWithEntry:(const git_tree_entry *)theEntry parentTree:(nullable GTTree *)parent error:(NSError **)error;
 
 /// The underlying `git_tree_entry`.
 - (git_tree_entry *)git_tree_entry __attribute__((objc_returns_inner_pointer));
 
-/// The entry's parent tree. This may be nil if nil is passed in to -initWithEntry:
-@property (nonatomic, strong, readonly) GTTree *tree;
+/// The entry's parent tree. This may be nil if nil parentTree is passed in to -initWithEntry:
+@property (nonatomic, strong, readonly, nullable) GTTree *tree;
 
 /// The filename of the entry
 @property (nonatomic, copy, readonly) NSString *name;
@@ -50,27 +54,29 @@
 @property (nonatomic, readonly) NSInteger attributes;
 
 /// The SHA hash of the entry
-@property (nonatomic, copy, readonly) NSString *SHA;
+@property (nonatomic, copy, readonly, nullable) NSString *SHA;
 
 /// The type of GTObject that -object: will return.
 @property (nonatomic, readonly) GTObjectType type;
 
 /// The OID of the entry.
-@property (nonatomic, strong, readonly) GTOID *OID;
+@property (nonatomic, strong, readonly, nullable) GTOID *OID;
 
 /// Convert the entry into an GTObject
 ///
 /// error - will be filled if an error occurs
 ///
 /// Returns this entry as a GTObject or nil if an error occurred.
-- (GTObject *)GTObject:(NSError **)error;
+- (nullable GTObject *)GTObject:(NSError **)error;
 
 @end
 
 
 @interface GTObject (GTTreeEntry)
 
-+ (instancetype)objectWithTreeEntry:(GTTreeEntry *)treeEntry error:(NSError **)error;
-- (instancetype)initWithTreeEntry:(GTTreeEntry *)treeEntry error:(NSError **)error;
++ (nullable instancetype)objectWithTreeEntry:(GTTreeEntry *)treeEntry error:(NSError **)error;
+- (nullable instancetype)initWithTreeEntry:(GTTreeEntry *)treeEntry error:(NSError **)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGitFramework.xcodeproj/project.pbxproj
+++ b/ObjectiveGitFramework.xcodeproj/project.pbxproj
@@ -1127,7 +1127,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastTestingUpgradeCheck = 0510;
-				LastUpgradeCheck = 0620;
+				LastUpgradeCheck = 0630;
 				ORGANIZATIONNAME = "GitHub, Inc";
 				TargetAttributes = {
 					D01B6ED219F82E2000D411BC = {
@@ -1491,6 +1491,7 @@
 			baseConfigurationReference = D0A463D817E57C45000F5021 /* Debug.xcconfig */;
 			buildSettings = {
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
 				HEADER_SEARCH_PATHS = (
 					External/libgit2/include,
@@ -1520,6 +1521,7 @@
 			baseConfigurationReference = D0A463DA17E57C45000F5021 /* Release.xcconfig */;
 			buildSettings = {
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
 				HEADER_SEARCH_PATHS = (
 					External/libgit2/include,
@@ -1624,6 +1626,7 @@
 			baseConfigurationReference = D0A463DB17E57C45000F5021 /* Test.xcconfig */;
 			buildSettings = {
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
 				HEADER_SEARCH_PATHS = (
 					External/libgit2/include,
@@ -1845,6 +1848,7 @@
 			baseConfigurationReference = D0A463D917E57C45000F5021 /* Profile.xcconfig */;
 			buildSettings = {
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
 				HEADER_SEARCH_PATHS = (
 					External/libgit2/include,

--- a/ObjectiveGitFramework.xcodeproj/xcshareddata/xcschemes/ObjectiveGit Mac.xcscheme
+++ b/ObjectiveGitFramework.xcodeproj/xcshareddata/xcschemes/ObjectiveGit Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0620"
+   LastUpgradeVersion = "0630"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ObjectiveGitFramework.xcodeproj/xcshareddata/xcschemes/ObjectiveGit iOS.xcscheme
+++ b/ObjectiveGitFramework.xcodeproj/xcshareddata/xcschemes/ObjectiveGit iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0620"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ ObjectiveGit relies upon, using Homebrew. If you want this behavior, please
 make sure you have Homebrew installed.
 
 To develop ObjectiveGit on its own, open the `ObjectiveGitFramework.xcworkspace` file.
+Note that Xcode 6.3 is required to build the framework and run unit tests.
+Projects that must use an older version of Xcode can use 
+[Carthage](https://github.com/Carthage/Carthage) to install pre-built binaries
+or download them from the [releases](https://github.com/libgit2/objective-git/releases).
 
 ## Importing ObjectiveGit on OS X
 


### PR DESCRIPTION
Updated Quick (0.3.1) and Nimble (0.4.2), which are both now using Swift 1.2. :warning: These changes require Xcode 6.3.

One of the nice features for Objective-C in 6.3 is new [nullability qualifiers](https://developer.apple.com/swift/blog/?id=25). I did an audit of the API, marking parameters, return types and properties as `nullable` where documented, but also verifying behavior in the implementation. I did not go all the way into the libgit2 implementation but rather erred on the `nonnull` side in most cases.

IMO, the `NS_ASSUME_NONNULL_BEGIN` / `END` macros have more signal to noise than ` #pragma clang assume_nonnull begin` / `end`, but either of them are better than sprinkling `nonnull` on everything. Plus, this mirrors what's appearing on the Swift side: (assumed) `nonnull` become non-optional and `nullable` become optional. Much safer than forced unwrap on everything.

Also added some missing doc comments and switched initializer return types from `id` to `instancetype`.

Tested with [Xcode 6.3](https://developer.apple.com/library/ios/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW306)

Addresses #448