### PR TITLE
Update travis.yml to use new OS X image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,4 @@
+osx_image: xcode6.4
 language: objective-c
-install:
-- brew install cmake
+install: script/bootstrap
 script: script/cibuild
-notifications:
-  email: false
-  campfire:
-    on_success: always
-    on_failure: always
-    template:
-      - "Build %{build_url} of %{repository}: %{message}"
-    rooms:
-      secure: IxO/lskcwkcrvbgq9UsI4rjD7auSbbc52QdOcEzh5klXf6KkmIRSrJDUbsRGJ6GahlB0ELfgTcr0ycqsYhW5M9mNwzWR1cerbedA2HT0sOy7uvgGQwAY+iiikCsIMuYQJ1qvb6DrrpgyejQWXW5cOEVbNuoPV45DE0lsPUHcpyg=


### PR DESCRIPTION
Fixes https://github.com/libgit2/objective-git/issues/485

@joshaber you have to turn on travis for this repository, I couldn't do it as it requires admin access:
You can simply go to https://travis-ci.org/profile/libgit2 and add the checkmark for `objective-git`.

The build output can be seen at https://travis-ci.org/nerdishbynature/objective-git/builds/70506107