### PR TITLE
Xcode 7 Annoyances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ External/libgit2-ios
 project.xcworkspace
 */xcuserdata/
 *.xccheckout
+*.xcscmblueprint
 
 ObjectiveGitTests/fixtures/Fixtures/*
 

--- a/ObjectiveGitFramework.xcodeproj/project.pbxproj
+++ b/ObjectiveGitFramework.xcodeproj/project.pbxproj
@@ -1134,6 +1134,7 @@
 		0867D690FE84028FC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0700;
 				LastTestingUpgradeCheck = 0510;
 				LastUpgradeCheck = 0630;
 				ORGANIZATIONNAME = "GitHub, Inc";


### PR DESCRIPTION
Just opening this project in Xcode 7 dirties the work tree with a `.xcscmblueprint` file and adds `LastSwiftUpdateCheck` to `project.pbxproj`. While I have other changes in mind for full Xcode 7 compatibility, these are just annoyances which should be completely innocuous to older Xcode versions.