### PR TITLE
Fix entryWithPath:error: on GTTree

### DIFF
--- a/ObjectiveGit/GTTree.m
+++ b/ObjectiveGit/GTTree.m
@@ -71,7 +71,7 @@ typedef struct GTTreeEnumerationStruct {
 - (GTTreeEntry *)entryWithPath:(NSString *)path error:(NSError **)error {
 	git_tree_entry *internalEntry = NULL;
 	int gitError = git_tree_entry_bypath(&internalEntry, self.git_tree, path.UTF8String);
-	if (error != GIT_OK) {
+	if (gitError != GIT_OK) {
 		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to get tree entry %@", path];
 		return nil;
 	}

--- a/ObjectiveGitTests/GTTreeSpec.m
+++ b/ObjectiveGitTests/GTTreeSpec.m
@@ -99,6 +99,30 @@ it(@"should return nil for non-existent entries", ^{
 	expect([tree entryWithName:@"_does not exist"]).to(beNil());
 });
 
+describe(@"fetching entries from paths", ^{
+	it(@"should be able to fetch existing paths",^{
+		NSError *error = nil;
+		GTTreeEntry *entry;
+		
+		entry = [tree entryWithPath:@"README" error:&error];
+		expect(error).to(beNil());
+		expect(entry).notTo(beNil());
+		
+		entry = [tree entryWithPath:@"subdir/README" error:&error];
+		expect(error).to(beNil());
+		expect(entry).notTo(beNil());
+	});
+	
+	it(@"should return nil and fill error for non-existent paths",^{
+		NSError *error = nil;
+		GTTreeEntry *entry;
+		
+		entry = [tree entryWithPath:@"does/not/exist" error:&error];
+		expect(error).notTo(beNil());
+		expect(entry).to(beNil());
+	});
+});
+
 afterEach(^{
 	[self tearDown];
 });


### PR DESCRIPTION
`entryWithPath:error:` was failing when error was not `nil`.

Fixed the typo and added some specs for that functionality.