### PR TITLE
Add failing test for SSH clone

### DIFF
--- a/ObjectiveGitTests/GTRepositorySpec.m
+++ b/ObjectiveGitTests/GTRepositorySpec.m
@@ -84,6 +84,29 @@ describe(@"+cloneFromURL:toWorkingDirectory:options:error:transferProgressBlock:
 		workdirURL = [self.tempDirectoryFileURL URLByAppendingPathComponent:@"temp-repo"];
 	});
 
+	describe(@"with remote ssh repositories", ^{
+		beforeEach(^{
+			originURL = [NSURL URLWithString:@"ssh://github.com/libgit2/rugged.git"];
+			workdirURL = [self.tempDirectoryFileURL URLByAppendingPathComponent:@"rugged"];
+		});
+
+		it(@"should not throw an error", ^{
+			NSError *error = nil;
+			__block BOOL credentialProviderCalled = NO;
+			GTCredentialProvider *provider = [GTCredentialProvider providerWithBlock:^GTCredential * __nonnull(GTCredentialType type, NSString *URL, NSString *username) {
+				credentialProviderCalled = YES;
+				return nil;
+			}];
+
+			repository = [GTRepository cloneFromURL:originURL toWorkingDirectory:workdirURL options:@{ GTRepositoryCloneOptionsCredentialProvider: provider } error:&error transferProgressBlock:transferProgressBlock checkoutProgressBlock:checkoutProgressBlock];
+			expect(repository).notTo(beNil());
+			expect(error).to(beNil());
+			expect(@(transferProgressCalled)).to(beTruthy());
+			expect(@(checkoutProgressCalled)).to(beTruthy());
+			expect(@(credentialProviderCalled)).to(beTruthy());
+		});
+	});
+
 	describe(@"with local repositories", ^{
 		beforeEach(^{
 			originURL = self.bareFixtureRepository.gitDirectoryURL;

--- a/ObjectiveGitTests/GTRepositorySpec.m
+++ b/ObjectiveGitTests/GTRepositorySpec.m
@@ -90,7 +90,7 @@ describe(@"+cloneFromURL:toWorkingDirectory:options:error:transferProgressBlock:
 			workdirURL = [self.tempDirectoryFileURL URLByAppendingPathComponent:@"rugged"];
 		});
 
-		it(@"should not throw an error", ^{
+		it(@"should accept ssh urls", ^{
 			NSError *error = nil;
 			__block BOOL credentialProviderCalled = NO;
 			GTCredentialProvider *provider = [GTCredentialProvider providerWithBlock:^GTCredential * __nonnull(GTCredentialType type, NSString *URL, NSString *username) {
@@ -99,10 +99,9 @@ describe(@"+cloneFromURL:toWorkingDirectory:options:error:transferProgressBlock:
 			}];
 
 			repository = [GTRepository cloneFromURL:originURL toWorkingDirectory:workdirURL options:@{ GTRepositoryCloneOptionsCredentialProvider: provider } error:&error transferProgressBlock:transferProgressBlock checkoutProgressBlock:checkoutProgressBlock];
-			expect(repository).notTo(beNil());
-			expect(error).to(beNil());
-			expect(@(transferProgressCalled)).to(beTruthy());
-			expect(@(checkoutProgressCalled)).to(beTruthy());
+			NSError *underlyingError = error.userInfo[NSUnderlyingErrorKey];
+			expect(underlyingError.localizedDescription).notTo(equal(@"Unsupported URL protocol"));
+			expect(error).notTo(beNil());
 			expect(@(credentialProviderCalled)).to(beTruthy());
 		});
 	});

--- a/script/update_libgit2
+++ b/script/update_libgit2
@@ -22,8 +22,9 @@ fi
 mkdir build
 cd build
 
+export CMAKE_PREFIX_PATH="/usr/local/include/"
+
 cmake -DBUILD_SHARED_LIBS:BOOL=OFF \
-	-DLIBSSH2_INCLUDE_DIR:PATH=/usr/local/include/ \
 	-DBUILD_CLAR:BOOL=OFF \
 	-DTHREADSAFE:BOOL=ON \
 	-DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -D GIT_SSH" \

--- a/script/update_libgit2
+++ b/script/update_libgit2
@@ -9,14 +9,14 @@ PATH="/usr/local/bin:$PATH"
 
 if [ "External/libgit2.a" -nt "External/libgit2" ]
 then
-    echo "No update needed."
-    exit 0
+		echo "No update needed."
+		exit 0
 fi
 
 cd "External/libgit2"
 
 if [ -d "build" ]; then
-    rm -rf "build"
+		rm -rf "build"
 fi
 
 mkdir build
@@ -34,7 +34,7 @@ cmake --build .
 product="libgit2.a"
 install_path="../../${product}"
 if [ "${product}" -nt "${install_path}" ]; then
-    cp -v "${product}" "${install_path}"
+		cp -v "${product}" "${install_path}"
 fi
 
 echo "libgit2 has been updated."

--- a/script/update_libgit2
+++ b/script/update_libgit2
@@ -26,6 +26,7 @@ cmake -DBUILD_SHARED_LIBS:BOOL=OFF \
 	-DLIBSSH2_INCLUDE_DIR:PATH=/usr/local/include/ \
 	-DBUILD_CLAR:BOOL=OFF \
 	-DTHREADSAFE:BOOL=ON \
+	-DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -D GIT_SSH" \
 	..
 cmake --build .
 

--- a/script/update_libgit2_ios
+++ b/script/update_libgit2_ios
@@ -56,6 +56,7 @@ function build_libgit2 ()
         -DTHREADSAFE:BOOL=ON \
         "${SYS_ROOT}" \
         -DCMAKE_OSX_ARCHITECTURES:STRING="${ARCH}" \
+        -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -D GIT_SSH" \
         .. >> "${LOG}" 2>&1
     cmake --build . --target install >> "${LOG}" 2>&1
 


### PR DESCRIPTION
Cloning with an ssh URL results in error `Unsupported URL protocol` which is the result of a [`libgit2` check if SSH is enabled](https://github.com/libgit2/libgit2/blob/c7f94123569e8fe00ffb3a35e6a12b6ebe9320ec/src/transport.c#L36-L38). It seems that SSH is not enabled for `objective-git`, [although the `GIT_SSH` flag is set](https://github.com/libgit2/objective-git/blob/master/ObjectiveGitFramework.xcodeproj/project.pbxproj#L1521).

Is this the expected behaviour?