### PR TITLE
Upgrade xctool on Travis instead of installing HEAD version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 osx_image: xcode7
 language: objective-c
-before_install: brew update
-install:
-  - brew uninstall xctool && brew install --HEAD xctool
-  - script/bootstrap
+before_install:
+  - brew update
+  - brew outdated xctool || brew upgrade xctool
+install: script/bootstrap
 script: script/cibuild
 notifications:
   email: false


### PR DESCRIPTION
[xctool 0.2.7](https://github.com/facebook/xctool/releases/tag/0.2.7) was finally released, so this updates the `.travis.yml` to upgrade `xctool` to the latest release, rather than installing from `HEAD`.