### PR TITLE
Add/Fetch NSData from index

### DIFF
--- a/ObjectiveGit/GTIndex.h
+++ b/ObjectiveGit/GTIndex.h
@@ -114,10 +114,6 @@
 /// Returns a new GTIndexEntry, or nil if an error occurred.
 - (GTIndexEntry *)entryWithName:(NSString *)name error:(NSError **)error;
 
-///TODO: Document
-/// Get the 
-- (NSData *)dataWithName:(NSString *)name error:(NSError **)error;
-
 /// Add an entry to the index.
 ///
 /// Note that this *cannot* add submodules. See -[GTSubmodule addToIndex:].

--- a/ObjectiveGit/GTIndex.h
+++ b/ObjectiveGit/GTIndex.h
@@ -114,6 +114,9 @@
 /// Returns a new GTIndexEntry, or nil if an error occurred.
 - (GTIndexEntry *)entryWithName:(NSString *)name error:(NSError **)error;
 
+///TODO: Document
+- (NSData *)dataWithName:(NSString *)name error:(NSError **)error;
+
 /// Add an entry to the index.
 ///
 /// Note that this *cannot* add submodules. See -[GTSubmodule addToIndex:].
@@ -142,6 +145,9 @@
 ///
 /// Returns whether reading the tree was successful.
 - (BOOL)addContentsOfTree:(GTTree *)tree error:(NSError **)error;
+
+///TODO: Document
+- (BOOL)addData:(NSData *)data withName:(NSString *)name error:(NSError **)error;
 
 /// Remove an entry (by relative path) from the index.
 /// Will fail if the receiver's repository is nil.

--- a/ObjectiveGit/GTIndex.h
+++ b/ObjectiveGit/GTIndex.h
@@ -115,6 +115,7 @@
 - (GTIndexEntry *)entryWithName:(NSString *)name error:(NSError **)error;
 
 ///TODO: Document
+/// Get the 
 - (NSData *)dataWithName:(NSString *)name error:(NSError **)error;
 
 /// Add an entry to the index.
@@ -138,6 +139,14 @@
 /// Returns YES if successful, NO otherwise.
 - (BOOL)addFile:(NSString *)file error:(NSError **)error;
 
+/// Add an entry (with the provided data and name) to the index.
+/// Will fail if the receiver's repository is nil.
+///
+/// data  - The content of the entry to add
+/// name  - The name of the entry to add
+/// error - The error if one occurred.
+- (BOOL)addData:(NSData *)data withName:(NSString *)name error:(NSError **)error;
+
 /// Reads the contents of the given tree into the index.
 ///
 /// tree  - The tree to add to the index. This must not be nil.
@@ -145,9 +154,6 @@
 ///
 /// Returns whether reading the tree was successful.
 - (BOOL)addContentsOfTree:(GTTree *)tree error:(NSError **)error;
-
-///TODO: Document
-- (BOOL)addData:(NSData *)data withName:(NSString *)name error:(NSError **)error;
 
 /// Remove an entry (by relative path) from the index.
 /// Will fail if the receiver's repository is nil.

--- a/ObjectiveGit/GTIndex.h
+++ b/ObjectiveGit/GTIndex.h
@@ -138,8 +138,8 @@
 /// Add an entry (with the provided data and name) to the index.
 /// Will fail if the receiver's repository is nil.
 ///
-/// data  - The content of the entry to add
-/// name  - The name of the entry to add
+/// data  - The content of the entry to add. Cannot be nil.
+/// name  - The name of the entry to add. Cannot be nil.
 /// error - The error if one occurred.
 - (BOOL)addData:(NSData *)data withName:(NSString *)name error:(NSError **)error;
 

--- a/ObjectiveGit/GTIndex.m
+++ b/ObjectiveGit/GTIndex.m
@@ -160,18 +160,6 @@ typedef BOOL (^GTIndexPathspecMatchedBlock)(NSString *matchedPathspec, NSString 
 	return [self entryAtIndex:pos];
 }
 
-- (NSData *)dataWithName:(NSString *)name error:(NSError **)error {
-	GTIndexEntry *entry = [self entryWithName:name error:error];
-	if (*error) return nil;
-	
-	const git_oid *oid = &entry.git_index_entry->id;
-	GTBlob *blob = [self.repository lookUpObjectByGitOid:oid
-											  objectType:GTObjectTypeBlob
-												   error:error];
-	
-	return [blob data];
-}
-
 - (BOOL)addEntry:(GTIndexEntry *)entry error:(NSError **)error {
 	int status = git_index_add(self.git_index, entry.git_index_entry);
 	if (status != GIT_OK) {

--- a/ObjectiveGit/GTIndex.m
+++ b/ObjectiveGit/GTIndex.m
@@ -77,6 +77,7 @@ typedef BOOL (^GTIndexPathspecMatchedBlock)(NSString *matchedPathspec, NSString 
 
 + (instancetype)inMemoryIndexWithRepository:(GTRepository *)repository error:(NSError **)error {
 	git_index *index = NULL;
+	
 	int status = git_index_new(&index);
 	if (status != GIT_OK) {
 		if (error != NULL) *error = [NSError git_errorFor:status description:@"Failed to initialize in-memory index"];
@@ -193,17 +194,6 @@ typedef BOOL (^GTIndexPathspecMatchedBlock)(NSString *matchedPathspec, NSString 
 	return YES;
 }
 
-- (BOOL)addContentsOfTree:(GTTree *)tree error:(NSError **)error {
-	NSParameterAssert(tree != nil);
-
-	int status = git_index_read_tree(self.git_index, tree.git_tree);
-	if (status != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:status description:@"Failed to read tree %@ into index.", tree];
-		return NO;
-	}
-
-	return YES;
-}
 - (BOOL)addData:(NSData *)data withName:(NSString *)name error:(NSError **)error {
 	NSParameterAssert(data != nil);
 	NSParameterAssert(name != nil);
@@ -220,6 +210,18 @@ typedef BOOL (^GTIndexPathspecMatchedBlock)(NSString *matchedPathspec, NSString 
 		return NO;
 	}
 	
+	return YES;
+}
+
+- (BOOL)addContentsOfTree:(GTTree *)tree error:(NSError **)error {
+	NSParameterAssert(tree != nil);
+
+	int status = git_index_read_tree(self.git_index, tree.git_tree);
+	if (status != GIT_OK) {
+		if (error != NULL) *error = [NSError git_errorFor:status description:@"Failed to read tree %@ into index.", tree];
+		return NO;
+	}
+
 	return YES;
 }
 

--- a/ObjectiveGit/GTIndex.m
+++ b/ObjectiveGit/GTIndex.m
@@ -143,7 +143,7 @@ typedef BOOL (^GTIndexPathspecMatchedBlock)(NSString *matchedPathspec, NSString 
 	const git_index_entry *entry = git_index_get_byindex(self.git_index, (unsigned int)index);
 	if (entry == NULL) return nil;
 
-	return [[GTIndexEntry alloc] initWithGitIndexEntry:entry];
+	return [[GTIndexEntry alloc] initWithGitIndexEntry:entry index:self error:NULL];
 }
 
 - (GTIndexEntry *)entryWithName:(NSString *)name {

--- a/ObjectiveGit/GTIndexEntry.h
+++ b/ObjectiveGit/GTIndexEntry.h
@@ -29,6 +29,9 @@
 
 #import <Foundation/Foundation.h>
 #include "git2/index.h"
+#import "GTObject.h"
+
+@class GTIndex;
 
 typedef NS_ENUM(NSInteger, GTIndexEntryStatus) {
 	GTIndexEntryStatusUpdated = 0,
@@ -40,6 +43,22 @@ typedef NS_ENUM(NSInteger, GTIndexEntryStatus) {
 
 @interface GTIndexEntry : NSObject
 
+/// Initializes the receiver with the given libgit2 index entry.
+///
+/// entry - The libgit2 index entry. Cannot be NULL.
+/// index - The index this entry belongs to.
+/// error - will be filled if an error occurs
+///
+/// Returns the initialized object.
+- (instancetype)initWithGitIndexEntry:(const git_index_entry *)entry index:(GTIndex *)index error:(NSError **)error NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithGitIndexEntry:(const git_index_entry *)entry;
+
+/// The underlying `git_index_entry` object.
+- (const git_index_entry *)git_index_entry __attribute__((objc_returns_inner_pointer));
+
+/// The entry's index. This may be nil if nil is passed in to -initWithGitIndexEntry:
+@property (nonatomic, strong, readonly) GTIndex *index;
+
 /// The repository-relative path for the entry.
 @property (nonatomic, readonly, copy) NSString *path;
 
@@ -49,14 +68,21 @@ typedef NS_ENUM(NSInteger, GTIndexEntryStatus) {
 /// What is the entry's status?
 @property (nonatomic, readonly) GTIndexEntryStatus status;
 
-/// Initializes the receiver with the given libgit2 index entry.
-///
-/// entry - The libgit2 index entry. Cannot be NULL.
-///
-/// Returns the initialized object.
-- (id)initWithGitIndexEntry:(const git_index_entry *)entry NS_DESIGNATED_INITIALIZER;
+/// The OID of the entry.
+@property (nonatomic, strong, readonly) GTOID *OID;
 
-/// The underlying `git_index_entry` object.
-- (const git_index_entry *)git_index_entry __attribute__((objc_returns_inner_pointer));
+/// Convert the entry into an GTObject
+///
+/// error - will be filled if an error occurs
+///
+/// Returns this entry as a GTObject or nil if an error occurred.
+- (GTObject *)GTObject:(NSError **)error;
+
+@end
+
+@interface GTObject (GTIndexEntry)
+
++ (instancetype)objectWithIndexEntry:(GTIndexEntry *)treeEntry error:(NSError **)error;
+- (instancetype)initWithIndexEntry:(GTIndexEntry *)treeEntry error:(NSError **)error;
 
 @end

--- a/ObjectiveGit/GTIndexEntry.m
+++ b/ObjectiveGit/GTIndexEntry.m
@@ -30,6 +30,11 @@
 #import "GTIndexEntry.h"
 #import "NSError+Git.h"
 #import "NSString+Git.h"
+#import "GTOID.h"
+#import "GTRepository.h"
+#import "GTIndex.h"
+
+#import "git2.h"
 
 @interface GTIndexEntry ()
 @property (nonatomic, assign, readonly) const git_index_entry *git_index_entry;
@@ -45,15 +50,20 @@
 
 #pragma mark Lifecycle
 
-- (id)initWithGitIndexEntry:(const git_index_entry *)entry {
+- (instancetype)initWithGitIndexEntry:(const git_index_entry *)entry index:(GTIndex *)index error:(NSError **)error {
 	NSParameterAssert(entry != NULL);
 
 	self = [super init];
 	if (self == nil) return nil;
 
 	_git_index_entry = entry;
+	_index = index;
 	
 	return self;
+}
+
+- (instancetype)initWithGitIndexEntry:(const git_index_entry *)entry {
+	return [self initWithGitIndexEntry:entry index:nil error:NULL];
 }
 
 #pragma mark Properties
@@ -86,4 +96,44 @@
 	return GTIndexEntryStatusUpToDate;
 }
 
+- (GTOID *)OID {
+	return [GTOID oidWithGitOid:&self.git_index_entry->id];
+}
+
+#pragma mark API
+
+- (GTRepository *)repository {
+	return self.index.repository;
+}
+
+- (GTObject *)GTObject:(NSError **)error {
+	return [GTObject objectWithIndexEntry:self error:error];
+}
+
 @end
+
+@implementation GTObject (GTIndexEntry)
+
++ (instancetype)objectWithIndexEntry:(GTIndexEntry *)indexEntry error:(NSError **)error {
+	return [[self alloc] initWithIndexEntry:indexEntry error:error];
+}
+
+- (instancetype)initWithIndexEntry:(GTIndexEntry *)indexEntry error:(NSError **)error {
+
+	git_object *obj;
+	int gitError = git_object_lookup(&obj, indexEntry.repository.git_repository, indexEntry.OID.git_oid, (git_otype)GTObjectTypeAny);
+
+	if (gitError < GIT_OK) {
+		if (error != NULL) {
+    		*error = [NSError git_errorFor:gitError description:@"Failed to get object for index entry."];
+		}
+
+		return nil;
+	}
+
+
+    return [self initWithObj:obj inRepository:indexEntry.repository];
+}
+
+@end
+

--- a/ObjectiveGit/GTIndexEntry.m
+++ b/ObjectiveGit/GTIndexEntry.m
@@ -45,7 +45,7 @@
 #pragma mark NSObject
 
 - (NSString *)description {
-  return [NSString stringWithFormat:@"<%@: %p> path: %@", self.class, self, self.path];
+	return [NSString stringWithFormat:@"<%@: %p> path: %@", self.class, self, self.path];
 }
 
 #pragma mark Lifecycle
@@ -58,7 +58,7 @@
 
 	_git_index_entry = entry;
 	_index = index;
-	
+
 	return self;
 }
 
@@ -92,7 +92,7 @@
 	} else if ((self.flags & GIT_IDXENTRY_REMOVE) != 0) {
 		return GTIndexEntryStatusRemoved;
 	}
-	
+
 	return GTIndexEntryStatusUpToDate;
 }
 
@@ -119,21 +119,18 @@
 }
 
 - (instancetype)initWithIndexEntry:(GTIndexEntry *)indexEntry error:(NSError **)error {
-
 	git_object *obj;
 	int gitError = git_object_lookup(&obj, indexEntry.repository.git_repository, indexEntry.OID.git_oid, (git_otype)GTObjectTypeAny);
 
 	if (gitError < GIT_OK) {
 		if (error != NULL) {
-    		*error = [NSError git_errorFor:gitError description:@"Failed to get object for index entry."];
+			*error = [NSError git_errorFor:gitError description:@"Failed to get object for index entry."];
 		}
 
 		return nil;
 	}
 
-
-    return [self initWithObj:obj inRepository:indexEntry.repository];
+	return [self initWithObj:obj inRepository:indexEntry.repository];
 }
 
 @end
-

--- a/ObjectiveGitTests/GTIndexSpec.m
+++ b/ObjectiveGitTests/GTIndexSpec.m
@@ -276,6 +276,32 @@ describe(@"adding files", ^{
 	});
 });
 
+describe(@"adding data", ^{
+	__block GTRepository *repo;
+	__block GTIndex *index;
+	__block NSError *error;
+	
+	beforeEach(^{
+		error = nil;
+		repo = self.testUnicodeFixtureRepository;
+		// Not sure why but it doesn't work with an in memory index
+		// index = [GTIndex inMemoryIndexWithRepository:repo error:&error];
+		index = [repo indexWithError:&error];
+		expect(error).to(beNil());
+	});
+	
+	it(@"should store data at given path", ^{
+		NSData *data = [NSData dataWithBytes:"foo" length:4];
+		[index addData:data withName:@"bar/foo" error:&error];
+		expect(error).to(beNil());
+		
+		NSData *returnData = [index dataWithName:@"bar/foo" error:&error];
+		expect(error).to(beNil());
+//		expect([[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]).to(equal(@"foo"));
+		expect(returnData).to(equal(data));
+	});
+});
+
 afterEach(^{
 	[self tearDown];
 });

--- a/ObjectiveGitTests/GTIndexSpec.m
+++ b/ObjectiveGitTests/GTIndexSpec.m
@@ -295,10 +295,9 @@ describe(@"adding data", ^{
 		[index addData:data withName:@"bar/foo" error:&error];
 		expect(error).to(beNil());
 		
-		NSData *returnData = [index dataWithName:@"bar/foo" error:&error];
+		GTIndexEntry *entry = [index entryWithName:@"bar/foo" error:&error];
+		expect(entry).notTo(beNil());
 		expect(error).to(beNil());
-//		expect([[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]).to(equal(@"foo"));
-		expect(returnData).to(equal(data));
 	});
 });
 


### PR DESCRIPTION
Hi,

I added support for libgit2 `git_index_add_frombuffer` function on `GTIndex` with the following methods:

```
// - (NSData *)dataWithName:(NSString *)name error:(NSError **)error; (removed)
- (BOOL)addData:(NSData *)data withName:(NSString *)name error:(NSError **)error;
```

I still have to add some documentation and need to make it work with an `inMemoryIndexWithRepository:error:`

Also I had to update `External/libgit2` to get the method, not sure if there's an issue with this.
Right now GTIndexSpec is passing but have failing specs at `GTConfigurationSpec` and `GTRemoteSpec`

So, I'm still working on it but I'm pushing this in case you find something fishy (specially with the updated dependency and the two failing specs)