### PR TITLE
Expose -moveHEAD

### DIFF
--- a/ObjectiveGit/GTRepository.h
+++ b/ObjectiveGit/GTRepository.h
@@ -280,7 +280,7 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 /// Move HEAD reference safely, since deleting and recreating HEAD is always wrong.
 ///
 /// commit - The commit which HEAD should point to.
-/// error - If not NULL, set to any error that occurs.
+/// error  - If not NULL, set to any error that occurs.
 ///
 /// Returns NO if an error occurs.
 - (BOOL)moveHEADToCommit:(GTCommit *)commit error:(NSError **)error;
@@ -302,7 +302,7 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 /// Get branches with names sharing a given prefix.
 ///
 /// prefix - The prefix to use for filtering. Must not be nil.
-/// error - If not NULL, set to any error that occurs.
+/// error  - If not NULL, set to any error that occurs.
 ///
 /// Returns an array of GTBranches or nil if an error occurs.
 - (nullable NSArray<GTBranch *> *)branchesWithPrefix:(NSString *)prefix error:(NSError **)error;

--- a/ObjectiveGit/GTRepository.h
+++ b/ObjectiveGit/GTRepository.h
@@ -272,7 +272,7 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 /// Move HEAD reference safely, since deleting and recreating HEAD is always wrong.
 ///
 /// reference - The new target reference for HEAD.
-/// error - If not NULL, set to any error that occurs.
+/// error     - If not NULL, set to any error that occurs.
 ///
 /// Returns NO if an error occurs.
 - (BOOL)moveHEADToReference:(GTReference *)reference error:(NSError **)error;

--- a/ObjectiveGit/GTRepository.h
+++ b/ObjectiveGit/GTRepository.h
@@ -269,6 +269,14 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 /// Returns a GTReference or nil if an error occurs.
 - (nullable GTReference *)headReferenceWithError:(NSError **)error;
 
+/// Move HEAD reference safely, since deleting and recreating HEAD is always wrong
+///
+/// error - If not NULL, set to any error that occurs.
+///
+/// Returns NO if an error occurs.
+- (BOOL)moveHEADToReference:(GTReference *)reference error:(NSError **)error;
+- (BOOL)moveHEADToCommit:(GTCommit *)commit error:(NSError **)error;
+
 /// Get the local branches.
 ///
 /// error - If not NULL, set to any error that occurs.

--- a/ObjectiveGit/GTRepository.h
+++ b/ObjectiveGit/GTRepository.h
@@ -269,12 +269,20 @@ extern NSString * const GTRepositoryInitOptionsOriginURLString;
 /// Returns a GTReference or nil if an error occurs.
 - (nullable GTReference *)headReferenceWithError:(NSError **)error;
 
-/// Move HEAD reference safely, since deleting and recreating HEAD is always wrong
+/// Move HEAD reference safely, since deleting and recreating HEAD is always wrong.
 ///
+/// reference - The new target reference for HEAD.
 /// error - If not NULL, set to any error that occurs.
 ///
 /// Returns NO if an error occurs.
 - (BOOL)moveHEADToReference:(GTReference *)reference error:(NSError **)error;
+
+/// Move HEAD reference safely, since deleting and recreating HEAD is always wrong.
+///
+/// commit - The commit which HEAD should point to.
+/// error - If not NULL, set to any error that occurs.
+///
+/// Returns NO if an error occurs.
 - (BOOL)moveHEADToCommit:(GTCommit *)commit error:(NSError **)error;
 
 /// Get the local branches.

--- a/ObjectiveGitTests/GTRepositorySpec.m
+++ b/ObjectiveGitTests/GTRepositorySpec.m
@@ -358,6 +358,58 @@ describe(@"-OIDByCreatingTagNamed:target:tagger:message:error", ^{
 	});
 });
 
+describe(@"move head", ^{
+	beforeEach(^{
+		repository = self.testAppFixtureRepository;
+	});
+
+	//- (BOOL)moveHEADToReference:(GTReference *)reference error:(NSError **)error;
+	it(@"should move to reference", ^{
+		NSError *error = nil;
+		GTReference *originalHead = [repository headReferenceWithError:NULL];
+
+		GTReference *targetReference = [repository lookUpReferenceWithName:@"refs/heads/other-branch" error:NULL];
+		expect(targetReference).notTo(beNil());
+
+		// -> Test the move
+		BOOL success = [repository moveHEADToReference:targetReference error:&error];
+		expect(@(success)).to(beTruthy());
+		expect(error).to(beNil());
+
+		// Verify
+		GTReference *head = [repository headReferenceWithError:&error];
+		expect(head).notTo(beNil());
+		expect(head).notTo(equal(originalHead));
+		expect(head.targetOID.SHA).to(equal(targetReference.targetOID.SHA));
+	});
+
+	//- (BOOL)moveHEADToCommit:(GTCommit *)commit error:(NSError **)error;
+	it(@"should move to commit", ^{
+		NSError *error = nil;
+		GTReference *originalHead = [repository headReferenceWithError:NULL];
+		NSString *targetCommitSHA = @"f7ecd8f4404d3a388efbff6711f1bdf28ffd16a0";
+
+		GTCommit *commit = [repository lookUpObjectBySHA:targetCommitSHA error:NULL];
+		expect(commit).notTo(beNil());
+
+		GTCommit *originalHeadCommit = [repository lookUpObjectByOID:originalHead.targetOID error:NULL];
+		expect(originalHeadCommit).notTo(beNil());
+
+		// -> Test the move
+		BOOL success = [repository moveHEADToCommit:commit error:&error];
+		expect(@(success)).to(beTruthy());
+		expect(error).to(beNil());
+
+		// Test for detached?
+
+		// Verify
+		GTReference *head = [repository headReferenceWithError:&error];
+		expect(head).notTo(beNil());
+		expect(head.targetOID.SHA).to(equal(targetCommitSHA));
+	});
+});
+
+
 describe(@"-checkout:strategy:error:progressBlock:", ^{
 	it(@"should allow references", ^{
 		NSError *error = nil;


### PR DESCRIPTION
Expose move HEAD operations through public API. Includes tests.

> Moved private method declarations -moveHEADToReference:error: and -moveHEADToCommit:error: to the header so they can be used from apps. This seems important because I'm told the only legitimate way to move the HEAD is with these methods (and the underlying git2 functions) and NOT to delete and recreate the HEAD reference manually, so these methods must be public if client apps need to move the HEAD.

Supersedes #515 from @wilshipley 