### PR TITLE
Add offsets to bit flag comparisons for GTIndexEntryStatus

### DIFF
--- a/ObjectiveGit/GTIndexEntry.m
+++ b/ObjectiveGit/GTIndexEntry.m
@@ -86,15 +86,15 @@
 }
 
 - (GTIndexEntryStatus)status {
-	if ((self.flags & GIT_IDXENTRY_UPDATE) != 0) {
+	if ((self.flags & (GIT_IDXENTRY_UPDATE << 16)) != 0) {
 		return GTIndexEntryStatusUpdated;
-	} else if ((self.flags & GIT_IDXENTRY_UPTODATE) != 0) {
+	} else if ((self.flags & (GIT_IDXENTRY_UPTODATE << 16)) != 0) {
 		return GTIndexEntryStatusUpToDate;
-	} else if ((self.flags & GIT_IDXENTRY_CONFLICTED) != 0) {
+	} else if ((self.flags & (GIT_IDXENTRY_CONFLICTED << 16)) != 0) {
 		return GTIndexEntryStatusConflicted;
-	} else if ((self.flags & GIT_IDXENTRY_ADDED) != 0) {
+	} else if ((self.flags & (GIT_IDXENTRY_ADDED << 16)) != 0) {
 		return GTIndexEntryStatusAdded;
-	} else if ((self.flags & GIT_IDXENTRY_REMOVE) != 0) {
+	} else if ((self.flags & (GIT_IDXENTRY_REMOVE << 16)) != 0) {
 		return GTIndexEntryStatusRemoved;
 	}
 


### PR DESCRIPTION
Are you sick of random minor pull requests from me yet? :-)

You'll note on line 81 of the same file that the flags_extended bit flag from libgit2 is shifted 16 bits left in order to combine it with the basic flags field into a single int. However, the comparisons were not shifted, and thus were improperly reporting statuses depending on the bits set in the NAMEMASK portion of the basic flags. This commit fixes the bug.

Incidentally, I have not come across any instances where the flags_extended are actually set (and it appears that [they are not intended for external use, anyway](http://stackoverflow.com/a/35075953/38666)). It might be worth considering deprecating this method to avoid confusion for future newbies to Objective-Git.