### PR TITLE
Added missing nullable keyword to [GTIndex entryWithPath:path] convenience method

### DIFF
--- a/ObjectiveGit/GTIndex.h
+++ b/ObjectiveGit/GTIndex.h
@@ -107,8 +107,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns a new GTIndexEntry, or nil if an error occurred.
 - (nullable GTIndexEntry *)entryAtIndex:(NSUInteger)index;
 
-/// Get the entry with the given path.
-- (GTIndexEntry *)entryWithPath:(NSString *)path;
+/// Get the entry with the given path, or nil if an error occurred.
+- (nullable GTIndexEntry *)entryWithPath:(NSString *)path;
 
 /// Get the entry with the given name.
 ///


### PR DESCRIPTION
Missing keyword made it impossible to use this method properly in Swift (and since it basically just aliases entryWithPath:error: with a NULL error, there's no reason the signature should be different).