### PR TITLE
Update libssh2 submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/openssl/openssl.git
 [submodule "libssh2"]
 	path = External/libssh2
-	url = git://git.libssh2.org/libssh2.git
+	url = https://github.com/libssh2/libssh2.git
 [submodule "Carthage.checkout/Nimble"]
 	path = Carthage/Checkouts/Nimble
 	url = https://github.com/Quick/Nimble.git


### PR DESCRIPTION
Moved to github as of 2015-03-23. There have been some commits but no official release since the move, so no need to update the commit yet. The biggest gain from the switch is no more invalid certificates.

```
fatal: unable to access 'https://git.libssh2.org/libssh2.git/': SSL certificate problem: Invalid certificate chain
Clone of 'git://git.libssh2.org/libssh2.git' into submodule path 'External/libssh2' failed
```

old: https://git.libssh2.org/?p=libssh2.git;a=shortlog;js=1
new: https://github.com/libssh2/libssh2/commits/master

announcement: http://www.libssh2.org/mail/libssh2-devel-archive-2015-03/0029.shtml