### PR TITLE
Fix libssh2 inclusion in libgit2 iOS build script

### DIFF
--- a/script/update_libgit2_ios
+++ b/script/update_libgit2_ios
@@ -45,9 +45,8 @@ function build_libgit2 ()
     cmake \
         -DCMAKE_C_COMPILER_WORKS:BOOL=ON \
         -DBUILD_SHARED_LIBS:BOOL=OFF \
-        -DCMAKE_LIBRARY_PATH:PATH=../../External/libssh2-ios/lib/ \
-        -DLIBSSH2_INCLUDE_DIRS:PATH=../../External/libssh2-ios/include/libssh2/ \
-        -DCMAKE_LIBRARY_PATH:PATH="${SDKROOT}/usr/lib/" \
+        -DCMAKE_PREFIX_PATH:PATH="${ROOT_PATH}/External/libssh2-ios/bin/${SDKNAME}-${ARCH}.sdk" \
+        -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH:BOOL=ON \
         -DCMAKE_INSTALL_PREFIX:PATH="${INSTALL_PREFIX}/" \
         -DBUILD_CLAR:BOOL=OFF \
         -DTHREADSAFE:BOOL=ON \


### PR DESCRIPTION
The `update_libgit2_ios` build script was mistakenly picking up libssh2 (version 1.6.0) from homebrew instead of the local version built specifically for iOS (currently 1.4.3).

```
-- checking for module 'libssh2'
--   found libssh2, version 1.4.3_DEV
-- Looking for libssh2_userauth_publickey_frommemory in ssh2
-- Looking for libssh2_userauth_publickey_frommemory in ssh2 - not found
```

Resolves #531