### PR TITLE
Fix issue when compiling when UIKit is imported

### DIFF
--- a/ObjectiveGit/GTRepository.m
+++ b/ObjectiveGit/GTRepository.m
@@ -134,7 +134,7 @@ typedef struct {
 	[optionsDict[GTRepositoryInitOptionsMode] unsignedIntegerValue];
 	options.workdir_path = [optionsDict[GTRepositoryInitOptionsWorkingDirectoryPath] UTF8String];
 	options.description = [optionsDict[GTRepositoryInitOptionsDescription] UTF8String];
-	options.template_path = [optionsDict[GTRepositoryInitOptionsTemplateURL] path].UTF8String;
+	options.template_path = ((NSURL *)optionsDict[GTRepositoryInitOptionsTemplateURL]).path.UTF8String;
 	options.initial_head = [optionsDict[GTRepositoryInitOptionsInitialHEAD] UTF8String];
 	options.origin_url = [optionsDict[GTRepositoryInitOptionsOriginURLString] UTF8String];
 


### PR DESCRIPTION
I've gotten Objective-Git working with Cocoapods for iOS, but this one small change is necessary. It seems like Cocoapods unconditionally includes UIKit in the prefix header for the target it generates, and doing so confuses this code -- it thinks the `path` selector you're using is one of the ones from CoreAnimation, and expects it to return a `CGPathRef`. The explicit cast fixes that problem.