### PR TITLE
Cleanup libgit2 build

### DIFF
--- a/ObjectiveGitFramework.xcodeproj/project.pbxproj
+++ b/ObjectiveGitFramework.xcodeproj/project.pbxproj
@@ -311,6 +311,7 @@
 		DD3D9513182A81E1004AF532 /* GTBlame.m in Sources */ = {isa = PBXBuildFile; fileRef = DD3D9511182A81E1004AF532 /* GTBlame.m */; };
 		DD3D951C182AB25C004AF532 /* GTBlameHunk.h in Headers */ = {isa = PBXBuildFile; fileRef = DD3D951A182AB25C004AF532 /* GTBlameHunk.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DD3D951D182AB25C004AF532 /* GTBlameHunk.m in Sources */ = {isa = PBXBuildFile; fileRef = DD3D951B182AB25C004AF532 /* GTBlameHunk.m */; };
+		F879D8311B4B788F002D5C07 /* Libgit2FeaturesSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = F879D82F1B4B77F4002D5C07 /* Libgit2FeaturesSpec.m */; };
 		F8E4A2911A170CA6006485A8 /* GTRemotePushSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = F8E4A2901A170CA6006485A8 /* GTRemotePushSpec.m */; };
 /* End PBXBuildFile section */
 
@@ -573,6 +574,7 @@
 		DD3D951B182AB25C004AF532 /* GTBlameHunk.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GTBlameHunk.m; sourceTree = "<group>"; };
 		E46931A7172740D300F2077D /* update_libgit2 */ = {isa = PBXFileReference; lastKnownFileType = text; name = update_libgit2; path = script/update_libgit2; sourceTree = "<group>"; };
 		E46931A8172740D300F2077D /* update_libgit2_ios */ = {isa = PBXFileReference; lastKnownFileType = text; name = update_libgit2_ios; path = script/update_libgit2_ios; sourceTree = "<group>"; };
+		F879D82F1B4B77F4002D5C07 /* Libgit2FeaturesSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Libgit2FeaturesSpec.m; sourceTree = "<group>"; };
 		F8E4A2901A170CA6006485A8 /* GTRemotePushSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GTRemotePushSpec.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -746,6 +748,7 @@
 				88234B2518F2FE260039972E /* GTRepositoryResetSpec.m */,
 				8870390A1975E3F2004118D7 /* GTDiffDeltaSpec.m */,
 				88E353051982EA6B0051001F /* GTRepositoryAttributesSpec.m */,
+				F879D82F1B4B77F4002D5C07 /* Libgit2FeaturesSpec.m */,
 			);
 			path = ObjectiveGitTests;
 			sourceTree = "<group>";
@@ -1272,6 +1275,7 @@
 				307623AB17C6C8BD00E2CDF1 /* NSArray+StringArraySpec.m in Sources */,
 				8832811F173D8816006D7DCF /* GTIndexSpec.m in Sources */,
 				D0F4E28A17C7F24200BBDE30 /* NSErrorGitSpec.m in Sources */,
+				F879D8311B4B788F002D5C07 /* Libgit2FeaturesSpec.m in Sources */,
 				88328128173D8A64006D7DCF /* GTTreeSpec.m in Sources */,
 				88E353061982EA6B0051001F /* GTRepositoryAttributesSpec.m in Sources */,
 				88234B2618F2FE260039972E /* GTRepositoryResetSpec.m in Sources */,

--- a/ObjectiveGitTests/Libgit2FeaturesSpec.m
+++ b/ObjectiveGitTests/Libgit2FeaturesSpec.m
@@ -1,0 +1,39 @@
+//
+//  Libgit2FeaturesSpec.m
+//  ObjectiveGitFramework
+//
+//  Created by Ben Chatelain on 7/6/15.
+//  Copyright (c) 2015 GitHub, Inc. All rights reserved.
+//
+
+#import <Nimble/Nimble.h>
+#import <ObjectiveGit/ObjectiveGit.h>
+#import <Quick/Quick.h>
+
+#import "QuickSpec+GTFixtures.h"
+
+QuickSpecBegin(Libgit2FeaturesSpec)
+
+describe(@"libgit", ^{
+
+	__block git_feature_t git_features = 0;
+
+	beforeEach(^{
+		git_features = git_libgit2_features();
+	});
+
+	it(@"should be built with THREADS enabled", ^{
+		expect(@(git_features & GIT_FEATURE_THREADS)).to(beTruthy());
+	});
+
+	it(@"should be built with HTTPS enabled", ^{
+		expect(@(git_features & GIT_FEATURE_HTTPS)).to(beTruthy());
+	});
+
+	it(@"should be built with SSH enabled", ^{
+		expect(@(git_features & GIT_FEATURE_SSH)).to(beTruthy());
+	});
+
+});
+
+QuickSpecEnd

--- a/script/update_libgit2
+++ b/script/update_libgit2
@@ -23,7 +23,7 @@ mkdir build
 cd build
 
 cmake -DBUILD_SHARED_LIBS:BOOL=OFF \
-	-DLIBSSH2_INCLUDE_DIR:PATH=/usr/local/include/ \
+	-DLIBSSH2_INCLUDE_DIRS:PATH=/usr/local/include/ \
 	-DBUILD_CLAR:BOOL=OFF \
 	-DTHREADSAFE:BOOL=ON \
 	..

--- a/script/update_libgit2_ios
+++ b/script/update_libgit2_ios
@@ -47,7 +47,7 @@ function build_libgit2 ()
         -DBUILD_SHARED_LIBS:BOOL=OFF \
         -DOPENSSL_INCLUDE_DIR:PATH=../../External/ios-openssl/include/ \
         -DCMAKE_LIBRARY_PATH:PATH=../../External/libssh2-ios/lib/ \
-        -DLIBSSH2_INCLUDE_DIR:PATH=../../External/libssh2-ios/include/libssh2/ \
+        -DLIBSSH2_INCLUDE_DIRS:PATH=../../External/libssh2-ios/include/libssh2/ \
         -DOPENSSL_SSL_LIBRARY:FILEPATH=../../External/ios-openssl/lib/libssl.a \
         -DCMAKE_LIBRARY_PATH:PATH="${SDKROOT}/usr/lib/" \
         -DOPENSSL_CRYPTO_LIBRARY:FILEPATH=../../External/ios-openssl/lib/libcrypto.a \

--- a/script/update_libgit2_ios
+++ b/script/update_libgit2_ios
@@ -45,12 +45,9 @@ function build_libgit2 ()
     cmake -DCMAKE_C_COMPILER=clang \
         -DCMAKE_C_COMPILER_WORKS:BOOL=ON \
         -DBUILD_SHARED_LIBS:BOOL=OFF \
-        -DOPENSSL_INCLUDE_DIR:PATH=../../External/ios-openssl/include/ \
         -DCMAKE_LIBRARY_PATH:PATH=../../External/libssh2-ios/lib/ \
         -DLIBSSH2_INCLUDE_DIRS:PATH=../../External/libssh2-ios/include/libssh2/ \
-        -DOPENSSL_SSL_LIBRARY:FILEPATH=../../External/ios-openssl/lib/libssl.a \
         -DCMAKE_LIBRARY_PATH:PATH="${SDKROOT}/usr/lib/" \
-        -DOPENSSL_CRYPTO_LIBRARY:FILEPATH=../../External/ios-openssl/lib/libcrypto.a \
         -DCMAKE_INSTALL_PREFIX:PATH="${INSTALL_PREFIX}/" \
         -DBUILD_CLAR:BOOL=OFF \
         -DTHREADSAFE:BOOL=ON \

--- a/script/update_libgit2_ios
+++ b/script/update_libgit2_ios
@@ -51,6 +51,7 @@ function build_libgit2 ()
         -DCMAKE_INSTALL_PREFIX:PATH="${INSTALL_PREFIX}/" \
         -DBUILD_CLAR:BOOL=OFF \
         -DTHREADSAFE:BOOL=ON \
+        -DCURL:BOOL=OFF \
         "${SYS_ROOT}" \
         -DCMAKE_OSX_ARCHITECTURES:STRING="${ARCH}" \
         .. >> "${LOG}" 2>&1


### PR DESCRIPTION
Fixing the libgit2 iOS build and removing unused defines.

* Correct spelling of `LIBSSH2_INCLUDE_DIRS` (fixes #481)
* Disable CURL on iOS
* Remove obsolete `OPENSSL_*` defines (libgit2 now uses SecureTransport on Apple platforms) 
* Add tests for `git_libgit2_features` flags