### PR TITLE
Ignore Carthage/Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,7 @@ ObjectiveGitTests/fixtures/Fixtures/*
 
 External/ios-openssl/include
 External/ios-openssl/lib
-
 External/libssh2-ios
+
+Carthage/Build
+


### PR DESCRIPTION
Running `carthage update` builds by default which dirties the work tree. While the current project configuration doesn't require these dependencies to be built with Carthage (Quick and Nimble are just added to the workspace as dependent projects), I always forget to add `--no-build` and am left wondering why the work tree is dirty.