### PR TITLE
Fix intermittent libgit2 iOS build failures

### DIFF
--- a/script/update_libgit2_ios
+++ b/script/update_libgit2_ios
@@ -42,7 +42,7 @@ function build_libgit2 ()
     LOG="${INSTALL_PREFIX}/build-libgit2.log"
     echo "$LOG"
 
-    cmake -DCMAKE_C_COMPILER=clang \
+    cmake \
         -DCMAKE_C_COMPILER_WORKS:BOOL=ON \
         -DBUILD_SHARED_LIBS:BOOL=OFF \
         -DCMAKE_LIBRARY_PATH:PATH=../../External/libssh2-ios/lib/ \


### PR DESCRIPTION
The libgit2 build for iOS has been failing intermittently for me and I've chased the issue down to the wrong version of clang being used. 

```
$ clang --version
clang version 3.5 (tags/checker/checker-276)
Target: x86_64-apple-darwin14.4.0
Thread model: posix
$ which clang
/usr/local/bin/clang

$ xcrun clang --version
Apple LLVM version 6.1.0 (clang-602.0.53) (based on LLVM 3.6.0svn)
Target: x86_64-apple-darwin14.4.0
Thread model: posix
$ xcrun -find clang
/Applications/Xcode6.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang

$ sudo xcode-select -s /Applications/Xcode7-beta3.app
$ xcrun clang --version
Apple LLVM version 7.0.0 (clang-700.0.57.2)
Target: x86_64-apple-darwin14.4.0
Thread model: posix
$ xcrun -find clang
/Applications/Xcode7-beta3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
```

[ios_build_functions.sh](https://github.com/libgit2/objective-git/blob/master/script/ios_build_functions.sh) sets up the `CC` environment variable to use `xcrun clang` which will use the version of clang that corresponds to the current Xcode environment. However, the `CMAKE_C_COMPILER` argument to cmake in [update_libgit2_ios](https://github.com/libgit2/objective-git/blob/master/script/update_libgit2_ios) appears to be preventing the correct selection of clang.


## Xcode 7 beta 3

### Broken

```
/Users/phatblat/dev/libgit2/objective-git/External/libgit2-ios/iphonesimulator9.0-x86_64.sdk/build-libgit2.log
-- The C compiler identification is Clang 3.5.0
✅

/Users/phatblat/dev/libgit2/objective-git/External/libgit2-ios/iphonesimulator9.0-i386.sdk/build-libgit2.log
-- The C compiler identification is Clang 3.5.0
✅

/Users/phatblat/dev/libgit2/objective-git/External/libgit2-ios/iphoneos9.0-armv7.sdk/build-libgit2.log

-- The C compiler identification is Clang 3.5.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - failed
-- Found PkgConfig: /usr/local/bin/pkg-config (found version "0.28") 
-- Found Security /Applications/Xcode7-beta3.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Security.framework
-- Found CoreFoundation /Applications/Xcode7-beta3.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/CoreFoundation.framework
-- Could NOT find HTTP_Parser (missing:  HTTP_PARSER_INCLUDE_DIR HTTP_PARSER_LIBRARY) 
-- http-parser was not found or is too old; using bundled 3rd-party sources.
-- Found ZLIB: /usr/lib/libz.dylib (found version "1.2.5") 
-- checking for module 'libssh2'
--   found libssh2, version 1.6.0
-- Looking for libssh2_userauth_publickey_frommemory in ssh2
-- Looking for libssh2_userauth_publickey_frommemory in ssh2 - not found
-- Found Iconv: -L/usr/lib -liconv
-- Performing Test IS_WNO-MISSING-FIELD-INITIALIZERS_SUPPORTED
-- Performing Test IS_WNO-MISSING-FIELD-INITIALIZERS_SUPPORTED - Failed
-- Performing Test IS_WSTRICT-ALIASING=2_SUPPORTED
-- Performing Test IS_WSTRICT-ALIASING=2_SUPPORTED - Failed
-- Performing Test IS_WSTRICT-PROTOTYPES_SUPPORTED
-- Performing Test IS_WSTRICT-PROTOTYPES_SUPPORTED - Failed
-- Performing Test IS_WDECLARATION-AFTER-STATEMENT_SUPPORTED
-- Performing Test IS_WDECLARATION-AFTER-STATEMENT_SUPPORTED - Failed
-- Performing Test IS_WNO-UNUSED-CONST-VARIABLE_SUPPORTED
-- Performing Test IS_WNO-UNUSED-CONST-VARIABLE_SUPPORTED - Failed
-- Performing Test IS_WNO-UNUSED-FUNCTION_SUPPORTED
-- Performing Test IS_WNO-UNUSED-FUNCTION_SUPPORTED - Failed
-- Performing Test IS_WNO-DEPRECATED-DECLARATIONS_SUPPORTED
-- Performing Test IS_WNO-DEPRECATED-DECLARATIONS_SUPPORTED - Failed
-- Looking for include file pthread.h
-- Looking for include file pthread.h - not found
CMake Error at /usr/local/Cellar/cmake/3.2.3/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:138 (message):
  Could NOT find Threads (missing: Threads_FOUND)
Call Stack (most recent call first):
  /usr/local/Cellar/cmake/3.2.3/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:374 (_FPHSA_FAILURE_MESSAGE)
  /usr/local/Cellar/cmake/3.2.3/share/cmake/Modules/FindThreads.cmake:204 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:457 (FIND_PACKAGE)


-- Configuring incomplete, errors occurred!
See also "/Users/phatblat/dev/libgit2/objective-git/External/libgit2/build/CMakeFiles/CMakeOutput.log".
See also "/Users/phatblat/dev/libgit2/objective-git/External/libgit2/build/CMakeFiles/CMakeError.log".
🚫
```

### Fixed 

Removed `-DCMAKE_C_COMPILER=clang`

```
/Users/phatblat/dev/libgit2/objective-git/External/libgit2-ios/iphonesimulator9.0-x86_64.sdk/build-libgit2.log
-- The C compiler identification is AppleClang 7.0.0.7000057
✅

/Users/phatblat/dev/libgit2/objective-git/External/libgit2-ios/iphonesimulator9.0-i386.sdk/build-libgit2.log
-- The C compiler identification is AppleClang 7.0.0.7000057
✅

/Users/phatblat/dev/libgit2/objective-git/External/libgit2-ios/iphoneos9.0-armv7.sdk/build-libgit2.log
-- The C compiler identification is AppleClang 7.0.0.7000057
✅

/Users/phatblat/dev/libgit2/objective-git/External/libgit2-ios/iphoneos9.0-armv7s.sdk/build-libgit2.log
-- The C compiler identification is AppleClang 7.0.0.7000057
✅

/Users/phatblat/dev/libgit2/objective-git/External/libgit2-ios/iphoneos9.0-arm64.sdk/build-libgit2.log
-- The C compiler identification is AppleClang 7.0.0.7000057
✅
```

What's weird about this issue is that it breaks in Xcode 6.4 too, but my suspicion is that using `xcode-select -s` to switch Xcode versions is somehow triggering the issue. In any case, letting `xcrun` handle locating `clang` resolves the issue for both versions of Xcode.