### PR TITLE
Fix bug in -isWorkingDirectoryClean

### DIFF
--- a/ObjectiveGit/GTRepository+Status.m
+++ b/ObjectiveGit/GTRepository+Status.m
@@ -78,7 +78,7 @@ NSString *const GTRepositoryStatusOptionsPathSpecArrayKey = @"GTRepositoryStatus
 		}
 		
 		// any untracked files?
-		if (indexToWorkDirStatus == GTStatusDeltaStatusAdded) {
+		if (indexToWorkDirStatus == GTStatusDeltaStatusUntracked) {
 			clean = NO;
 			*stop = YES;
 		}


### PR DESCRIPTION
Comment described checking for untracked files, but status was compared to GTStatusDeltaStatusAdded instead of GTStatusDeltaStatusUntracked