### PR TITLE
Give extern'd string known nullability.

### DIFF
--- a/ObjectiveGit/GTDiff.h
+++ b/ObjectiveGit/GTDiff.h
@@ -14,6 +14,8 @@
 @class GTRepository;
 @class GTTree;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// An `NSNumber` wrapped `GTDiffOptionsFlags` representing any flags you wish to
 /// pass into the initialisation.
 extern NSString *const GTDiffOptionsFlagsKey;
@@ -171,8 +173,6 @@ typedef NS_OPTIONS(NSInteger, GTDiffFindOptionsFlags) {
 
 	GTDiffFindOptionsFlagsBreakRewritesForRenamesOnly = GIT_DIFF_BREAK_REWRITES_FOR_RENAMES_ONLY,
 };
-
-NS_ASSUME_NONNULL_BEGIN
 
 /// A class representing a single "diff".
 ///

--- a/ObjectiveGit/GTFilter.h
+++ b/ObjectiveGit/GTFilter.h
@@ -11,13 +11,13 @@
 @class GTRepository;
 @class GTFilterSource;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// The error domain for errors originating from GTFilter.
 extern NSString * const GTFilterErrorDomain;
 
 /// A filter with that name has already been registered.
 extern const NSInteger GTFilterErrorNameAlreadyRegistered;
-
-NS_ASSUME_NONNULL_BEGIN
 
 /// Git filter abstraction.
 ///

--- a/ObjectiveGit/GTRemote.h
+++ b/ObjectiveGit/GTRemote.h
@@ -14,6 +14,8 @@
 @class GTReference;
 @class GTCredentialProvider;
 
+NS_ASSUME_NONNULL_BEGIN
+
 extern NSString * const GTRemoteRenameProblematicRefSpecs;
 
 // Auto Tag settings. See `git_remote_autotag_option_t`.
@@ -22,8 +24,6 @@ typedef enum {
 	GTRemoteDownloadTagsNone = GIT_REMOTE_DOWNLOAD_TAGS_NONE,
 	GTRemoteDownloadTagsAll = GIT_REMOTE_DOWNLOAD_TAGS_ALL,
 } GTRemoteAutoTagOption;
-
-NS_ASSUME_NONNULL_BEGIN
 
 /// A class representing a remote for a git repository.
 ///

--- a/ObjectiveGit/GTRepository+RemoteOperations.h
+++ b/ObjectiveGit/GTRepository+RemoteOperations.h
@@ -10,10 +10,10 @@
 
 @class GTFetchHeadEntry;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A `GTCredentialProvider`, that will be used to authenticate against the remote.
 extern NSString *const GTRepositoryRemoteOptionsCredentialProvider;
-
-NS_ASSUME_NONNULL_BEGIN
 
 @interface GTRepository (RemoteOperations)
 

--- a/ObjectiveGit/GTRepository+Status.h
+++ b/ObjectiveGit/GTRepository+Status.h
@@ -12,6 +12,8 @@
 
 @class GTStatusDelta;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// An enum representing the status of a file
 /// See git_status_t
 typedef NS_OPTIONS(NSInteger, GTFileStatusFlags) {
@@ -80,8 +82,6 @@ typedef enum {
 ///
 /// Defaults to including all files.
 extern NSString *const GTRepositoryStatusOptionsPathSpecArrayKey;
-
-NS_ASSUME_NONNULL_BEGIN
 
 @interface GTRepository (Status)
 

--- a/ObjectiveGit/GTRepository.h
+++ b/ObjectiveGit/GTRepository.h
@@ -52,6 +52,8 @@
 @class GTTree;
 @class GTRemote;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Checkout strategies used by the various -checkout... methods
 /// See git_checkout_strategy_t
 typedef NS_OPTIONS(NSInteger, GTCheckoutStrategyType) {
@@ -147,8 +149,6 @@ extern NSString * const GTRepositoryInitOptionsInitialHEAD;
 /// An `NSString` representing an origin URL to add to the repository after
 /// initialization.
 extern NSString * const GTRepositoryInitOptionsOriginURLString;
-
-NS_ASSUME_NONNULL_BEGIN
 
 @interface GTRepository : NSObject
 


### PR DESCRIPTION
Moved `NS_ASSUME_NONNULL_BEGIN` to before the definition of our `extern`’d strings.

Otherwise framework consumers would see warnings about unspecified nullability.