### PR TITLE
Avoid calling tag enumerator block if lookup returns nil tag

### DIFF
--- a/ObjectiveGit/GTRepository.m
+++ b/ObjectiveGit/GTRepository.m
@@ -457,7 +457,7 @@ static int GTRepositoryForeachTagCallback(const char *name, git_oid *oid, void *
 	GTTag *tag = (GTTag *)[info->myself lookUpObjectByGitOid:oid objectType:GTObjectTypeTag error:NULL];
 
 	BOOL stop = NO;
-	if (tag) {
+	if (tag != nil) {
 		info->block(tag, &stop);
 	}
 

--- a/ObjectiveGit/GTRepository.m
+++ b/ObjectiveGit/GTRepository.m
@@ -457,7 +457,9 @@ static int GTRepositoryForeachTagCallback(const char *name, git_oid *oid, void *
 	GTTag *tag = (GTTag *)[info->myself lookUpObjectByGitOid:oid objectType:GTObjectTypeTag error:NULL];
 
 	BOOL stop = NO;
-	info->block(tag, &stop);
+	if (tag) {
+		info->block(tag, &stop);
+	}
 
 	return stop ? GIT_EUSER : 0;
 }


### PR DESCRIPTION
Tag lookup may fail in `GTRepositoryForeachTagCallback`, resulting in a nil value for `tag`. This change skips the block if `tag` is nil.

Otherwise, a nil tag may be passed to the block. In the case of `allTagsWithError:`, the nil is added to an array, causing an exception or crash.