### PR TITLE
Fixed erroneous shouldIgnoreFile return value

### DIFF
--- a/ObjectiveGit/GTRepository+Status.h
+++ b/ObjectiveGit/GTRepository+Status.h
@@ -126,7 +126,7 @@ extern NSString *const GTRepositoryStatusOptionsPathSpecArrayKey;
 
 /// Tests the ignore rules to see if the file should be considered as ignored.
 ///
-/// fileURL  - A string path relative to the working copy. Must not be nil.
+/// fileURL  - A local file URL for a file in the repository. Must not be nil.
 /// success  - If not NULL, will be set to indicate success or fail.
 /// error    - If not nil, set to any error that occurs.
 ///

--- a/ObjectiveGit/GTRepository+Status.m
+++ b/ObjectiveGit/GTRepository+Status.m
@@ -122,7 +122,7 @@ NSString *const GTRepositoryStatusOptionsPathSpecArrayKey = @"GTRepositoryStatus
 	}
 
 	if (success != NULL) *success = YES;
-	return (ignoreState == 0 ? YES : NO);
+	return (ignoreState == 1 ? YES : NO);
 }
 
 @end


### PR DESCRIPTION
Per the [git_status_should_ignore](https://libgit2.github.com/libgit2/#HEAD/group/status/git_status_should_ignore) docs (emphasis mine):

> ignored: Boolean returning 0 if the file is **not ignored**, 1 if it is

However, the current implementation was returning YES ("the file should be ignored") if the ignore state was 0 ("the file should not be ignored").

Also tweaked the documentation comment to accurately describe the fileURL parameter; I tested and both an absolute path derived from an NSURL (currently in use) and a string path relative to the repository root work fine, so I didn't see any reason to change the method to match the documentation comment instead.