### PR TITLE
2nd attempt: Hopefully just requesting pull of GTRepository.h

### DIFF
--- a/ObjectiveGit/GTRepository.h
+++ b/ObjectiveGit/GTRepository.h
@@ -269,6 +269,14 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 /// Returns a GTReference or nil if an error occurs.
 - (nullable GTReference *)headReferenceWithError:(NSError **)error;
 
+/// Move HEAD reference safely, since deleting and recreating HEAD is always wrong
+///
+/// error - If not NULL, set to any error that occurs.
+///
+/// Returns NO if an error occurs.
+- (BOOL)moveHEADToReference:(GTReference *)reference error:(NSError **)error;
+- (BOOL)moveHEADToCommit:(GTCommit *)commit error:(NSError **)error;
+
 /// Get the local branches.
 ///
 /// error - If not NULL, set to any error that occurs.


### PR DESCRIPTION
Moved private method declarations -moveHEADToReference:error: and -moveHEADToCommit:error: to the header so they can be used from apps. This seems important because I'm told the only legitimate way to move the HEAD is with these methods (and the underlying git2 functions) and NOT to delete and recreate the HEAD reference manually, so these methods must be public if client apps need to move the HEAD.