### PR TITLE
Improved remote branch implements

### DIFF
--- a/ObjectiveGit/GTBranch.m
+++ b/ObjectiveGit/GTBranch.m
@@ -193,9 +193,9 @@
 }
 
 - (BOOL)updateTrackingBranch:(GTBranch *)trackingBranch error:(NSError **)error {
-  int result = GIT_ENOTFOUND;
-  if (trackingBranch.branchType == GTBranchTypeRemote) {
-    result = git_branch_set_upstream(self.reference.git_reference, [trackingBranch.name stringByReplacingOccurrencesOfString:[GTBranch remoteNamePrefix] withString:@""].UTF8String);
+	int result = GIT_ENOTFOUND;
+	if (trackingBranch.branchType == GTBranchTypeRemote) {
+		result = git_branch_set_upstream(self.reference.git_reference, [trackingBranch.name stringByReplacingOccurrencesOfString:[GTBranch remoteNamePrefix] withString:@""].UTF8String);
 	} else {
 		result = git_branch_set_upstream(self.reference.git_reference, trackingBranch.shortName.UTF8String);
 	}

--- a/ObjectiveGit/GTRepository+RemoteOperations.h
+++ b/ObjectiveGit/GTRepository+RemoteOperations.h
@@ -83,9 +83,8 @@ extern NSString *const GTRepositoryRemoteOptionsCredentialProvider;
 ///                 Recognized options are:
 ///                 `GTRepositoryRemoteOptionsCredentialProvider`
 /// error         - The error if one occurred. Can be NULL.
-/// progressBlock - An optional callback for monitoring progress.
 ///
 /// Returns YES if the push was successful, NO otherwise (and `error`, if provided,
 /// will point to an error describing what happened).
-- (BOOL)deleteBranch:(GTBranch *)branch fromRemote:(GTRemote *)remote withOptions:(NSDictionary *)options error:(NSError **)error progress:(void (^)(unsigned int current, unsigned int total, size_t bytes, BOOL *stop))progressBlock;
+- (BOOL)deleteBranch:(GTBranch *)branch fromRemote:(GTRemote *)remote withOptions:(NSDictionary *)options error:(NSError **)error;
 @end

--- a/ObjectiveGit/GTRepository+RemoteOperations.m
+++ b/ObjectiveGit/GTRepository+RemoteOperations.m
@@ -197,13 +197,13 @@ int GTFetchHeadEntriesCallback(const char *ref_name, const char *remote_url, con
 }
 
 #pragma mark - Deletion (Public)
-- (BOOL)deleteBranch:(GTBranch *)branch fromRemote:(GTRemote *)remote withOptions:(NSDictionary *)options error:(NSError **)error progress:(GTRemotePushTransferProgressBlock)progressBlock {
-		NSParameterAssert(branch != nil);
-		NSParameterAssert(remote != nil);
+- (BOOL)deleteBranch:(GTBranch *)branch fromRemote:(GTRemote *)remote withOptions:(NSDictionary *)options error:(NSError **)error {
+	NSParameterAssert(branch != nil);
+	NSParameterAssert(remote != nil);
 		
-		NSArray *refspecs = @[[NSString stringWithFormat:@":refs/heads/%@", branch.shortName]];
+	NSArray *refspecs = @[ [NSString stringWithFormat:@":refs/heads/%@", branch.shortName] ];
 		
-		return [self pushRefspecs:refspecs toRemote:remote withOptions:options error:error progress:progressBlock];
+	return [self pushRefspecs:refspecs toRemote:remote withOptions:options error:error progress:nil];
 }
 
 #pragma mark - Push (Private)

--- a/ObjectiveGitTests/GTBranchSpec.m
+++ b/ObjectiveGitTests/GTBranchSpec.m
@@ -229,8 +229,8 @@ describe(@"-updateTrackingBranch:error:", ^{
 		expect(@(success)).to(beTruthy());
 	});
 		
-  it(@"should set a remote tracking branch without branches amount change", ^{
-	  GTRepository *repository = self.testAppForkFixtureRepository;
+	it(@"should set a remote tracking branch without branches amount change", ^{
+		GTRepository *repository = self.testAppForkFixtureRepository;
 		expect(repository).notTo(beNil());
 			
 		NSError *error = nil;


### PR DESCRIPTION
### Modified

- `- (BOOL)updateTrackingBranch:(GTBranch *)trackingBranch error:(NSError **)error`

The original implement of this method wrongly considered remote tracking branch as local branch and added `remote = .` to `.git/config` which supposed to be `remote = <remote_name>`. This was caused by a wrong parameter objective-git used to pass to underlying method. 
A test case is added to `GTBranchSpec.m`.

### Added

- `- (BOOL)deleteBranch:(GTBranch *)branch fromRemote:(GTRemote *)remote withOptions:(NSDictionary *)options error:(NSError **)error progress:(void (^)(unsigned int current, unsigned int total, size_t bytes, BOOL *stop))progressBlock;`

This Method added unpublish support for branches like GitHub client did, it does a `git push <remote_name> :<dest>` action using the objective-git private push method.  