### PR TITLE
Added support for git_cred_ssh_key_memory_new GTCredentials

### DIFF
--- a/ObjectiveGit/GTCredential.h
+++ b/ObjectiveGit/GTCredential.h
@@ -76,10 +76,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Create a credential object from a SSH keyfile data string
 ///
-/// userName         - The username to authenticate as. Must not be nil.
+/// userName         - The username to authenticate as.
 /// publicKeyString  - The string containing the public key for that user.
-///                  Can be omitted to reconstruct the public key from the private key.
-/// privateKeyString - The URL to the private key for that user. Must not be nil.
+///                     Can be omitted to reconstruct the public key from the private key.
+/// privateKeyString - The URL to the private key for that user.
 /// passphrase       - The passPhrase for the private key. Optional if the private key has no password.
 /// error            - If not NULL, set to any errors that occur.
 ///

--- a/ObjectiveGit/GTCredential.h
+++ b/ObjectiveGit/GTCredential.h
@@ -74,6 +74,18 @@ NS_ASSUME_NONNULL_BEGIN
 /// Return a new GTCredential instance, or nil if an error occurred
 + (nullable instancetype)credentialWithUserName:(NSString *)userName publicKeyURL:(nullable NSURL *)publicKeyURL privateKeyURL:(NSURL *)privateKeyURL passphrase:(nullable NSString *)passphrase error:(NSError **)error;
 
+/// Create a credential object from a SSH keyfile data string
+///
+/// userName         - The username to authenticate as. Must not be nil.
+/// publicKeyString  - The string containing the public key for that user.
+///                  Can be omitted to reconstruct the public key from the private key.
+/// privateKeyString - The URL to the private key for that user. Must not be nil.
+/// passphrase       - The passPhrase for the private key. Optional if the private key has no password.
+/// error            - If not NULL, set to any errors that occur.
+///
+/// Return a new GTCredential instance, or nil if an error occurred
++ (nullable instancetype)credentialWithUserName:(NSString *)userName publicKeyString:(nullable NSString *)publicKeyString privateKeyString:(NSString *)privateKeyString passphrase:(nullable NSString *)passphrase error:(NSError **)error;
+
 /// The underlying `git_cred` object.
 - (git_cred *)git_cred __attribute__((objc_returns_inner_pointer));
 

--- a/ObjectiveGit/GTCredential.m
+++ b/ObjectiveGit/GTCredential.m
@@ -71,6 +71,19 @@ typedef GTCredential *(^GTCredentialProviderBlock)(GTCredentialType allowedTypes
 	return [[self alloc] initWithGitCred:cred];
 }
 
++ (instancetype)credentialWithUserName:(NSString *)userName publicKeyString:(NSString *)publicKeyString privateKeyString:(NSString *)privateKeyString passphrase:(NSString *)passphrase error:(NSError **)error {
+	NSParameterAssert(privateKeyString != nil);
+	
+	git_cred *cred;
+	int gitError = git_cred_ssh_key_memory_new(&cred, userName.UTF8String, publicKeyString.UTF8String, privateKeyString.UTF8String, passphrase.UTF8String);
+	if (gitError != GIT_OK) {
+		if (error) *error = [NSError git_errorFor:gitError description:@"Failed to create credentials object" failureReason:@"There was an error creating a credential object for username %@ with the provided public/private key pair.\nPublic key: %@\nPrivate key: %@", userName, publicKeyString, privateKeyString];
+		return nil;
+	}
+	
+	return [[self alloc] initWithGitCred:cred];
+}
+
 - (instancetype)initWithGitCred:(git_cred *)cred {
 	NSParameterAssert(cred != nil);
 	self = [self init];


### PR DESCRIPTION
Added +[GTCredential credentialWithUserName:publicKeyString:privateKeyString:passphrase:error:] to support libgit2 git_cred_ssh_key_memory_new() credentials.