### PR TITLE
Fix checkout methods that use notifyBlock/GTCheckoutStrategySafe

### DIFF
--- a/ObjectiveGit/GTRepository.m
+++ b/ObjectiveGit/GTRepository.m
@@ -809,7 +809,7 @@ static int checkoutNotifyCallback(git_checkout_notify_t why, const char *path, c
 	return gitError == GIT_OK;
 }
 
-- (BOOL)performCheckoutWithStrategy:(GTCheckoutStrategyType)strategy notifyFlags:(GTCheckoutNotifyFlags)notifyFlags error:(NSError **)error progressBlock:(GTCheckoutProgressBlock)progressBlock notifyBlock:(GTCheckoutNotifyBlock)notifyBlock {
+- (BOOL)performCheckout:(GTObject *)target withStrategy:(GTCheckoutStrategyType)strategy notifyFlags:(GTCheckoutNotifyFlags)notifyFlags error:(NSError **)error progressBlock:(GTCheckoutProgressBlock)progressBlock notifyBlock:(GTCheckoutNotifyBlock)notifyBlock {
 
 	git_checkout_options checkoutOptions = GIT_CHECKOUT_OPTIONS_INIT;
 
@@ -821,7 +821,7 @@ static int checkoutNotifyCallback(git_checkout_notify_t why, const char *path, c
 	checkoutOptions.notify_flags = notifyFlags;
 	checkoutOptions.notify_payload = (__bridge void *)notifyBlock;
 
-	int gitError = git_checkout_head(self.git_repository, &checkoutOptions);
+	int gitError = git_checkout_tree(self.git_repository, target.git_object, &checkoutOptions);
 	if (gitError < GIT_OK) {
 		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to checkout tree."];
 	}
@@ -830,13 +830,18 @@ static int checkoutNotifyCallback(git_checkout_notify_t why, const char *path, c
 }
 
 - (BOOL)checkoutCommit:(GTCommit *)targetCommit strategy:(GTCheckoutStrategyType)strategy notifyFlags:(GTCheckoutNotifyFlags)notifyFlags error:(NSError **)error progressBlock:(GTCheckoutProgressBlock)progressBlock notifyBlock:(GTCheckoutNotifyBlock)notifyBlock {
-	BOOL success = [self performCheckoutWithStrategy:strategy notifyFlags:notifyFlags error:error progressBlock:progressBlock notifyBlock:notifyBlock];
+	BOOL success = [self performCheckout:targetCommit withStrategy:strategy notifyFlags:notifyFlags error:error progressBlock:progressBlock notifyBlock:notifyBlock];
 	if (success == NO) return NO;
 	return [self moveHEADToCommit:targetCommit error:error];
 }
 
 - (BOOL)checkoutReference:(GTReference *)targetReference strategy:(GTCheckoutStrategyType)strategy notifyFlags:(GTCheckoutNotifyFlags)notifyFlags error:(NSError **)error progressBlock:(GTCheckoutProgressBlock)progressBlock notifyBlock:(GTCheckoutNotifyBlock)notifyBlock {
-	BOOL success = [self performCheckoutWithStrategy:strategy notifyFlags:notifyFlags error:error progressBlock:progressBlock notifyBlock:notifyBlock];
+	GTOID *targetOID = [targetReference targetOID];
+	GTObject *target = [self lookUpObjectByOID:targetOID error:error];
+	if (target == nil) {
+		return NO;
+	}
+	BOOL success = [self performCheckout:target withStrategy:strategy notifyFlags:notifyFlags error:error progressBlock:progressBlock notifyBlock:notifyBlock];
 	if (success == NO) return NO;
 	return [self moveHEADToReference:targetReference error:error];
 }

--- a/ObjectiveGit/GTRepository.m
+++ b/ObjectiveGit/GTRepository.m
@@ -830,17 +830,15 @@ static int checkoutNotifyCallback(git_checkout_notify_t why, const char *path, c
 }
 
 - (BOOL)checkoutCommit:(GTCommit *)targetCommit strategy:(GTCheckoutStrategyType)strategy notifyFlags:(GTCheckoutNotifyFlags)notifyFlags error:(NSError **)error progressBlock:(GTCheckoutProgressBlock)progressBlock notifyBlock:(GTCheckoutNotifyBlock)notifyBlock {
-	BOOL success = [self moveHEADToCommit:targetCommit error:error];
+	BOOL success = [self performCheckoutWithStrategy:strategy notifyFlags:notifyFlags error:error progressBlock:progressBlock notifyBlock:notifyBlock];
 	if (success == NO) return NO;
-
-	return [self performCheckoutWithStrategy:strategy notifyFlags:notifyFlags error:error progressBlock:progressBlock notifyBlock:notifyBlock];
+	return [self moveHEADToCommit:targetCommit error:error];
 }
 
 - (BOOL)checkoutReference:(GTReference *)targetReference strategy:(GTCheckoutStrategyType)strategy notifyFlags:(GTCheckoutNotifyFlags)notifyFlags error:(NSError **)error progressBlock:(GTCheckoutProgressBlock)progressBlock notifyBlock:(GTCheckoutNotifyBlock)notifyBlock {
-	BOOL success = [self moveHEADToReference:targetReference error:error];
+	BOOL success = [self performCheckoutWithStrategy:strategy notifyFlags:notifyFlags error:error progressBlock:progressBlock notifyBlock:notifyBlock];
 	if (success == NO) return NO;
-
-	return [self performCheckoutWithStrategy:strategy notifyFlags:notifyFlags error:error progressBlock:progressBlock notifyBlock:notifyBlock];
+	return [self moveHEADToReference:targetReference error:error];
 }
 
 - (BOOL)checkoutCommit:(GTCommit *)target strategy:(GTCheckoutStrategyType)strategy error:(NSError **)error progressBlock:(GTCheckoutProgressBlock)progressBlock {

--- a/ObjectiveGit/GTRepository.m
+++ b/ObjectiveGit/GTRepository.m
@@ -838,9 +838,7 @@ static int checkoutNotifyCallback(git_checkout_notify_t why, const char *path, c
 - (BOOL)checkoutReference:(GTReference *)targetReference strategy:(GTCheckoutStrategyType)strategy notifyFlags:(GTCheckoutNotifyFlags)notifyFlags error:(NSError **)error progressBlock:(GTCheckoutProgressBlock)progressBlock notifyBlock:(GTCheckoutNotifyBlock)notifyBlock {
 	GTOID *targetOID = [targetReference targetOID];
 	GTObject *target = [self lookUpObjectByOID:targetOID error:error];
-	if (target == nil) {
-		return NO;
-	}
+	if (target == nil) return NO;
 	BOOL success = [self performCheckout:target withStrategy:strategy notifyFlags:notifyFlags error:error progressBlock:progressBlock notifyBlock:notifyBlock];
 	if (success == NO) return NO;
 	return [self moveHEADToReference:targetReference error:error];

--- a/ObjectiveGitTests/GTRepositorySpec.m
+++ b/ObjectiveGitTests/GTRepositorySpec.m
@@ -381,15 +381,13 @@ describe(@"-checkout:strategy:error:progressBlock:", ^{
 });
 
 describe(@"-checkout:strategy:notifyFlags:error:notifyBlock:progressBlock:", ^{
-	it(@"should notify dirty file and stop ref checkout", ^{
+	it(@"should fail ref checkout with dirty file and notify", ^{
 		NSError *error = nil;
 		GTReference *ref = [repository lookUpReferenceWithName:@"refs/heads/other-branch" error:&error];
 		expect(ref).notTo(beNil());
 		expect(error.localizedDescription).to(beNil());
-		// Write something to a file in the repo
 		BOOL writeResult = [@"Replacement data in main.m\n" writeToURL:[repository.fileURL URLByAppendingPathComponent:mainFile] atomically:YES encoding:NSUTF8StringEncoding error:&error];
 		expect(@(writeResult)).to(beTruthy());
-		// Now attempt to checkout the other-branch
 		__block NSUInteger notifyCount = 0;
 		__block BOOL mainFileDirty = NO;
 		int (^notifyBlock)(GTCheckoutNotifyFlags, NSString *, GTDiffFile *, GTDiffFile *, GTDiffFile *);
@@ -410,14 +408,13 @@ describe(@"-checkout:strategy:notifyFlags:error:notifyBlock:progressBlock:", ^{
 		expect(@(error.code)).to(equal(@(GIT_EUSER)));
 	});
 
-	it(@"should notify dirty file and stop commit checkout", ^{
+	it(@"should fail commit checkout with dirty file and notify", ^{
 		NSError *error = nil;
 		GTCommit *commit = [repository lookUpObjectBySHA:@"1d69f3c0aeaf0d62e25591987b93b8ffc53abd77" objectType:GTObjectTypeCommit error:&error];
 		expect(commit).notTo(beNil());
 		expect(error.localizedDescription).to(beNil());
 		BOOL writeResult = [@"Replacement data in README\n" writeToURL:[repository.fileURL URLByAppendingPathComponent:readmeFile] atomically:YES encoding:NSUTF8StringEncoding error:&error];
 		expect(@(writeResult)).to(beTruthy());
-		// Now attempt to checkout the other-branch
 		__block NSUInteger notifyCount = 0;
 		__block BOOL readmeFileDirty = NO;
 		int (^notifyBlock)(GTCheckoutNotifyFlags, NSString *, GTDiffFile *, GTDiffFile *, GTDiffFile *);

--- a/ObjectiveGitTests/GTRepositorySpec.m
+++ b/ObjectiveGitTests/GTRepositorySpec.m
@@ -14,6 +14,10 @@
 
 QuickSpecBegin(GTRepositorySpec)
 
+static NSString * const mainFile = @"main.m";
+static NSString * const readmeFile = @"README1.txt";
+
+
 __block GTRepository *repository;
 
 beforeEach(^{
@@ -373,6 +377,65 @@ describe(@"-checkout:strategy:error:progressBlock:", ^{
 		BOOL result = [repository checkoutCommit:commit strategy:GTCheckoutStrategyAllowConflicts error:&error progressBlock:nil];
 		expect(@(result)).to(beTruthy());
 		expect(error.localizedDescription).to(beNil());
+	});
+});
+
+describe(@"-checkout:strategy:notifyFlags:error:notifyBlock:progressBlock:", ^{
+	it(@"should notify dirty file and stop ref checkout", ^{
+		NSError *error = nil;
+		GTReference *ref = [repository lookUpReferenceWithName:@"refs/heads/other-branch" error:&error];
+		expect(ref).notTo(beNil());
+		expect(error.localizedDescription).to(beNil());
+		// Write something to a file in the repo
+		BOOL writeResult = [@"Replacement data in main.m\n" writeToURL:[repository.fileURL URLByAppendingPathComponent:mainFile] atomically:YES encoding:NSUTF8StringEncoding error:&error];
+		expect(@(writeResult)).to(beTruthy());
+		// Now attempt to checkout the other-branch
+		__block NSUInteger notifyCount = 0;
+		__block BOOL mainFileDirty = NO;
+		int (^notifyBlock)(GTCheckoutNotifyFlags, NSString *, GTDiffFile *, GTDiffFile *, GTDiffFile *);
+		notifyBlock = ^(GTCheckoutNotifyFlags why, NSString *path, GTDiffFile *baseline, GTDiffFile *target, GTDiffFile *workdir) {
+			notifyCount++;
+			if([path isEqualToString:mainFile] && (why & GTCheckoutNotifyDirty)) {
+				mainFileDirty = YES;
+				return GIT_EUSER;
+			} else {
+				return 0;
+			}
+		};
+
+		BOOL result = [repository checkoutReference:ref strategy:GTCheckoutStrategySafe notifyFlags:GTCheckoutNotifyDirty error:&error progressBlock:nil notifyBlock:notifyBlock];
+		expect(@(notifyCount)).to(equal(@(1)));
+		expect(@(mainFileDirty)).to(beTruthy());
+		expect(@(result)).to(beFalsy());
+		expect(@(error.code)).to(equal(@(GIT_EUSER)));
+	});
+
+	it(@"should notify dirty file and stop commit checkout", ^{
+		NSError *error = nil;
+		GTCommit *commit = [repository lookUpObjectBySHA:@"1d69f3c0aeaf0d62e25591987b93b8ffc53abd77" objectType:GTObjectTypeCommit error:&error];
+		expect(commit).notTo(beNil());
+		expect(error.localizedDescription).to(beNil());
+		BOOL writeResult = [@"Replacement data in README\n" writeToURL:[repository.fileURL URLByAppendingPathComponent:readmeFile] atomically:YES encoding:NSUTF8StringEncoding error:&error];
+		expect(@(writeResult)).to(beTruthy());
+		// Now attempt to checkout the other-branch
+		__block NSUInteger notifyCount = 0;
+		__block BOOL readmeFileDirty = NO;
+		int (^notifyBlock)(GTCheckoutNotifyFlags, NSString *, GTDiffFile *, GTDiffFile *, GTDiffFile *);
+		notifyBlock = ^(GTCheckoutNotifyFlags why, NSString *path, GTDiffFile *baseline, GTDiffFile *target, GTDiffFile *workdir) {
+			notifyCount++;
+			if([path isEqualToString:readmeFile] && (why & GTCheckoutNotifyDirty)) {
+				readmeFileDirty = YES;
+				return GIT_EUSER;
+			} else {
+				return 0;
+			}
+		};
+
+		BOOL result = [repository checkoutCommit:commit strategy:GTCheckoutStrategySafe notifyFlags:GTCheckoutNotifyDirty error:&error progressBlock:nil notifyBlock:notifyBlock];
+		expect(@(notifyCount)).to(equal(@(1)));
+		expect(@(readmeFileDirty)).to(beTruthy());
+		expect(@(result)).to(beFalsy());
+		expect(@(error.code)).to(equal(@(GIT_EUSER)));
 	});
 });
 


### PR DESCRIPTION
Previously, `performCheckout` method moved __HEAD__ to the target, then called `git_checkout_head()`. This does not match behavior in git core, and prevents the `checkoutStrategy` and `notifyCallback` parameters from being used correctly. The only way to reliably checkout a branch or commit was to use GTCheckoutStrategyForce, which throws away conflicts. Also, the HEAD could be moved even if the checkout fails, resulting in a confused state.

This PR corrects the checkout behavior with two changes:

1. __HEAD__ is not moved until after the checkout succeeds.
2. `git_checkout_tree()` is used instead of `git_checkout_head()`. The tree that is checked out is the target object (commit or ref).

Included tests demonstrate the correct behavior catching a conflicted file. The notifyBlock is called to report the conflict, and with GTCheckoutStrategySafe, the checkout fails because of the conflict as expected.