### PR TITLE
Fix iOS SDK version detection for Xcode 7

### DIFF
--- a/script/xcode_functions.sh
+++ b/script/xcode_functions.sh
@@ -14,12 +14,18 @@ function xcode_major_version ()
     xcode_version | awk -F '.' '{ print $1 }'
 }
 
-# Returns the latest iOS SDK version available
-# via xcodebuild
+# Returns the latest iOS SDK version available via xcodebuild.
 function ios_sdk_version ()
 {
-    # This relies on the fact that the latest iPhone SDK
-    # is the last thing listed before the Xcode version.
+    # The grep command produces output like the following, singling out the
+    # SDKVersion of just the iPhone* SDKs:
+    #
+    #   iPhoneOS9.0.sdk - iOS 9.0 (iphoneos9.0)
+    #   SDKVersion: 9.0
+    #   --
+    #   iPhoneSimulator9.0.sdk - Simulator - iOS 9.0 (iphonesimulator9.0)
+    #   SDKVersion: 9.0
+
     /usr/bin/xcodebuild -version -sdk 2> /dev/null | grep -A 1 '^iPhone' | tail -n 1 |  awk '{ print $2 }' 
 }
 

--- a/script/xcode_functions.sh
+++ b/script/xcode_functions.sh
@@ -20,7 +20,7 @@ function ios_sdk_version ()
 {
     # This relies on the fact that the latest iPhone SDK
     # is the last thing listed before the Xcode version.
-    /usr/bin/xcodebuild -version -sdk 2> /dev/null | grep SDKVersion | tail -n 1 |  awk '{ print $2 }' 
+    /usr/bin/xcodebuild -version -sdk 2> /dev/null | grep -A 1 '^iPhone' | tail -n 1 |  awk '{ print $2 }' 
 }
 
 # Returns the path to the specified iOS SDK name


### PR DESCRIPTION
Without this change, update_libgit2_ios reports building for **iphonesimulator2.0** when using Xcode 7

```
Building for x86_64 i386 armv7 armv7s arm64
Building libgit2 for iphonesimulator2.0 x86_64
Please stand by...
/Users/phatblat/dev/ios/Octopad/Carthage/Checkouts/objective-git/External/libgit2-ios/iphonesimulator2.0-x86_64.sdk/build-libgit2.log
```

And the build randomly fails (Xcode GUI fails on first architecture, command line builds get through those but fail on the first ARM architecture).

```
-- The C compiler identification is AppleClang 7.0.0.7000065
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - failed
...
-- Looking for include file pthread.h
-- Looking for include file pthread.h - not found
CMake Error at /usr/local/Cellar/cmake/3.3.0/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:148 (message):
  Could NOT find Threads (missing: Threads_FOUND)
Call Stack (most recent call first):
  /usr/local/Cellar/cmake/3.3.0/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:388 (_FPHSA_FAILURE_MESSAGE)
  /usr/local/Cellar/cmake/3.3.0/share/cmake/Modules/FindThreads.cmake:204 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:458 (FIND_PACKAGE)
```

:ok_hand:  This change is compatible with Xcode 6.3 and 6.4.

```
DEVELOPER_DIR=/Applications/Xcode7-beta5.app xcodebuild -version -sdk | grep -A 1 '^iPhone' | tail -n 1 | awk '{ print $2 }'
9.0

DEVELOPER_DIR=/Applications/Xcode6.4.app xcodebuild -version -sdk | grep -A 1 '^iPhone' | tail -n 1 | awk '{ print $2 }'
8.4 

DEVELOPER_DIR=/Applications/Xcode6.3.2.app xcodebuild -version -sdk | grep -A 1 '^iPhone' | tail -n 1 | awk '{ print $2 }'
8.3
```

The new WatchOS2.0.sdk and WatchSimulator2.0.sdk broke the assumption that the iPhone SDK was last in the list.