### PR TITLE
+[GTDiff diffOldTree:withNewIndex:…]

### DIFF
--- a/ObjectiveGit/GTDiff.h
+++ b/ObjectiveGit/GTDiff.h
@@ -13,6 +13,7 @@
 @class GTDiffDelta;
 @class GTRepository;
 @class GTTree;
+@class GTIndex;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -199,6 +200,23 @@ typedef NS_OPTIONS(NSInteger, GTDiffFindOptionsFlags) {
 ///
 /// Returns a newly created `GTDiff` object or nil on error.
 + (nullable instancetype)diffOldTree:(nullable GTTree *)oldTree withNewTree:(nullable GTTree *)newTree inRepository:(GTRepository *)repository options:(nullable NSDictionary *)options error:(NSError **)error;
+
+/// Create a diff between `GTTree` and `GTIndex`.
+///
+/// Both instances must be from the same repository, or an exception will be thrown.
+///
+/// oldTree    - The "left" side of the diff. May be nil to represent an empty
+///              tree.
+/// newIndex   - The "right" side of the diff. May be nil to represent an empty
+///              index.
+/// repository - The repository to be used for the diff. Cannot be nil.
+/// options    - A dictionary containing any of the above options key constants, or
+///              nil to use the defaults.
+/// error      - Populated with an `NSError` object on error, if information is
+///              available.
+///
+/// Returns a newly created `GTDiff` object or nil on error.
++ (nullable instancetype)diffOldTree:(nullable GTTree *)oldTree withNewIndex:(nullable GTIndex *)newIndex inRepository:(GTRepository *)repository options:(nullable NSDictionary *)options error:(NSError **)error;
 
 /// Create a diff between a repository's current index.
 ///

--- a/ObjectiveGit/GTDiff.m
+++ b/ObjectiveGit/GTDiff.m
@@ -11,6 +11,7 @@
 #import "GTCommit.h"
 #import "GTRepository.h"
 #import "GTTree.h"
+#import "GTIndex.h"
 #import "NSArray+StringArray.h"
 #import "NSError+Git.h"
 
@@ -88,6 +89,21 @@ NSString *const GTDiffFindOptionsRenameLimitKey = @"GTDiffFindOptionsRenameLimit
 	}];
 	if (status != GIT_OK) {
 		if (error != NULL) *error = [NSError git_errorFor:status description:@"Failed to create diff between %@ and %@", oldTree.SHA, newTree.SHA];
+		return nil;
+	}
+	
+	return [[self alloc] initWithGitDiff:diff repository:repository];
+}
+
++ (instancetype)diffOldTree:(GTTree *)oldTree withNewIndex:(GTIndex *)newIndex inRepository:(GTRepository *)repository options:(NSDictionary *)options error:(NSError **)error {
+	NSParameterAssert(repository != nil);
+	
+	__block git_diff *diff;
+	int status = [self handleParsedOptionsDictionary:options usingBlock:^(git_diff_options *optionsStruct) {
+		return git_diff_tree_to_index(&diff, repository.git_repository, oldTree.git_tree, newIndex.git_index, optionsStruct);
+	}];
+	if (status != GIT_OK) {
+		if (error != NULL) *error = [NSError git_errorFor:status description:@"Failed to create diff between %@ and %@", oldTree.SHA, newIndex];
 		return nil;
 	}
 	


### PR DESCRIPTION
Adding support for diffing a tree and an arbitrary GTIndex (for in-mem comparisons of pending merges)