### PR TITLE
Disable bitcode in iOS framework target

### DIFF
--- a/ObjectiveGitFramework.xcodeproj/project.pbxproj
+++ b/ObjectiveGitFramework.xcodeproj/project.pbxproj
@@ -1718,6 +1718,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
+				ENABLE_BITCODE = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"External/libssh2-ios/include/libssh2",
@@ -1781,6 +1782,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
+				ENABLE_BITCODE = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"External/libssh2-ios/include/libssh2",
@@ -1812,6 +1814,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
+				ENABLE_BITCODE = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"External/libssh2-ios/include/libssh2",
@@ -1843,6 +1846,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
+				ENABLE_BITCODE = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"External/libssh2-ios/include/libssh2",


### PR DESCRIPTION
This change explicitly sets the `ENABLE_BITCODE` build setting to `NO` to allow the build to work in Xcode 7. I've only had these failures when building ObjectiveGit for a containing app using Carthage on the command line; for some reason the build in the GUI still works. Regardless, the Xcode 7 release notes have been warning that when bitcode is enabled for a target (default is `YES` in the iOS 9 SDK), it will eventually be an error if anything that target links to does not also contain bitcode.

```
Ld /Volumes/DerivedData/ObjectiveGitFramework-giaqbyabyyzemdcaoijtrovcrygz/Build/Intermediates/ObjectiveGitFramework.build/Release-iphoneos/ObjectiveGit-iOS.build/Objects-normal/arm64/ObjectiveGit normal arm64
    cd /Users/phatblat/dev/libgit2/GitApp/Carthage/Checkouts/objective-git
    export IPHONEOS_DEPLOYMENT_TARGET=8.0
    export PATH="/Applications/Xcode7-beta5.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin:/Applications/Xcode7-beta5.app/Contents/Developer/usr/bin:/usr/local/var/rbenv/shims:/usr/local/opt/rbenv/bin:/Users/phatblat/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/phatblat/Library/Python/2.7/bin"
    /Applications/Xcode7-beta5.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -arch arm64 -dynamiclib -isysroot /Applications/Xcode7-beta5.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk -L/Volumes/DerivedData/ObjectiveGitFramework-giaqbyabyyzemdcaoijtrovcrygz/Build/Products/Release-iphoneos -LExternal/ios-openssl/lib -LExternal/libssh2-ios/lib -LExternal/libgit2-ios -F/Volumes/DerivedData/ObjectiveGitFramework-giaqbyabyyzemdcaoijtrovcrygz/Build/Products/Release-iphoneos -filelist /Volumes/DerivedData/ObjectiveGitFramework-giaqbyabyyzemdcaoijtrovcrygz/Build/Intermediates/ObjectiveGitFramework.build/Release-iphoneos/ObjectiveGit-iOS.build/Objects-normal/arm64/ObjectiveGit.LinkFileList -install_name @rpath/ObjectiveGit.framework/ObjectiveGit -Xlinker -rpath -Xlinker @executable_path/Frameworks -Xlinker -rpath -Xlinker @loader_path/Frameworks -miphoneos-version-min=8.0 -fembed-bitcode-marker -lgit2-ios -all_load -fobjc-arc -fobjc-link-runtime -liconv -lz -lssl -lcrypto -lssh2-ios -single_module -compatibility_version 1 -current_version 1 -Xlinker -dependency_info -Xlinker /Volumes/DerivedData/ObjectiveGitFramework-giaqbyabyyzemdcaoijtrovcrygz/Build/Intermediates/ObjectiveGitFramework.build/Release-iphoneos/ObjectiveGit-iOS.build/Objects-normal/arm64/ObjectiveGit_dependency_info.dat -o /Volumes/DerivedData/ObjectiveGitFramework-giaqbyabyyzemdcaoijtrovcrygz/Build/Intermediates/ObjectiveGitFramework.build/Release-iphoneos/ObjectiveGit-iOS.build/Objects-normal/arm64/ObjectiveGit
ld: 'External/libgit2-ios/libgit2-ios.a(annotated_commit.c.o)' does not contain bitcode. You must rebuild it with bitcode enabled (Xcode setting ENABLE_BITCODE), obtain an updated library from the vendor, or disable bitcode for this target. for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)

** BUILD FAILED **
```

:ok_hand: Xcode 6 doesn't know about the new `ENABLE_BITCODE` setting. It shows up in the User-Defined settings, but has no effect.