### PR TITLE
Added NS_UNAVAILABLE flag to all unneeded super initializers (NSObject init)

### DIFF
--- a/ObjectiveGit/GTBlame.h
+++ b/ObjectiveGit/GTBlame.h
@@ -17,6 +17,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// A `GTBlame` provides authorship info, through `GTBlameHunk` for each line of a file. Analogous to `git_blame` in libgit2.
 @interface GTBlame : NSObject
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Designated initializer.
 ///
 /// blame - A git_blame to wrap. May not be NULL.

--- a/ObjectiveGit/GTBlame.m
+++ b/ObjectiveGit/GTBlame.m
@@ -21,6 +21,11 @@
 
 @implementation GTBlame
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithGitBlame:(git_blame *)blame {
 	NSParameterAssert(blame != NULL);
 	

--- a/ObjectiveGit/GTBlameHunk.h
+++ b/ObjectiveGit/GTBlameHunk.h
@@ -17,6 +17,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// A `GTBlameHunk` is an object that provides authorship info for a set of lines in a `GTBlame`.
 @interface GTBlameHunk : NSObject
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Designated initializer.
 ///
 /// hunk - A git_blame_hunk to wrap. May not be NULL.

--- a/ObjectiveGit/GTBlameHunk.m
+++ b/ObjectiveGit/GTBlameHunk.m
@@ -12,6 +12,11 @@
 
 @implementation GTBlameHunk
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithGitBlameHunk:(git_blame_hunk)hunk {
 	self = [super init];
 	if (self == nil) return nil;

--- a/ObjectiveGit/GTBranch.h
+++ b/ObjectiveGit/GTBranch.h
@@ -54,6 +54,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *)localNamePrefix;
 + (NSString *)remoteNamePrefix;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Designated initializer.
 ///
 /// ref  - The branch reference to wrap. Must not be nil.

--- a/ObjectiveGit/GTBranch.m
+++ b/ObjectiveGit/GTBranch.m
@@ -69,6 +69,11 @@
 	return [[self alloc] initWithReference:ref repository:repo];
 }
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (nullable instancetype)initWithReference:(GTReference *)ref repository:(GTRepository *)repo {
 	NSParameterAssert(ref != nil);
 	NSParameterAssert(repo != nil);

--- a/ObjectiveGit/GTConfiguration.h
+++ b/ObjectiveGit/GTConfiguration.h
@@ -23,6 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// repository, this will always be nil.
 @property (nonatomic, readonly, copy, nullable) NSArray *remotes;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Creates and returns a configuration which includes the global, XDG, and
 /// system configurations.
 + (nullable instancetype)defaultConfiguration;

--- a/ObjectiveGit/GTConfiguration.m
+++ b/ObjectiveGit/GTConfiguration.m
@@ -33,6 +33,11 @@
 	}
 }
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithGitConfig:(git_config *)config repository:(GTRepository *)repository {
 	NSParameterAssert(config != NULL);
 

--- a/ObjectiveGit/GTDiff.h
+++ b/ObjectiveGit/GTDiff.h
@@ -259,6 +259,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns a newly created GTDiff, or nil if an error occurred.
 + (nullable instancetype)diffWorkingDirectoryToHEADInRepository:(GTRepository *)repository options:(nullable NSDictionary *)options error:(NSError **)error;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Designated initialiser.
 ///
 /// diff       - The diff to represent. Cannot be NULL.

--- a/ObjectiveGit/GTDiff.m
+++ b/ObjectiveGit/GTDiff.m
@@ -156,6 +156,11 @@ NSString *const GTDiffFindOptionsRenameLimitKey = @"GTDiffFindOptionsRenameLimit
 	return HEADIndexDiff;
 }
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithGitDiff:(git_diff *)diff repository:(GTRepository *)repository {
 	NSParameterAssert(diff != NULL);
 	NSParameterAssert(repository != nil);

--- a/ObjectiveGit/GTDiffDelta.h
+++ b/ObjectiveGit/GTDiffDelta.h
@@ -115,6 +115,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns a diff delta, or nil if an error occurs.
 + (nullable instancetype)diffDeltaFromData:(nullable NSData *)oldData forPath:(nullable NSString *)oldDataPath toData:(nullable NSData *)newData forPath:(nullable NSString *)newDataPath options:(nullable NSDictionary *)options error:(NSError **)error;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Initializes the receiver to wrap the delta at the given index.
 ///
 /// diff       - The diff which contains the delta to wrap. Must not be nil.

--- a/ObjectiveGit/GTDiffDelta.m
+++ b/ObjectiveGit/GTDiffDelta.m
@@ -132,6 +132,11 @@ static int GTDiffDeltaCallback(const git_diff_delta *delta, float progress, void
 	}];
 }
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithDiff:(GTDiff *)diff deltaIndex:(NSUInteger)deltaIndex {
 	NSCParameterAssert(diff != nil);
 

--- a/ObjectiveGit/GTDiffFile.h
+++ b/ObjectiveGit/GTDiffFile.h
@@ -48,6 +48,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// The git_diff_file represented by the receiver.
 @property (nonatomic, readonly) git_diff_file git_diff_file;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Initializes the receiver with the provided libgit2 object. Designated initializer.
 ///
 /// file - The git_diff_file wrapped by the receiver.

--- a/ObjectiveGit/GTDiffFile.m
+++ b/ObjectiveGit/GTDiffFile.m
@@ -11,6 +11,11 @@
 
 @implementation GTDiffFile
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithGitDiffFile:(git_diff_file)file {
 	NSParameterAssert(file.path != NULL);
 

--- a/ObjectiveGit/GTDiffHunk.h
+++ b/ObjectiveGit/GTDiffHunk.h
@@ -22,6 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// The number of lines represented in the hunk.
 @property (nonatomic, readonly) NSUInteger lineCount;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Designated initialiser.
 ///
 /// The contents of a hunk are lazily loaded, therefore we initialise the object

--- a/ObjectiveGit/GTDiffHunk.m
+++ b/ObjectiveGit/GTDiffHunk.m
@@ -25,6 +25,11 @@
 
 @implementation GTDiffHunk
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithPatch:(GTDiffPatch *)patch hunkIndex:(NSUInteger)hunkIndex {
 	NSParameterAssert(patch != nil);
 

--- a/ObjectiveGit/GTDiffLine.h
+++ b/ObjectiveGit/GTDiffLine.h
@@ -45,6 +45,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// The number of newlines appearing in `-content`.
 @property (nonatomic, readonly) NSInteger lineCount;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Designated initialiser.
 ///
 /// line - The diff line to wrap. May not be NULL.

--- a/ObjectiveGit/GTDiffLine.m
+++ b/ObjectiveGit/GTDiffLine.m
@@ -10,6 +10,11 @@
 
 @implementation GTDiffLine
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithGitLine:(const git_diff_line *)line {
 	self = [super init];
 	if (self == nil) return nil;

--- a/ObjectiveGit/GTDiffPatch.h
+++ b/ObjectiveGit/GTDiffPatch.h
@@ -32,6 +32,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// The number of hunks in this patch.
 @property (nonatomic, readonly) NSUInteger hunkCount;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Initializes the receiver to wrap the given patch. Designated initializer.
 ///
 /// patch - The patch object to wrap and take ownership of. This will

--- a/ObjectiveGit/GTDiffPatch.m
+++ b/ObjectiveGit/GTDiffPatch.m
@@ -20,6 +20,11 @@
 
 #pragma mark Lifecycle
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithGitPatch:(git_patch *)patch delta:(GTDiffDelta *)delta {
 	NSParameterAssert(patch != NULL);
 	NSParameterAssert(delta != nil);

--- a/ObjectiveGit/GTEnumerator.h
+++ b/ObjectiveGit/GTEnumerator.h
@@ -62,6 +62,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// To set new options, use -resetWithOptions:.
 @property (nonatomic, assign, readonly) GTEnumeratorOptions options;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Initializes the receiver to enumerate the commits in the given repository. Designated initializer.
 ///
 /// repo  - The repository to enumerate the commits of. This must not be nil.

--- a/ObjectiveGit/GTEnumerator.m
+++ b/ObjectiveGit/GTEnumerator.m
@@ -48,6 +48,11 @@
 
 #pragma mark Lifecycle
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithRepository:(GTRepository *)repo error:(NSError **)error {
 	NSParameterAssert(repo != nil);
 

--- a/ObjectiveGit/GTFetchHeadEntry.h
+++ b/ObjectiveGit/GTFetchHeadEntry.h
@@ -29,6 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// Flag indicating if we need to merge this entry or not.
 @property (nonatomic, getter = isMerge, readonly) BOOL merge;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Initializes a GTFetchHeadEntry. Designated initializer.
 ///
 /// reference       - Reference on the repository. Cannot be nil.

--- a/ObjectiveGit/GTFetchHeadEntry.m
+++ b/ObjectiveGit/GTFetchHeadEntry.m
@@ -11,6 +11,11 @@
 
 @implementation GTFetchHeadEntry
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithReference:(GTReference *)reference remoteURLString:(NSString *)remoteURLString targetOID:(GTOID *)targetOID isMerge:(BOOL)merge {
 	NSParameterAssert(reference != nil);
 	NSParameterAssert(remoteURLString != nil);

--- a/ObjectiveGit/GTFilter.h
+++ b/ObjectiveGit/GTFilter.h
@@ -40,6 +40,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// chance to clean up the `payload`.
 @property (nonatomic, copy) void (^cleanupBlock)(void *payload);
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Initializes the object with the given name and attributes. Designated initializer.
 ///
 /// name       - The name for the filter. Cannot be nil.

--- a/ObjectiveGit/GTFilter.m
+++ b/ObjectiveGit/GTFilter.m
@@ -42,6 +42,11 @@ static NSMutableDictionary *GTFiltersGitFilterToRegisteredFilters = nil;
 	GTFiltersGitFilterToRegisteredFilters = [[NSMutableDictionary alloc] init];
 }
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithName:(NSString *)name attributes:(NSString *)attributes applyBlock:(NSData * (^)(void **payload, NSData *from, GTFilterSource *source, BOOL *applied))applyBlock {
 	NSParameterAssert(name != nil);
 	NSParameterAssert(applyBlock != NULL);

--- a/ObjectiveGit/GTFilterList.h
+++ b/ObjectiveGit/GTFilterList.h
@@ -23,6 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// An opaque list of filters that apply to a given path.
 @interface GTFilterList : NSObject
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Initializes the receiver to wrap the given `git_filter_list`. Designated initializer.
 ///
 /// filterList - The filter list to wrap and take ownership of. This filter list

--- a/ObjectiveGit/GTFilterList.m
+++ b/ObjectiveGit/GTFilterList.m
@@ -25,6 +25,11 @@
 
 #pragma mark Lifecycle
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithGitFilterList:(git_filter_list *)filterList {
 	NSParameterAssert(filterList != NULL);
 

--- a/ObjectiveGit/GTFilterSource.h
+++ b/ObjectiveGit/GTFilterSource.h
@@ -40,6 +40,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// The filter mode.
 @property (nonatomic, readonly, assign) GTFilterSourceMode mode;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Intializes the receiver with the given filter source. Designated initializer.
 ///
 /// source - The filter source. Cannot be NULL.

--- a/ObjectiveGit/GTFilterSource.m
+++ b/ObjectiveGit/GTFilterSource.m
@@ -16,6 +16,11 @@
 
 #pragma mark Lifecycle
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithGitFilterSource:(const git_filter_source *)source {
 	NSParameterAssert(source != NULL);
 

--- a/ObjectiveGit/GTIndex.h
+++ b/ObjectiveGit/GTIndex.h
@@ -71,6 +71,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns the loaded index, or nil if an error occurred.
 + (instancetype)indexWithFileURL:(NSURL *)fileURL repository:(GTRepository *)repository error:(NSError **)error;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Initializes the receiver with the given libgit2 index. Designated initializer.
 ///
 /// index      - The libgit2 index from which the index should be created. Cannot

--- a/ObjectiveGit/GTIndex.m
+++ b/ObjectiveGit/GTIndex.m
@@ -87,6 +87,11 @@ typedef BOOL (^GTIndexPathspecMatchedBlock)(NSString *matchedPathspec, NSString 
 	return [[self alloc] initWithGitIndex:index repository:repository];
 }
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 + (instancetype)indexWithFileURL:(NSURL *)fileURL repository:(GTRepository *)repository error:(NSError **)error {
 	NSParameterAssert(fileURL != nil);
 	NSParameterAssert(fileURL.isFileURL);

--- a/ObjectiveGit/GTIndexEntry.h
+++ b/ObjectiveGit/GTIndexEntry.h
@@ -45,6 +45,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface GTIndexEntry : NSObject
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Initializes the receiver with the given libgit2 index entry.
 ///
 /// entry - The libgit2 index entry. Cannot be NULL.

--- a/ObjectiveGit/GTIndexEntry.m
+++ b/ObjectiveGit/GTIndexEntry.m
@@ -50,6 +50,11 @@
 
 #pragma mark Lifecycle
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithGitIndexEntry:(const git_index_entry *)entry index:(GTIndex *)index error:(NSError **)error {
 	NSParameterAssert(entry != NULL);
 

--- a/ObjectiveGit/GTOID.h
+++ b/ObjectiveGit/GTOID.h
@@ -22,6 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// inserted into the ODB yet.
 @property (nonatomic, readonly, assign, getter = isZero) BOOL zero;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Initializes the receiver with the given git_oid. Designated initializer.
 ///
 /// git_oid - The underlying git_oid. Cannot be NULL.

--- a/ObjectiveGit/GTOID.m
+++ b/ObjectiveGit/GTOID.m
@@ -39,6 +39,11 @@
 
 #pragma mark Lifecycle
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithGitOid:(const git_oid *)oid {
 	NSParameterAssert(oid != NULL);
 

--- a/ObjectiveGit/GTObject.h
+++ b/ObjectiveGit/GTObject.h
@@ -57,6 +57,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, strong) GTRepository *repository;
 @property (nonatomic, readonly, nullable) GTOID *OID;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Designated initializer.
 - (nullable id)initWithObj:(git_object *)theObject inRepository:(GTRepository *)theRepo NS_DESIGNATED_INITIALIZER;
 

--- a/ObjectiveGit/GTObject.m
+++ b/ObjectiveGit/GTObject.m
@@ -70,6 +70,11 @@
 
 #pragma mark API 
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (id)initWithObj:(git_object *)object inRepository:(GTRepository *)repo {
 	NSParameterAssert(object != NULL);
 	NSParameterAssert(repo != nil);

--- a/ObjectiveGit/GTObjectDatabase.h
+++ b/ObjectiveGit/GTObjectDatabase.h
@@ -33,6 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, strong) GTRepository *repository;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Initializes the object database with the given repository. Designated initializer.
 ///
 /// repo  - The repository from which the object database should be created.

--- a/ObjectiveGit/GTObjectDatabase.m
+++ b/ObjectiveGit/GTObjectDatabase.m
@@ -56,6 +56,11 @@
 
 #pragma mark API
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithRepository:(GTRepository *)repo error:(NSError **)error {
 	NSParameterAssert(repo != nil);
 

--- a/ObjectiveGit/GTOdbObject.h
+++ b/ObjectiveGit/GTOdbObject.h
@@ -15,6 +15,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// The repository in which the object resides.
 @property (nonatomic, readonly, strong) GTRepository *repository;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Initializes the object with the underlying libgit2 object and repository. Designated initializer.
 ///
 /// object     - The underlying libgit2 object. Cannot be NULL.

--- a/ObjectiveGit/GTOdbObject.m
+++ b/ObjectiveGit/GTOdbObject.m
@@ -31,6 +31,11 @@
 
 #pragma mark API
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithOdbObj:(git_odb_object *)object repository:(GTRepository *)repository {
 	NSParameterAssert(object != NULL);
 	NSParameterAssert(repository != nil);

--- a/ObjectiveGit/GTReference.h
+++ b/ObjectiveGit/GTReference.h
@@ -64,6 +64,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable instancetype)referenceByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error;
 - (nullable instancetype)initByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Designated initializer.
 ///
 /// ref        - The reference to wrap. Must not be nil.

--- a/ObjectiveGit/GTReference.m
+++ b/ObjectiveGit/GTReference.m
@@ -74,6 +74,11 @@ static NSString *referenceTypeToString(GTReferenceType type) {
 	return [[self alloc] initByResolvingSymbolicReference:symbolicRef error:error];
 }
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initByResolvingSymbolicReference:(GTReference *)symbolicRef error:(NSError **)error {
 	NSParameterAssert(symbolicRef != nil);
 

--- a/ObjectiveGit/GTReflog+Private.h
+++ b/ObjectiveGit/GTReflog+Private.h
@@ -12,6 +12,8 @@
 
 @interface GTReflog ()
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Initializes the receiver with a reference. Designated initializer.
 ///
 /// reference - The reference whose reflog is being represented. Cannot be nil.

--- a/ObjectiveGit/GTReflog.m
+++ b/ObjectiveGit/GTReflog.m
@@ -33,6 +33,11 @@
 	if (_git_reflog != NULL) git_reflog_free(_git_reflog);
 }
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithReference:(GTReference *)reference {
 	NSParameterAssert(reference != nil);
 	NSParameterAssert(reference.name != nil);

--- a/ObjectiveGit/GTRemote.h
+++ b/ObjectiveGit/GTRemote.h
@@ -86,6 +86,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns the loaded remote, or nil if an error occurred.
 + (nullable instancetype)remoteWithName:(NSString *)name inRepository:(GTRepository *)repo error:(NSError **)error;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Initialize a remote from a `git_remote`. Designated initializer.
 ///
 /// remote - The underlying `git_remote` object. Cannot be nil.

--- a/ObjectiveGit/GTRemote.m
+++ b/ObjectiveGit/GTRemote.m
@@ -60,6 +60,11 @@ NSString * const GTRemoteRenameProblematicRefSpecs = @"GTRemoteRenameProblematic
 	return [[self alloc] initWithGitRemote:remote inRepository:repo];
 }
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithGitRemote:(git_remote *)remote inRepository:(GTRepository *)repo {
 	NSParameterAssert(remote != NULL);
 	NSParameterAssert(repo != nil);

--- a/ObjectiveGit/GTRepository.h
+++ b/ObjectiveGit/GTRepository.h
@@ -195,6 +195,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns the initialized repository, or nil if an error occurred.
 - (nullable instancetype)initWithURL:(NSURL *)localFileURL error:(NSError **)error;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Initializes the receiver to wrap the given repository object. Designated initializer.
 ///
 /// repository - The repository to wrap. The receiver will take over memory

--- a/ObjectiveGit/GTRepository.m
+++ b/ObjectiveGit/GTRepository.m
@@ -157,6 +157,11 @@ typedef struct {
 	return [[self alloc] initWithURL:localFileURL error:error];
 }
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithGitRepository:(git_repository *)repository {
 	NSParameterAssert(repository != nil);
 

--- a/ObjectiveGit/GTStatusDelta.h
+++ b/ObjectiveGit/GTStatusDelta.h
@@ -47,6 +47,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// `GTStatusDeltaStatusCopied`.
 @property (nonatomic, readonly) double similarity;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Designated initializer.
 - (nullable instancetype)initWithGitDiffDelta:(const git_diff_delta *)delta NS_DESIGNATED_INITIALIZER;
 

--- a/ObjectiveGit/GTStatusDelta.m
+++ b/ObjectiveGit/GTStatusDelta.m
@@ -12,6 +12,11 @@
 
 @implementation GTStatusDelta
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithGitDiffDelta:(const git_diff_delta *)delta {
 	self = [super init];
 	if (self == nil || delta == NULL) return nil;

--- a/ObjectiveGit/GTSubmodule.h
+++ b/ObjectiveGit/GTSubmodule.h
@@ -90,6 +90,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// `.git/config` or `.gitmodules` file.
 @property (nonatomic, copy, readonly, nullable) NSString *URLString;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Initializes the receiver to wrap the given submodule object. Designated initializer.
 ///
 /// submodule  - The submodule to wrap. The receiver will not own this object, so

--- a/ObjectiveGit/GTSubmodule.m
+++ b/ObjectiveGit/GTSubmodule.m
@@ -83,6 +83,11 @@
 	}
 }
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithGitSubmodule:(git_submodule *)submodule parentRepository:(GTRepository *)repository {
 	NSParameterAssert(submodule != NULL);
 	NSParameterAssert(repository != nil);

--- a/ObjectiveGit/GTTreeBuilder.h
+++ b/ObjectiveGit/GTTreeBuilder.h
@@ -54,6 +54,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// Get the number of entries listed in a treebuilder.
 @property (nonatomic, readonly) NSUInteger entryCount;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Initializes the receiver, optionally from an existing tree. Designated initializer.
 ///
 /// treeOrNil  - Source tree (or nil)

--- a/ObjectiveGit/GTTreeBuilder.m
+++ b/ObjectiveGit/GTTreeBuilder.m
@@ -62,6 +62,11 @@
 
 #pragma mark Lifecycle
 
+- (instancetype)init {
+	NSAssert(NO, @"Call to an unavailable initializer.");
+	return nil;
+}
+
 - (instancetype)initWithTree:(GTTree *)treeOrNil repository:(GTRepository *)repository error:(NSError **)error {
 	NSParameterAssert(repository != nil);
 


### PR DESCRIPTION
I think that this fix is better than the previously submitted in #476, as XCode marks `init` usages as “unavailable” and, if for some reason an `init` call is achieved in runtime, it raises a runtime error via NSAssert.