### PR TITLE
Better unique commit enumeration

### DIFF
--- a/ObjectiveGit/GTBranch.m
+++ b/ObjectiveGit/GTBranch.m
@@ -146,7 +146,7 @@
 }
 
 - (NSArray *)uniqueCommitsRelativeToBranch:(GTBranch *)otherBranch error:(NSError **)error {
-	GTEnumerator *enumerator = [self.repository enumerateUniqueCommitsUpToOID:self.OID relativeToOID:otherBranch.OID error:error];
+	GTEnumerator *enumerator = [self.repository enumeratorForCommitsStartingAtOID:self.OID endingAtOID:otherBranch.OID error:error];
 	return [enumerator allObjectsWithError:error];
 }
 

--- a/ObjectiveGit/GTBranch.m
+++ b/ObjectiveGit/GTBranch.m
@@ -146,7 +146,7 @@
 }
 
 - (NSArray *)uniqueCommitsRelativeToBranch:(GTBranch *)otherBranch error:(NSError **)error {
-	GTEnumerator *enumerator = [self.repository enumeratorForCommitsStartingAtOID:self.OID endingAtOID:otherBranch.OID error:error];
+	GTEnumerator *enumerator = [self.repository enumeratorForUniqueCommitsFromOID:self.OID relativeToOID:otherBranch.OID error:error];
 	return [enumerator allObjectsWithError:error];
 }
 

--- a/ObjectiveGit/GTRepository.h
+++ b/ObjectiveGit/GTRepository.h
@@ -565,6 +565,20 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns whether `ahead` and `behind` were successfully calculated.
 - (BOOL)calculateAhead:(size_t *)ahead behind:(size_t *)behind ofOID:(GTOID *)headOID relativeToOID:(GTOID *)baseOID error:(NSError **)error;
 
+/// Creates an enumerator for walking the local commits in relative to the
+/// tracking branch.
+///
+/// Note that this will only be accurate iff `trackingBranch` truly is
+/// `localBranch`s tracking branch. If you need more general functionality, see
+/// -[GTBranch uniqueCommitsRelativeToBranch:error:].
+///
+/// localBranch    - The local branch.
+/// trackingBranch - `localBranch`s tracking branch.
+/// error          - The error if one occurred.
+///
+/// Returns the enumerator or nil if an error occurred.
+- (nullable GTEnumerator *)enumerateLocalCommitsInBranch:(GTBranch *)localBranch trackingBranch:(GTBranch *)trackingBranch error:(NSError **)error;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTRepository.h
+++ b/ObjectiveGit/GTRepository.h
@@ -543,16 +543,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// distinguished using the value of `success`.
 - (nullable GTFilterList *)filterListWithPath:(NSString *)path blob:(nullable GTBlob *)blob mode:(GTFilterSourceMode)mode options:(GTFilterListOptions)options success:(nullable BOOL *)success error:(NSError **)error;
 
-/// Creates an enumerator for finding all commits in the history of `headOID`
-/// that do not exist in the history of `baseOID`.
-///
-/// headOID - Must not be nil.
-/// baseOID - Must not be nil.
-/// error   - If not NULL, set to any error that occurs.
-///
-/// Returns the created enumerator upon success, or `nil` if an error occurred.
-- (nullable GTEnumerator *)enumerateUniqueCommitsUpToOID:(GTOID *)headOID relativeToOID:(GTOID *)baseOID error:(NSError **)error;
-
 /// Calculates how far ahead/behind the commit represented by `headOID` is,
 /// relative to the commit represented by `baseOID`.
 ///

--- a/ObjectiveGit/GTRepository.h
+++ b/ObjectiveGit/GTRepository.h
@@ -565,19 +565,15 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns whether `ahead` and `behind` were successfully calculated.
 - (BOOL)calculateAhead:(size_t *)ahead behind:(size_t *)behind ofOID:(GTOID *)headOID relativeToOID:(GTOID *)baseOID error:(NSError **)error;
 
-/// Creates an enumerator for walking the local commits in relative to the
-/// tracking branch.
+/// Creates an enumerator for walking the local commits beginning at one OID and
+/// ending at another. It will *not* include the commit for `endingOID`.
 ///
-/// Note that this will only be accurate iff `trackingBranch` truly is
-/// `localBranch`s tracking branch. If you need more general functionality, see
-/// -[GTBranch uniqueCommitsRelativeToBranch:error:].
-///
-/// localBranch    - The local branch.
-/// trackingBranch - `localBranch`s tracking branch.
-/// error          - The error if one occurred.
+/// startingOID - The starting OID.
+/// endingOID   - The ending OID.
+/// error       - The error if one occurred.
 ///
 /// Returns the enumerator or nil if an error occurred.
-- (nullable GTEnumerator *)enumerateLocalCommitsInBranch:(GTBranch *)localBranch trackingBranch:(GTBranch *)trackingBranch error:(NSError **)error;
+- (nullable GTEnumerator *)enumeratorForCommitsStartingAtOID:(GTOID *)startingOID endingAtOID:(GTOID *)endingOID error:(NSError **)error;
 
 @end
 

--- a/ObjectiveGit/GTRepository.h
+++ b/ObjectiveGit/GTRepository.h
@@ -555,15 +555,15 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns whether `ahead` and `behind` were successfully calculated.
 - (BOOL)calculateAhead:(size_t *)ahead behind:(size_t *)behind ofOID:(GTOID *)headOID relativeToOID:(GTOID *)baseOID error:(NSError **)error;
 
-/// Creates an enumerator for walking the local commits beginning at one OID and
-/// ending at another. It will *not* include the commit for `endingOID`.
+/// Creates an enumerator for walking the unique commits, as determined by a
+/// pushing a starting OID and hiding the relative OID.
 ///
-/// startingOID - The starting OID.
-/// endingOID   - The ending OID.
+/// fromOID     - The starting OID.
+/// relativeOID - The OID to hide.
 /// error       - The error if one occurred.
 ///
 /// Returns the enumerator or nil if an error occurred.
-- (nullable GTEnumerator *)enumeratorForCommitsStartingAtOID:(GTOID *)startingOID endingAtOID:(GTOID *)endingOID error:(NSError **)error;
+- (nullable GTEnumerator *)enumeratorForUniqueCommitsFromOID:(GTOID *)fromOID relativeToOID:(GTOID *)relativeOID error:(NSError **)error;
 
 @end
 

--- a/ObjectiveGit/GTRepository.m
+++ b/ObjectiveGit/GTRepository.m
@@ -880,24 +880,6 @@ static int checkoutNotifyCallback(git_checkout_notify_t why, const char *path, c
 	}
 }
 
-- (GTEnumerator *)enumerateUniqueCommitsUpToOID:(GTOID *)headOID relativeToOID:(GTOID *)baseOID error:(NSError **)error {
-	NSParameterAssert(headOID != nil);
-	NSParameterAssert(baseOID != nil);
-	
-	GTCommit *mergeBase = [self mergeBaseBetweenFirstOID:headOID secondOID:baseOID error:error];
-	if (mergeBase == nil) return nil;
-	
-	GTEnumerator *enumerator = [[GTEnumerator alloc] initWithRepository:self error:error];
-	if (enumerator == nil) return nil;
-	
-	[enumerator resetWithOptions:GTEnumeratorOptionsTimeSort];
-	
-	if (![enumerator pushSHA:headOID.SHA error:error]) return nil;
-	if (![enumerator hideSHA:mergeBase.OID.SHA error:error]) return nil;
-
-	return enumerator;
-}
-
 - (BOOL)calculateAhead:(size_t *)ahead behind:(size_t *)behind ofOID:(GTOID *)headOID relativeToOID:(GTOID *)baseOID error:(NSError **)error {
 	NSParameterAssert(headOID != nil);
 	NSParameterAssert(baseOID != nil);

--- a/ObjectiveGit/GTRepository.m
+++ b/ObjectiveGit/GTRepository.m
@@ -912,4 +912,20 @@ static int checkoutNotifyCallback(git_checkout_notify_t why, const char *path, c
 	return YES;
 }
 
+- (GTEnumerator *)enumerateLocalCommitsInBranch:(GTBranch *)localBranch trackingBranch:(GTBranch *)trackingBranch error:(NSError **)error {
+	NSParameterAssert(localBranch != nil);
+	NSParameterAssert(trackingBranch != nil);
+
+	GTEnumerator *enumerator = [[GTEnumerator alloc] initWithRepository:self error:error];
+	if (enumerator == nil) return nil;
+
+	BOOL success = [enumerator pushSHA:localBranch.OID.SHA error:error];
+	if (!success) return nil;
+
+	success = [enumerator hideSHA:trackingBranch.OID.SHA error:error];
+	if (!success) return nil;
+
+	return enumerator;
+}
+
 @end

--- a/ObjectiveGit/GTRepository.m
+++ b/ObjectiveGit/GTRepository.m
@@ -894,17 +894,17 @@ static int checkoutNotifyCallback(git_checkout_notify_t why, const char *path, c
 	return YES;
 }
 
-- (nullable GTEnumerator *)enumeratorForCommitsStartingAtOID:(GTOID *)startingOID endingAtOID:(GTOID *)endingOID error:(NSError **)error {
-	NSParameterAssert(startingOID != nil);
-	NSParameterAssert(endingOID != nil);
+- (nullable GTEnumerator *)enumeratorForUniqueCommitsFromOID:(GTOID *)fromOID relativeToOID:(GTOID *)relativeOID error:(NSError **)error {
+	NSParameterAssert(fromOID != nil);
+	NSParameterAssert(relativeOID != nil);
 
 	GTEnumerator *enumerator = [[GTEnumerator alloc] initWithRepository:self error:error];
 	if (enumerator == nil) return nil;
 
-	BOOL success = [enumerator pushSHA:startingOID.SHA error:error];
+	BOOL success = [enumerator pushSHA:fromOID.SHA error:error];
 	if (!success) return nil;
 
-	success = [enumerator hideSHA:endingOID.SHA error:error];
+	success = [enumerator hideSHA:relativeOID.SHA error:error];
 	if (!success) return nil;
 
 	return enumerator;

--- a/ObjectiveGit/GTRepository.m
+++ b/ObjectiveGit/GTRepository.m
@@ -912,17 +912,17 @@ static int checkoutNotifyCallback(git_checkout_notify_t why, const char *path, c
 	return YES;
 }
 
-- (GTEnumerator *)enumerateLocalCommitsInBranch:(GTBranch *)localBranch trackingBranch:(GTBranch *)trackingBranch error:(NSError **)error {
-	NSParameterAssert(localBranch != nil);
-	NSParameterAssert(trackingBranch != nil);
+- (nullable GTEnumerator *)enumeratorForCommitsStartingAtOID:(GTOID *)startingOID endingAtOID:(GTOID *)endingOID error:(NSError **)error {
+	NSParameterAssert(startingOID != nil);
+	NSParameterAssert(endingOID != nil);
 
 	GTEnumerator *enumerator = [[GTEnumerator alloc] initWithRepository:self error:error];
 	if (enumerator == nil) return nil;
 
-	BOOL success = [enumerator pushSHA:localBranch.OID.SHA error:error];
+	BOOL success = [enumerator pushSHA:startingOID.SHA error:error];
 	if (!success) return nil;
 
-	success = [enumerator hideSHA:trackingBranch.OID.SHA error:error];
+	success = [enumerator hideSHA:endingOID.SHA error:error];
 	if (!success) return nil;
 
 	return enumerator;


### PR DESCRIPTION
This is going to be much faster, though less general, than the existing `-[GTBranch uniqueCommitsRelativeToBranch:error:]` method.