### PR TITLE
Fix bug where GTPushTransferProgressBlock is unused

### DIFF
--- a/ObjectiveGit/GTRepository+RemoteOperations.m
+++ b/ObjectiveGit/GTRepository+RemoteOperations.m
@@ -238,7 +238,7 @@ int GTFetchHeadEntriesCallback(const char *ref_name, const char *remote_url, con
 		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to init push options"];
 		return NO;
 	}
-	
+
 	push_options.callbacks = remote_callbacks;
 
 	const git_strarray git_refspecs = refspecs.git_strarray;

--- a/ObjectiveGit/GTRepository+RemoteOperations.m
+++ b/ObjectiveGit/GTRepository+RemoteOperations.m
@@ -219,7 +219,7 @@ int GTFetchHeadEntriesCallback(const char *ref_name, const char *remote_url, con
 
 	git_remote_callbacks remote_callbacks = GIT_REMOTE_CALLBACKS_INIT;
 	remote_callbacks.credentials = (credProvider != nil ? GTCredentialAcquireCallback : NULL),
-	remote_callbacks.transfer_progress = GTRemoteFetchTransferProgressCallback,
+	remote_callbacks.push_transfer_progress = GTRemotePushTransferProgressCallback;
 	remote_callbacks.payload = &connectionInfo,
 
 	gitError = git_remote_connect(remote.git_remote, GIT_DIRECTION_PUSH, &remote_callbacks);
@@ -238,6 +238,8 @@ int GTFetchHeadEntriesCallback(const char *ref_name, const char *remote_url, con
 		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to init push options"];
 		return NO;
 	}
+	
+	push_options.callbacks = remote_callbacks;
 
 	const git_strarray git_refspecs = refspecs.git_strarray;
 

--- a/ObjectiveGitTests/GTRemotePushSpec.m
+++ b/ObjectiveGitTests/GTRemotePushSpec.m
@@ -115,7 +115,7 @@ describe(@"pushing", ^{
 				}];
 				expect(error).to(beNil());
 				expect(@(result)).to(beTruthy());
-				expect(@(transferProgressed)).to(beFalsy()); // Local transport doesn't currently call progress callbacks
+				expect(@(transferProgressed)).to(beTruthy());
 
 				// Same number of commits after push, refresh branch first
 				remoteMasterBranch = localBranchWithName(@"master", remoteRepo);
@@ -152,7 +152,7 @@ describe(@"pushing", ^{
 			}];
 			expect(error).to(beNil());
 			expect(@(result)).to(beTruthy());
-			expect(@(transferProgressed)).to(beFalsy()); // Local transport doesn't currently call progress callbacks
+			expect(@(transferProgressed)).to(beTruthy());
 
 			// Number of commits on tracking branch after push
 			localTrackingBranch = [masterBranch trackingBranchWithError:&error success:&success];


### PR DESCRIPTION
In `pushRefspecs:toRemote:withOptions`, the remote_callbacks struct was incorrectly configured and the  push_transfer_progress callback was not set. This caused the user-provided GTRemotePushTransferProgressBlock to never be used, since it was bound to `GTRemotePushTransferProgressCallback`, which was not set in the struct.

This change fixes the bug in objective-git, but there's a very similar bug in libgit2 that results in the callback only being called once for smart protocol pushes, at the end - fixed in  https://github.com/libgit2/libgit2/pull/3377
