### PR TITLE
API consistency sugestions

### DIFF
--- a/ObjectiveGit/GTBranch.h
+++ b/ObjectiveGit/GTBranch.h
@@ -75,7 +75,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// error(out) - will be filled if an error occurs
 ///
 /// returns a GTCommit object or nil if an error occurred
-- (nullable GTCommit *)targetCommitAndReturnError:(NSError **)error;
+- (nullable GTCommit *)targetCommitWithError:(NSError **)error;
 
 /// Count all commits in this branch
 ///
@@ -129,6 +129,9 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// Returns whether the calculation was successful.
 - (BOOL)calculateAhead:(size_t *)ahead behind:(size_t *)behind relativeTo:(GTBranch *)branch error:(NSError **)error;
+
+#pragma mark Deprecations
+- (nullable GTCommit *)targetCommitAndReturnError:(NSError **)error __deprecated_msg("use targetCommitWithError: instead.");
 
 @end
 

--- a/ObjectiveGit/GTBranch.m
+++ b/ObjectiveGit/GTBranch.m
@@ -120,7 +120,7 @@
 	return [[NSString alloc] initWithBytes:name length:end - name encoding:NSUTF8StringEncoding];
 }
 
-- (GTCommit *)targetCommitAndReturnError:(NSError **)error {
+- (GTCommit *)targetCommitWithError:(NSError **)error {
 	if (self.OID == nil) {
 		if (error != NULL) *error = GTReference.invalidReferenceError;
 		return nil;
@@ -216,6 +216,11 @@
 
 - (BOOL)calculateAhead:(size_t *)ahead behind:(size_t *)behind relativeTo:(GTBranch *)branch error:(NSError **)error {
 	return [self.repository calculateAhead:ahead behind:behind ofOID:self.OID relativeToOID:branch.OID error:error];
+}
+
+#pragma mark Deprecations
+- (GTCommit *)targetCommitAndReturnError:(NSError **)error {
+	return [self targetCommitWithError:error];
 }
 
 @end

--- a/ObjectiveGit/GTIndex.h
+++ b/ObjectiveGit/GTIndex.h
@@ -105,16 +105,16 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns a new GTIndexEntry, or nil if an error occurred.
 - (nullable GTIndexEntry *)entryAtIndex:(NSUInteger)index;
 
-/// Get the entry with the given name.
-- (GTIndexEntry *)entryWithName:(NSString *)name;
+/// Get the entry with the given path.
+- (GTIndexEntry *)entryWithPath:(NSString *)path;
 
 /// Get the entry with the given name.
 ///
-/// name  - The name of the entry to get. Cannot be nil.
+/// path  - The path of the entry to get. Cannot be nil.
 /// error - The error if one occurred.
 ///
 /// Returns a new GTIndexEntry, or nil if an error occurred.
-- (nullable GTIndexEntry *)entryWithName:(NSString *)name error:(NSError **)error;
+- (nullable GTIndexEntry *)entryWithPath:(NSString *)path error:(NSError **)error;
 
 /// Add an entry to the index.
 ///
@@ -141,9 +141,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Will fail if the receiver's repository is nil.
 ///
 /// data  - The content of the entry to add. Cannot be nil.
-/// name  - The name of the entry to add. Cannot be nil.
+/// path  - The path of the entry to add. Cannot be nil.
 /// error - The error if one occurred.
-- (BOOL)addData:(NSData *)data withName:(NSString *)name error:(NSError **)error;
+- (BOOL)addData:(NSData *)data withPath:(NSString *)path error:(NSError **)error;
 
 /// Reads the contents of the given tree into the index.
 ///
@@ -219,6 +219,11 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// Returns `YES` in the event that everything has gone smoothly. Otherwise, `NO`.
 - (BOOL)updatePathspecs:(nullable NSArray *)pathspecs error:(NSError **)error passingTest:(nullable BOOL (^)(NSString *matchedPathspec, NSString *path, BOOL *stop))block;
+
+#pragma mark Deprecations
+- (nullable GTIndexEntry *)entryWithName:(NSString *)name __deprecated_msg("use entryWithPath: instead.");
+- (nullable GTIndexEntry *)entryWithName:(NSString *)name error:(NSError **)error __deprecated_msg("use entryWithPath:error: instead.");
+
 
 @end
 

--- a/ObjectiveGit/GTIndex.m
+++ b/ObjectiveGit/GTIndex.m
@@ -146,15 +146,15 @@ typedef BOOL (^GTIndexPathspecMatchedBlock)(NSString *matchedPathspec, NSString 
 	return [[GTIndexEntry alloc] initWithGitIndexEntry:entry index:self error:NULL];
 }
 
-- (GTIndexEntry *)entryWithName:(NSString *)name {
-	return [self entryWithName:name error:NULL];
+- (GTIndexEntry *)entryWithPath:(NSString *)path {
+	return [self entryWithPath:path error:NULL];
 }
 
-- (GTIndexEntry *)entryWithName:(NSString *)name error:(NSError **)error {
+- (GTIndexEntry *)entryWithPath:(NSString *)path error:(NSError **)error {
 	size_t pos = 0;
-	int gitError = git_index_find(&pos, self.git_index, name.UTF8String);
+	int gitError = git_index_find(&pos, self.git_index, path.UTF8String);
 	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"%@ not found in index", name];
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"%@ not found in index", path];
 		return NULL;
 	}
 	return [self entryAtIndex:pos];
@@ -182,19 +182,19 @@ typedef BOOL (^GTIndexPathspecMatchedBlock)(NSString *matchedPathspec, NSString 
 	return YES;
 }
 
-- (BOOL)addData:(NSData *)data withName:(NSString *)name error:(NSError **)error {
+- (BOOL)addData:(NSData *)data withPath:(NSString *)path error:(NSError **)error {
 	NSParameterAssert(data != nil);
-	NSParameterAssert(name != nil);
+	NSParameterAssert(path != nil);
 	
 	git_index_entry entry;
 	memset(&entry, 0x0, sizeof(git_index_entry));
-	entry.path = [name cStringUsingEncoding:NSUTF8StringEncoding];
+	entry.path = [path cStringUsingEncoding:NSUTF8StringEncoding];
 	entry.mode = GIT_FILEMODE_BLOB;
 	
 	int status = git_index_add_frombuffer(self.git_index, &entry, [data bytes], [data length]);
 	
 	if (status != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:status description:@"Failed to add data with name %@ into index.", name];
+		if (error != NULL) *error = [NSError git_errorFor:status description:@"Failed to add data with name %@ into index.", path];
 		return NO;
 	}
 	
@@ -380,4 +380,13 @@ int GTIndexPathspecMatchFound(const char *path, const char *matched_pathspec, vo
       return (shouldPrecompose ? [string precomposedStringWithCanonicalMapping] : [string decomposedStringWithCanonicalMapping]);
 }
 
+#pragma mark Deprecations
+
+- (GTIndexEntry *)entryWithName:(NSString *)name {
+    return [self entryWithPath:name];
+}
+
+- (GTIndexEntry *)entryWithName:(NSString *)name error:(NSError **)error {
+    return [self entryWithPath:name error:error];
+}
 @end

--- a/ObjectiveGit/GTIndexEntry.h
+++ b/ObjectiveGit/GTIndexEntry.h
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// error - will be filled if an error occurs
 ///
 /// Returns the initialized object.
-- (instancetype)initWithGitIndexEntry:(const git_index_entry *)entry index:(GTIndex *)index error:(NSError **)error NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithGitIndexEntry:(const git_index_entry *)entry index:(nullable GTIndex *)index error:(NSError **)error NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithGitIndexEntry:(const git_index_entry *)entry;
 
 /// The underlying `git_index_entry` object.
@@ -79,12 +79,6 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// Returns this entry as a GTObject or nil if an error occurred.
 - (GTObject *)GTObject:(NSError **)error;
-
-/// Initializes the receiver with the given libgit2 index entry. Designated initializer.
-///
-/// Returns the initialized object.
-- (nullable instancetype)initWithGitIndexEntry:(const git_index_entry *)entry NS_DESIGNATED_INITIALIZER;
-
 
 @end
 

--- a/ObjectiveGitTests/GTBranchSpec.m
+++ b/ObjectiveGitTests/GTBranchSpec.m
@@ -121,13 +121,13 @@ describe(@"-reloadedBranchWithError:", ^{
 	it(@"should reload the branch from disk", ^{
 		static NSString * const originalSHA = @"a4bca6b67a5483169963572ee3da563da33712f7";
 		static NSString * const updatedSHA = @"6b0c1c8b8816416089c534e474f4c692a76ac14f";
-		expect([masterBranch targetCommitAndReturnError:NULL].SHA).to(equal(originalSHA));
+		expect([masterBranch targetCommitWithError:NULL].SHA).to(equal(originalSHA));
 		[masterBranch.reference referenceByUpdatingTarget:updatedSHA message:nil error:NULL];
 
 		GTBranch *reloadedBranch = [masterBranch reloadedBranchWithError:NULL];
 		expect(reloadedBranch).notTo(beNil());
-		expect([reloadedBranch targetCommitAndReturnError:NULL].SHA).to(equal(updatedSHA));
-		expect([masterBranch targetCommitAndReturnError:NULL].SHA).to(equal(originalSHA));
+		expect([reloadedBranch targetCommitWithError:NULL].SHA).to(equal(updatedSHA));
+		expect([masterBranch targetCommitWithError:NULL].SHA).to(equal(originalSHA));
 	});
 });
 

--- a/ObjectiveGitTests/GTIndexSpec.m
+++ b/ObjectiveGitTests/GTIndexSpec.m
@@ -53,8 +53,8 @@ it(@"should write to the repository and return a tree", ^{
 it(@"should write to a specific repository and return a tree", ^{
 	GTRepository *repository = self.bareFixtureRepository;
 	NSArray *branches = [repository branches:NULL];
-	GTCommit *masterCommit = [branches[0] targetCommitAndReturnError:NULL];
-	GTCommit *packedCommit = [branches[1] targetCommitAndReturnError:NULL];
+	GTCommit *masterCommit = [branches[0] targetCommitWithError:NULL];
+	GTCommit *packedCommit = [branches[1] targetCommitWithError:NULL];
 
 	expect(masterCommit).notTo(beNil());
 	expect(packedCommit).notTo(beNil());

--- a/ObjectiveGitTests/GTIndexSpec.m
+++ b/ObjectiveGitTests/GTIndexSpec.m
@@ -92,7 +92,7 @@ it(@"should add the contents of a tree", ^{
 		if (treeEntry.type == GTObjectTypeBlob) {
 			NSString *path = [root stringByAppendingString:treeEntry.name];
 
-			GTIndexEntry *indexEntry = [memoryIndex entryWithName:path];
+			GTIndexEntry *indexEntry = [memoryIndex entryWithPath:path];
 			expect(indexEntry).notTo(beNil());
 		}
 
@@ -229,40 +229,40 @@ describe(@"adding files", ^{
 
 	it(@"it preserves decomposed Unicode in index paths with precomposeunicode disabled", ^{
 		NSString *decomposedFilename = [filename decomposedStringWithCanonicalMapping];
-		GTIndexEntry *entry = [index entryWithName:decomposedFilename error:NULL];
+		GTIndexEntry *entry = [index entryWithPath:decomposedFilename error:NULL];
 		expect(@(fileStatusEqualsExpected(entry.path, GTStatusDeltaStatusUnmodified, GTStatusDeltaStatusUnmodified))).to(beTruthy());
 
 		expect(@([[NSFileManager defaultManager] moveItemAtURL:fileURL toURL:renamedFileURL error:NULL])).to(beTruthy());
 
-		entry = [index entryWithName:decomposedFilename error:NULL];
+		entry = [index entryWithPath:decomposedFilename error:NULL];
 		expect(@(fileStatusEqualsExpected(entry.path, GTStatusDeltaStatusUnmodified, GTStatusDeltaStatusDeleted))).to(beTruthy());
 
 		[index removeFile:filename error:NULL];
 		[index addFile:renamedFilename error:NULL];
 		[index write:NULL];
 
-		entry = [index entryWithName:[renamedFilename decomposedStringWithCanonicalMapping] error:NULL];
+		entry = [index entryWithPath:[renamedFilename decomposedStringWithCanonicalMapping] error:NULL];
 		expect(@(fileStatusEqualsExpected(entry.path, GTStatusDeltaStatusRenamed, GTStatusDeltaStatusUnmodified))).to(beTruthy());
 	});
 
 	it(@"it preserves precomposed Unicode in index paths with precomposeunicode enabled", ^{
-		GTIndexEntry *fileEntry = [index entryWithName:[filename decomposedStringWithCanonicalMapping] error:NULL];
+		GTIndexEntry *fileEntry = [index entryWithPath:[filename decomposedStringWithCanonicalMapping] error:NULL];
 		expect(fileEntry).notTo(beNil());
 		expect(@(fileStatusEqualsExpected(fileEntry.path, GTStatusDeltaStatusUnmodified, GTStatusDeltaStatusUnmodified))).to(beTruthy());
 
 		[configuration setBool:true forKey:@"core.precomposeunicode"];
 		expect(@([configuration boolForKey:@"core.precomposeunicode"])).to(beTruthy());
 
-		GTIndexEntry *decomposedFileEntry = [index entryWithName:[filename decomposedStringWithCanonicalMapping] error:NULL];
+		GTIndexEntry *decomposedFileEntry = [index entryWithPath:[filename decomposedStringWithCanonicalMapping] error:NULL];
 		expect(decomposedFileEntry).notTo(beNil());
 		expect(@(fileStatusEqualsExpected(decomposedFileEntry.path, GTStatusDeltaStatusUnmodified, GTStatusDeltaStatusDeleted))).to(beTruthy());
 
 		expect(@([[NSFileManager defaultManager] moveItemAtURL:fileURL toURL:renamedFileURL error:NULL])).to(beTruthy());
 
-		GTIndexEntry *precomposedFileEntry = [index entryWithName:filename error:NULL];
+		GTIndexEntry *precomposedFileEntry = [index entryWithPath:filename error:NULL];
 		expect(precomposedFileEntry).to(beNil());
 
-		decomposedFileEntry = [index entryWithName:[filename decomposedStringWithCanonicalMapping] error:NULL];
+		decomposedFileEntry = [index entryWithPath:[filename decomposedStringWithCanonicalMapping] error:NULL];
 		expect(decomposedFileEntry).notTo(beNil());
 		expect(@(fileStatusEqualsExpected(decomposedFileEntry.path, GTStatusDeltaStatusUnmodified, GTStatusDeltaStatusDeleted))).to(beTruthy());
 
@@ -270,7 +270,7 @@ describe(@"adding files", ^{
 		[index addFile:renamedFilename error:NULL];
 		[index write:NULL];
 
-		GTIndexEntry *precomposedRenamedFileEntry = [index entryWithName:renamedFilename error:NULL];
+		GTIndexEntry *precomposedRenamedFileEntry = [index entryWithPath:renamedFilename error:NULL];
 		expect(precomposedRenamedFileEntry).notTo(beNil());
 		expect(@(fileStatusEqualsExpected(precomposedFileEntry.path, GTStatusDeltaStatusRenamed, GTStatusDeltaStatusUntracked))).to(beTruthy());
 	});
@@ -292,10 +292,10 @@ describe(@"adding data", ^{
 	
 	it(@"should store data at given path", ^{
 		NSData *data = [NSData dataWithBytes:"foo" length:4];
-		[index addData:data withName:@"bar/foo" error:&error];
+		[index addData:data withPath:@"bar/foo" error:&error];
 		expect(error).to(beNil());
 		
-		GTIndexEntry *entry = [index entryWithName:@"bar/foo" error:&error];
+		GTIndexEntry *entry = [index entryWithPath:@"bar/foo" error:&error];
 		expect(entry).notTo(beNil());
 		expect(error).to(beNil());
 	});


### PR DESCRIPTION
Here I'm proposing two small API changes.
I recently started working with this library and some names felt misleading to me at first. So I presume they might be misleading to others:

First, `GTIndex` operations are performed with paths but that's not clear from the API so I changed all references like `entryWithName:` to `entryWithPath:`

Then on `GTBranch`, `targetCommitAndReturnError:` felt strange ¿Is it returning an error or a commit? so I renamed it to `targetCommitWithError:` 

I kept the old methods with a deprecation warning.

:warning: this PR is based on #452 so merging this will merge that PR too, needed that because XCode 6.3 was released.