### PR TITLE
Fix fallback to iphonesimulator in script/cibuild

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -118,7 +118,7 @@ build_scheme ()
     echo "*** Building and testing $scheme..."
     echo
 
-    local sdkflag=
+    local sdkflags=()
     local action=test
 
     # Determine whether we can run unit tests for this target.
@@ -129,17 +129,17 @@ build_scheme ()
     if [ "$awkstatus" -eq "1" ]
     then
         # SDK not found, try for iphonesimulator.
-        sdkflag='-sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 5"'
+        sdkflags=(-sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 5")
 
         # Determine whether the unit tests will run with iphonesimulator
-        run_xctool "$sdkflag" -scheme "$scheme" run-tests | parse_build
+        run_xctool "${sdkflags[@]}" -scheme "$scheme" run-tests | parse_build
 
         awkstatus=$?
 
         if [ "$awkstatus" -ne "0" ]
         then
             # Unit tests will not run on iphonesimulator.
-            sdkflag=""
+            sdkflags=()
         fi
     fi
 
@@ -149,7 +149,7 @@ build_scheme ()
         action=build
     fi
 
-    run_xctool $sdkflag -scheme "$scheme" $action
+    run_xctool "${sdkflags[@]}" -scheme "$scheme" $action
 }
 
 export -f build_scheme


### PR DESCRIPTION
In https://github.com/libgit2/objective-git/pull/484 more flags were
added into the variable `sdkflag`, which then caused the following
execution of run_xctool to always fail. This means that iOS tests have
not been running as part of the TravisCI run, they have only been built.
You can see this if you look at the final run for the PR:
https://travis-ci.org/libgit2/objective-git/builds/78334551#L192

Bash does some great things when trying to interpret variables in
commands. Initially the `$sdkflag` didn't have any quotes around it as
can be seen in commit 15f906ca2efa9d5ba67744d25a825c9bc75ad9e7. When the
second flag was added this would have caused the command to fail because
of the way Bash would interpret the whitespace. Without the surrounding
quotes the command would have been executed as follows:

```
xctool -workspace ObjectiveGitFramework.xcworkspace RUN_CLANG_STATIC_ANALYZER=NO -sdk iphonesimulator -destination '"platform=iOS' Simulator,name=iPhone '5"' -scheme "ObjectiveGit iOS" test ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO
```

You can see in the above that the white space was split in the middle of
the `-destination` parameter and it causes `xctool` to spout out an
error. When the surrounding quotes were added it caused xctool to run
but `$sdkflag` would be interpretted as a single argument, as it is
executed as follows:

```
xctool -workspace ObjectiveGitFramework.xcworkspace RUN_CLANG_STATIC_ANALYZER=NO '-sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 5"' -scheme "ObjectiveGit iOS" test ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO
```

Notice in the above that the entire argument is still surrounded by
single quotes.

This can be solved by switching `$sdkflag` for an array of strings, this
can then be correctly expanded in the command getting around the issues
highlighted above.

You can read more about these issues with Bash in the following links:

  - http://mywiki.wooledge.org/BashFAQ/050
  - http://mywiki.wooledge.org/BashFAQ/073