### PR TITLE
Just install any missing tools in bootstrap

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -104,7 +104,9 @@ bootstrap_submodule ()
 
 update_submodules ()
 {
-    git submodule sync --quiet && git submodule update --init && git submodule foreach --quiet bootstrap_submodule
+    git submodule sync --quiet && \
+        git submodule update --init && \
+        git submodule foreach --quiet bootstrap_submodule
 }
 
 export -f bootstrap_submodule

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -9,7 +9,8 @@ export SCRIPT_DIR=$(dirname "$0")
 config ()
 {
     # A whitespace-separated list of executables that must be present and locatable.
-    : ${REQUIRED_TOOLS="xctool cmake"}
+    # These will each be installed through Homebrew if not found.
+    : ${REQUIRED_TOOLS="xctool cmake libssh2 libtool autoconf automake pkg-config"}
 
     export REQUIRED_TOOLS
 }
@@ -45,24 +46,13 @@ main ()
 
 check_deps ()
 {
-    for tool in $REQUIRED_TOOLS
-    do
-        which -s "$tool"
-        if [ "$?" -ne "0" ]
-        then
-            echo "*** Error: $tool not found. Please install it and bootstrap again."
-            exit 1
-        fi
-    done
-
     # Ensure that we have libgit2's dependencies installed.
     installed=`brew list`
-    libs="libssh2 libtool autoconf automake pkg-config"
 
-    for lib in $libs
+    for tool in $REQUIRED_TOOLS
     do
         # Skip packages that are already installed.
-        echo "$installed" | grep -q "$lib" && code=$? || code=$?
+        echo "$installed" | grep -q "$tool" && code=$? || code=$?
 
         if [ "$code" -eq "0" ]
         then
@@ -72,8 +62,8 @@ check_deps ()
             exit $code
         fi
 
-        echo "*** Installing $lib with Homebrew..."
-        brew install "$lib"
+        echo "*** Installing $tool with Homebrew..."
+        brew install "$tool"
     done
 
     brew_prefix=`brew --prefix`

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -56,7 +56,7 @@ check_deps ()
         echo "Homebrew is not installed (http://brew.sh). You will need to manually ensure the following tools are installed:"
         echo "  $REQUIRED_TOOLS"
         echo
-        echo "Additionally, the following libssh2 files must be symlinked under /user/local:"
+        echo "Additionally, the following libssh2 files must be symlinked under /usr/local:"
         echo "  lib/libssh2.a include/libssh2.h include/libssh2_sftp.h include/libssh2_publickey.h"
         exit $result
     fi

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -46,6 +46,21 @@ main ()
 
 check_deps ()
 {
+    # Check if Homebrew is installed
+    which -s brew
+    local result=$?
+
+    if [ "$result" -ne "0" ]
+    then
+        echo
+        echo "Homebrew is not installed (http://brew.sh). You will need to manually ensure the following tools are installed:"
+        echo "  $REQUIRED_TOOLS"
+        echo
+        echo "Additionally, the following libssh2 files must be symlinked under /user/local:"
+        echo "  lib/libssh2.a include/libssh2.h include/libssh2_sftp.h include/libssh2_publickey.h"
+        exit $result
+    fi
+
     # Ensure that we have libgit2's dependencies installed.
     installed=`brew list`
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -23,12 +23,6 @@ main ()
 {
     config
 
-    if [ -n "$REQUIRED_TOOLS" ]
-    then
-        echo "*** Checking dependencies..."
-        check_deps
-    fi
-
     local submodules=$(git submodule status)
     local result=$?
 
@@ -41,6 +35,12 @@ main ()
     then
         echo "*** Updating submodules..."
         update_submodules
+    fi
+
+    if [ -n "$REQUIRED_TOOLS" ]
+    then
+        echo "*** Checking dependencies..."
+        check_deps
     fi
 }
 


### PR DESCRIPTION
It seems silly for the bootstrap script to fail if xctool and cmake are not installed but then to go ahead and install other things through Homebrew. 