### PR TITLE
Added note setup step

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ There are three ways of including ObjectiveGit in a project:
 
 1. Commit the [`Cartfile.resolved`](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfileresolved)
 
+2. Under “Build Settings”, add the following to “Header Search Paths”: `$(SRCROOT)/Carthage/Build/iOS/ObjectiveGit.framework/Headers/` to avoid [`git2/filter.h file not found` errors](https://github.com/libgit2/objective-git/issues/441).
+
 The different instructions for iOS works around an [App Store submission bug](http://www.openradar.me/radar?id=6409498411401216) triggered by universal binaries.
 
 


### PR DESCRIPTION
I had to manually add a header search path as per https://github.com/libgit2/objective-git/issues/441 in order to compile. Added that as a step to the instructions. Only tested on iOS so added to end of that list. Not sure if it also applies for Mac targets (assuming so). If so, please feel free to move to the top where it might make more sense and apply to both.