### PR TITLE
Fix checkout methods utilizing notifyBlock/GTCheckoutStrategySafe

### DIFF
--- a/ObjectiveGit/GTRepository.m
+++ b/ObjectiveGit/GTRepository.m
@@ -830,17 +830,15 @@ static int checkoutNotifyCallback(git_checkout_notify_t why, const char *path, c
 }
 
 - (BOOL)checkoutCommit:(GTCommit *)targetCommit strategy:(GTCheckoutStrategyType)strategy notifyFlags:(GTCheckoutNotifyFlags)notifyFlags error:(NSError **)error progressBlock:(GTCheckoutProgressBlock)progressBlock notifyBlock:(GTCheckoutNotifyBlock)notifyBlock {
-	BOOL success = [self moveHEADToCommit:targetCommit error:error];
+	BOOL success = [self performCheckoutWithStrategy:strategy notifyFlags:notifyFlags error:error progressBlock:progressBlock notifyBlock:notifyBlock];
 	if (success == NO) return NO;
-
-	return [self performCheckoutWithStrategy:strategy notifyFlags:notifyFlags error:error progressBlock:progressBlock notifyBlock:notifyBlock];
+	return [self moveHEADToCommit:targetCommit error:error];
 }
 
 - (BOOL)checkoutReference:(GTReference *)targetReference strategy:(GTCheckoutStrategyType)strategy notifyFlags:(GTCheckoutNotifyFlags)notifyFlags error:(NSError **)error progressBlock:(GTCheckoutProgressBlock)progressBlock notifyBlock:(GTCheckoutNotifyBlock)notifyBlock {
-	BOOL success = [self moveHEADToReference:targetReference error:error];
+	BOOL success = [self performCheckoutWithStrategy:strategy notifyFlags:notifyFlags error:error progressBlock:progressBlock notifyBlock:notifyBlock];
 	if (success == NO) return NO;
-
-	return [self performCheckoutWithStrategy:strategy notifyFlags:notifyFlags error:error progressBlock:progressBlock notifyBlock:notifyBlock];
+	return [self moveHEADToReference:targetReference error:error];
 }
 
 - (BOOL)checkoutCommit:(GTCommit *)target strategy:(GTCheckoutStrategyType)strategy error:(NSError **)error progressBlock:(GTCheckoutProgressBlock)progressBlock {

--- a/ObjectiveGitTests/GTRepositorySpec.m
+++ b/ObjectiveGitTests/GTRepositorySpec.m
@@ -381,15 +381,13 @@ describe(@"-checkout:strategy:error:progressBlock:", ^{
 });
 
 describe(@"-checkout:strategy:notifyFlags:error:notifyBlock:progressBlock:", ^{
-	it(@"should notify dirty file and stop ref checkout", ^{
+	it(@"should fail ref checkout with dirty file and notify", ^{
 		NSError *error = nil;
 		GTReference *ref = [repository lookUpReferenceWithName:@"refs/heads/other-branch" error:&error];
 		expect(ref).notTo(beNil());
 		expect(error.localizedDescription).to(beNil());
-		// Write something to a file in the repo
 		BOOL writeResult = [@"Replacement data in main.m\n" writeToURL:[repository.fileURL URLByAppendingPathComponent:mainFile] atomically:YES encoding:NSUTF8StringEncoding error:&error];
 		expect(@(writeResult)).to(beTruthy());
-		// Now attempt to checkout the other-branch
 		__block NSUInteger notifyCount = 0;
 		__block BOOL mainFileDirty = NO;
 		int (^notifyBlock)(GTCheckoutNotifyFlags, NSString *, GTDiffFile *, GTDiffFile *, GTDiffFile *);
@@ -410,14 +408,13 @@ describe(@"-checkout:strategy:notifyFlags:error:notifyBlock:progressBlock:", ^{
 		expect(@(error.code)).to(equal(@(GIT_EUSER)));
 	});
 
-	it(@"should notify dirty file and stop commit checkout", ^{
+	it(@"should fail commit checkout with dirty file and notify", ^{
 		NSError *error = nil;
 		GTCommit *commit = [repository lookUpObjectBySHA:@"1d69f3c0aeaf0d62e25591987b93b8ffc53abd77" objectType:GTObjectTypeCommit error:&error];
 		expect(commit).notTo(beNil());
 		expect(error.localizedDescription).to(beNil());
 		BOOL writeResult = [@"Replacement data in README\n" writeToURL:[repository.fileURL URLByAppendingPathComponent:readmeFile] atomically:YES encoding:NSUTF8StringEncoding error:&error];
 		expect(@(writeResult)).to(beTruthy());
-		// Now attempt to checkout the other-branch
 		__block NSUInteger notifyCount = 0;
 		__block BOOL readmeFileDirty = NO;
 		int (^notifyBlock)(GTCheckoutNotifyFlags, NSString *, GTDiffFile *, GTDiffFile *, GTDiffFile *);

--- a/ObjectiveGitTests/GTRepositorySpec.m
+++ b/ObjectiveGitTests/GTRepositorySpec.m
@@ -14,6 +14,10 @@
 
 QuickSpecBegin(GTRepositorySpec)
 
+static NSString * const mainFile = @"main.m";
+static NSString * const readmeFile = @"README1.txt";
+
+
 __block GTRepository *repository;
 
 beforeEach(^{
@@ -373,6 +377,65 @@ describe(@"-checkout:strategy:error:progressBlock:", ^{
 		BOOL result = [repository checkoutCommit:commit strategy:GTCheckoutStrategyAllowConflicts error:&error progressBlock:nil];
 		expect(@(result)).to(beTruthy());
 		expect(error.localizedDescription).to(beNil());
+	});
+});
+
+describe(@"-checkout:strategy:notifyFlags:error:notifyBlock:progressBlock:", ^{
+	it(@"should notify dirty file and stop ref checkout", ^{
+		NSError *error = nil;
+		GTReference *ref = [repository lookUpReferenceWithName:@"refs/heads/other-branch" error:&error];
+		expect(ref).notTo(beNil());
+		expect(error.localizedDescription).to(beNil());
+		// Write something to a file in the repo
+		BOOL writeResult = [@"Replacement data in main.m\n" writeToURL:[repository.fileURL URLByAppendingPathComponent:mainFile] atomically:YES encoding:NSUTF8StringEncoding error:&error];
+		expect(@(writeResult)).to(beTruthy());
+		// Now attempt to checkout the other-branch
+		__block NSUInteger notifyCount = 0;
+		__block BOOL mainFileDirty = NO;
+		int (^notifyBlock)(GTCheckoutNotifyFlags, NSString *, GTDiffFile *, GTDiffFile *, GTDiffFile *);
+		notifyBlock = ^(GTCheckoutNotifyFlags why, NSString *path, GTDiffFile *baseline, GTDiffFile *target, GTDiffFile *workdir) {
+			notifyCount++;
+			if([path isEqualToString:mainFile] && (why & GTCheckoutNotifyDirty)) {
+				mainFileDirty = YES;
+				return GIT_EUSER;
+			} else {
+				return 0;
+			}
+		};
+
+		BOOL result = [repository checkoutReference:ref strategy:GTCheckoutStrategySafe notifyFlags:GTCheckoutNotifyDirty error:&error progressBlock:nil notifyBlock:notifyBlock];
+		expect(@(notifyCount)).to(equal(@(1)));
+		expect(@(mainFileDirty)).to(beTruthy());
+		expect(@(result)).to(beFalsy());
+		expect(@(error.code)).to(equal(@(GIT_EUSER)));
+	});
+
+	it(@"should notify dirty file and stop commit checkout", ^{
+		NSError *error = nil;
+		GTCommit *commit = [repository lookUpObjectBySHA:@"1d69f3c0aeaf0d62e25591987b93b8ffc53abd77" objectType:GTObjectTypeCommit error:&error];
+		expect(commit).notTo(beNil());
+		expect(error.localizedDescription).to(beNil());
+		BOOL writeResult = [@"Replacement data in README\n" writeToURL:[repository.fileURL URLByAppendingPathComponent:readmeFile] atomically:YES encoding:NSUTF8StringEncoding error:&error];
+		expect(@(writeResult)).to(beTruthy());
+		// Now attempt to checkout the other-branch
+		__block NSUInteger notifyCount = 0;
+		__block BOOL readmeFileDirty = NO;
+		int (^notifyBlock)(GTCheckoutNotifyFlags, NSString *, GTDiffFile *, GTDiffFile *, GTDiffFile *);
+		notifyBlock = ^(GTCheckoutNotifyFlags why, NSString *path, GTDiffFile *baseline, GTDiffFile *target, GTDiffFile *workdir) {
+			notifyCount++;
+			if([path isEqualToString:readmeFile] && (why & GTCheckoutNotifyDirty)) {
+				readmeFileDirty = YES;
+				return GIT_EUSER;
+			} else {
+				return 0;
+			}
+		};
+
+		BOOL result = [repository checkoutCommit:commit strategy:GTCheckoutStrategySafe notifyFlags:GTCheckoutNotifyDirty error:&error progressBlock:nil notifyBlock:notifyBlock];
+		expect(@(notifyCount)).to(equal(@(1)));
+		expect(@(readmeFileDirty)).to(beTruthy());
+		expect(@(result)).to(beFalsy());
+		expect(@(error.code)).to(equal(@(GIT_EUSER)));
 	});
 });
 


### PR DESCRIPTION
Currently, the `performCheckout` methods move __HEAD__ to the new ref/commit before calling `git_checkout_head`. This is incorrect behavior.

When `git_checkout_head` is called, it reports changes between the __workdir__ and __HEAD__ per-file to the `notifyBlock`, allowing the block to abort the checkout based on a reason (dirty/conflict/etc).

However, since __HEAD__ has already been moved to a different ref/commit, the `notifyBlock` is notified about changes between the current __workdir__ and the requested ref/commit. This results in a dirty state for any file that differs between the old ref and the new ref, regardless of whether or not any change was made in the workdir.

The correct behavior (e.g. with `GTCheckoutStrategySafe`) is to notify of changes that will cause data loss in the workdir.

This change leaves __HEAD__ in position until after the checkout, correcting the checkout behavior. When `GTCheckoutStrategySafe` is used, `notifyBlock` is only invoked as expected (e.g. dirty files that would be overwritten on checkout). Also, __HEAD__ is only moved if the checkout succeeds, preventing other confusing behavior.