### PR TITLE
Remove deprecated targetCommitAndReturnError

### DIFF
--- a/ObjectiveGit/GTBranch.h
+++ b/ObjectiveGit/GTBranch.h
@@ -132,9 +132,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns whether the calculation was successful.
 - (BOOL)calculateAhead:(size_t *)ahead behind:(size_t *)behind relativeTo:(GTBranch *)branch error:(NSError **)error;
 
-#pragma mark Deprecations
-- (nullable GTCommit *)targetCommitAndReturnError:(NSError **)error __deprecated_msg("use targetCommitWithError: instead.");
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTBranch.m
+++ b/ObjectiveGit/GTBranch.m
@@ -223,9 +223,4 @@
 	return [self.repository calculateAhead:ahead behind:behind ofOID:self.OID relativeToOID:branch.OID error:error];
 }
 
-#pragma mark Deprecations
-- (GTCommit *)targetCommitAndReturnError:(NSError **)error {
-	return [self targetCommitWithError:error];
-}
-
 @end


### PR DESCRIPTION
Conflicts with the non-deprecated `targetCommitWithError:` method in Swift 2 (Xcode 7b6)

```
error: ambiguous use of 'targetCommit()'
                    let gt_commit = try! gt_branch.targetCommit()
                                         ^
ObjectiveGit.GTBranch:38:14: note: found this candidate
  @objc func targetCommit() throws -> GTCommit
             ^
ObjectiveGit.GTBranch:86:14: note: found this candidate
  @objc func targetCommit() throws -> GTCommit
```