### PR TITLE
Write merge conflicted files when pulling

### DIFF
--- a/ObjectiveGit/GTRepository+Merging.h
+++ b/ObjectiveGit/GTRepository+Merging.h
@@ -45,11 +45,10 @@ typedef NS_OPTIONS(NSInteger, GTMergeAnalysis) {
 
 /// Merge Branch into current branch
 ///
-/// analysis   - The resulting analysis.
 /// fromBranch - The branch to merge from.
 /// error      - The error if one occurred. Can be NULL.
 ///
-/// Returns YES if the nerge was successful, NO otherwise (and `error`, if provided,
+/// Returns YES if the merge was successful, NO otherwise (and `error`, if provided,
 /// will point to an error describing what happened).
 - (BOOL)mergeBranchIntoCurrentBranch:(GTBranch *)fromBranch withError:(NSError **)error;
 

--- a/ObjectiveGit/GTRepository+Merging.h
+++ b/ObjectiveGit/GTRepository+Merging.h
@@ -1,0 +1,34 @@
+//
+//  GTRepository+Merging.h
+//  ObjectiveGitFramework
+//
+//  Created by Piet Brauer on 02/03/16.
+//  Copyright © 2016 GitHub, Inc. All rights reserved.
+//
+
+#import "GTRepository.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface GTRepository (Merging)
+
+/// Enumerate all available merge head entries.
+///
+/// error - The error if one ocurred. Can be NULL.
+/// block - A block to execute for each MERGE_HEAD entry. `mergeHeadEntry` will
+///         be the current merge head entry. Setting `stop` to YES will cause
+///         enumeration to stop after the block returns. Must not be nil.
+///
+/// Returns YES if the operation succedded, NO otherwise.
+- (BOOL)enumerateMergeHeadEntriesWithError:(NSError **)error usingBlock:(void (^)(GTCommit *mergeHeadEntry, BOOL *stop))block;
+
+/// Convenience method for -enumerateMergeHeadEntriesWithError:usingBlock: that retuns an NSArray with all the fetch head entries.
+///
+/// error - The error if one ocurred. Can be NULL.
+///
+/// Retruns a (possibly empty) array with GTCommit objects. Will not be nil.
+- (NSArray <GTCommit *>*)mergeHeadEntriesWithError:(NSError **)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveGit/GTRepository+Merging.h
+++ b/ObjectiveGit/GTRepository+Merging.h
@@ -43,6 +43,16 @@ typedef NS_OPTIONS(NSInteger, GTMergeAnalysis) {
 /// Retruns a (possibly empty) array with GTCommit objects. Will not be nil.
 - (NSArray <GTCommit *>*)mergeHeadEntriesWithError:(NSError **)error;
 
+/// Merge Branch into current branch
+///
+/// analysis   - The resulting analysis.
+/// fromBranch - The branch to merge from.
+/// error      - The error if one occurred. Can be NULL.
+///
+/// Returns YES if the nerge was successful, NO otherwise (and `error`, if provided,
+/// will point to an error describing what happened).
+- (BOOL)mergeBranchIntoCurrentBranch:(GTBranch *)fromBranch withError:(NSError **)error;
+
 /// Analyze which merge to perform.
 ///
 /// analysis   - The resulting analysis.

--- a/ObjectiveGit/GTRepository+Merging.h
+++ b/ObjectiveGit/GTRepository+Merging.h
@@ -34,14 +34,14 @@ typedef NS_OPTIONS(NSInteger, GTMergeAnalysis) {
 ///         enumeration to stop after the block returns. Must not be nil.
 ///
 /// Returns YES if the operation succedded, NO otherwise.
-- (BOOL)enumerateMergeHeadEntriesWithError:(NSError **)error usingBlock:(void (^)(GTCommit *mergeHeadEntry, BOOL *stop))block;
+- (BOOL)enumerateMergeHeadEntriesWithError:(NSError **)error usingBlock:(void (^)(GTOID *mergeHeadEntry, BOOL *stop))block;
 
 /// Convenience method for -enumerateMergeHeadEntriesWithError:usingBlock: that retuns an NSArray with all the fetch head entries.
 ///
 /// error - The error if one ocurred. Can be NULL.
 ///
-/// Retruns a (possibly empty) array with GTCommit objects. Will not be nil.
-- (NSArray <GTCommit *>*)mergeHeadEntriesWithError:(NSError **)error;
+/// Retruns a (possibly empty) array with GTOID objects. Will not be nil.
+- (NSArray <GTOID *>*)mergeHeadEntriesWithError:(NSError **)error;
 
 /// Merge Branch into current branch
 ///

--- a/ObjectiveGit/GTRepository+Merging.h
+++ b/ObjectiveGit/GTRepository+Merging.h
@@ -7,8 +7,22 @@
 //
 
 #import "GTRepository.h"
+#import "git2/merge.h"
 
 NS_ASSUME_NONNULL_BEGIN
+
+/// UserInfo key for conflicted files when pulling fails with a merge conflict
+extern NSString * const GTPullMergeConflictedFiles;
+
+/// An enum describing the result of the merge analysis.
+/// See `git_merge_analysis_t`.
+typedef NS_OPTIONS(NSInteger, GTMergeAnalysis) {
+	GTMergeAnalysisNone = GIT_MERGE_ANALYSIS_NONE,
+	GTMergeAnalysisNormal = GIT_MERGE_ANALYSIS_NORMAL,
+	GTMergeAnalysisUpToDate = GIT_MERGE_ANALYSIS_UP_TO_DATE,
+	GTMergeAnalysisUnborn = GIT_MERGE_ANALYSIS_UNBORN,
+	GTMergeAnalysisFastForward = GIT_MERGE_ANALYSIS_FASTFORWARD,
+};
 
 @interface GTRepository (Merging)
 
@@ -28,6 +42,16 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// Retruns a (possibly empty) array with GTCommit objects. Will not be nil.
 - (NSArray <GTCommit *>*)mergeHeadEntriesWithError:(NSError **)error;
+
+/// Analyze which merge to perform.
+///
+/// analysis   - The resulting analysis.
+/// fromBranch - The branch to merge from.
+/// error      - The error if one occurred. Can be NULL.
+///
+/// Returns YES if the analysis was successful, NO otherwise (and `error`, if provided,
+/// will point to an error describing what happened).
+- (BOOL)analyzeMerge:(GTMergeAnalysis *)analysis fromBranch:(GTBranch *)fromBranch error:(NSError **)error;
 
 @end
 

--- a/ObjectiveGit/GTRepository+Merging.m
+++ b/ObjectiveGit/GTRepository+Merging.m
@@ -10,6 +10,13 @@
 #import "GTOID.h"
 #import "NSError+Git.h"
 #import "git2/errors.h"
+#import "GTCommit.h"
+#import "GTReference.h"
+#import "GTRepository+Committing.h"
+#import "GTRepository+Pull.h"
+#import "GTTree.h"
+#import "GTIndex.h"
+#import "GTIndexEntry.h"
 
 typedef void (^GTRemoteFetchTransferProgressBlock)(const git_transfer_progress *stats, BOOL *stop);
 
@@ -65,6 +72,116 @@ int GTMergeHeadEntriesCallback(const git_oid *oid, void *payload) {
 	}];
 
 	return entries;
+}
+
+- (BOOL)mergeBranchIntoCurrentBranch:(GTBranch *)branch withError:(NSError **)error {
+	// Check if merge is necessary
+	GTBranch *localBranch = [self currentBranchWithError:error];
+	if (!localBranch) {
+		return NO;
+	}
+
+	GTCommit *localCommit = [localBranch targetCommitWithError:error];
+	if (!localCommit) {
+		return NO;
+	}
+
+	GTCommit *remoteCommit = [branch targetCommitWithError:error];
+	if (!remoteCommit) {
+		return NO;
+	}
+
+	if ([localCommit.SHA isEqualToString:remoteCommit.SHA]) {
+		// Local and remote tracking branch are already in sync
+		return YES;
+	}
+
+	GTMergeAnalysis analysis = GTMergeAnalysisNone;
+	BOOL success = [self analyzeMerge:&analysis fromBranch:branch error:error];
+	if (!success) {
+		return NO;
+	}
+
+	if (analysis & GTMergeAnalysisUpToDate) {
+		// Nothing to do
+		return YES;
+	} else if (analysis & GTMergeAnalysisFastForward ||
+			   analysis & GTMergeAnalysisUnborn) {
+		// Fast-forward branch
+		NSString *message = [NSString stringWithFormat:@"merge %@: Fast-forward", branch.name];
+		GTReference *reference = [localBranch.reference referenceByUpdatingTarget:remoteCommit.SHA message:message error:error];
+		BOOL checkoutSuccess = [self checkoutReference:reference strategy:GTCheckoutStrategyForce error:error progressBlock:nil];
+
+		return checkoutSuccess;
+	} else if (analysis & GTMergeAnalysisNormal) {
+		// Do normal merge
+		GTTree *localTree = localCommit.tree;
+		GTTree *remoteTree = remoteCommit.tree;
+
+		// TODO: Find common ancestor
+		GTTree *ancestorTree = nil;
+
+		// Merge
+		GTIndex *index = [localTree merge:remoteTree ancestor:ancestorTree error:error];
+		if (!index) {
+			return NO;
+		}
+
+		// Check for conflict
+		if (index.hasConflicts) {
+			NSMutableArray <NSString *>*files = [NSMutableArray array];
+			[index enumerateConflictedFilesWithError:error usingBlock:^(GTIndexEntry * _Nonnull ancestor, GTIndexEntry * _Nonnull ours, GTIndexEntry * _Nonnull theirs, BOOL * _Nonnull stop) {
+				[files addObject:ours.path];
+			}];
+
+			if (error != NULL) {
+				NSDictionary *userInfo = @{GTPullMergeConflictedFiles: files};
+				*error = [NSError git_errorFor:GIT_ECONFLICT description:@"Merge conflict" userInfo:userInfo failureReason:nil];
+			}
+
+			// Write conflicts
+			git_merge_options merge_opts = GIT_MERGE_OPTIONS_INIT;
+			git_checkout_options checkout_opts = GIT_CHECKOUT_OPTIONS_INIT;
+			checkout_opts.checkout_strategy = GIT_CHECKOUT_ALLOW_CONFLICTS;
+
+			git_annotated_commit *annotatedCommit;
+			[self annotatedCommit:&annotatedCommit fromCommit:remoteCommit error:error];
+
+			git_merge(self.git_repository, (const git_annotated_commit **)&annotatedCommit, 1, &merge_opts, &checkout_opts);
+
+			return NO;
+		}
+
+		GTTree *newTree = [index writeTreeToRepository:self error:error];
+		if (!newTree) {
+			return NO;
+		}
+
+		// Create merge commit
+		NSString *message = [NSString stringWithFormat:@"Merge branch '%@'", localBranch.shortName];
+		NSArray *parents = @[ localCommit, remoteCommit ];
+
+		// FIXME: This is stepping on the local tree
+		GTCommit *mergeCommit = [self createCommitWithTree:newTree  message:message parents:parents updatingReferenceNamed:localBranch.name error:error];
+		if (!mergeCommit) {
+			return NO;
+		}
+
+		BOOL success = [self checkoutReference:localBranch.reference strategy:GTCheckoutStrategyForce error:error progressBlock:nil];
+		return success;
+	}
+
+	return NO;
+}
+
+- (BOOL)annotatedCommit:(git_annotated_commit **)annotatedCommit fromCommit:(GTCommit *)fromCommit error:(NSError **)error {
+	int gitError = git_annotated_commit_lookup(annotatedCommit, self.git_repository, fromCommit.OID.git_oid);
+	if (gitError != GIT_OK) {
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to lookup annotated commit for %@", fromCommit];
+		return NO;
+	}
+
+	return YES;
 }
 
 - (BOOL)analyzeMerge:(GTMergeAnalysis *)analysis fromBranch:(GTBranch *)fromBranch error:(NSError **)error {

--- a/ObjectiveGit/GTRepository+Merging.m
+++ b/ObjectiveGit/GTRepository+Merging.m
@@ -1,0 +1,70 @@
+//
+//  GTRepository+Merging.m
+//  ObjectiveGitFramework
+//
+//  Created by Piet Brauer on 02/03/16.
+//  Copyright © 2016 GitHub, Inc. All rights reserved.
+//
+
+#import "GTRepository+Merging.h"
+#import "GTOID.h"
+#import "NSError+Git.h"
+#import "git2/errors.h"
+
+typedef void (^GTRemoteFetchTransferProgressBlock)(const git_transfer_progress *stats, BOOL *stop);
+
+@implementation GTRepository (Merging)
+
+typedef void (^GTRepositoryEnumerateMergeHeadEntryBlock)(GTCommit *entry, BOOL *stop);
+
+typedef struct {
+	__unsafe_unretained GTRepository *repository;
+	__unsafe_unretained GTRepositoryEnumerateMergeHeadEntryBlock enumerationBlock;
+} GTEnumerateMergeHeadEntriesPayload;
+
+int GTMergeHeadEntriesCallback(const git_oid *oid, void *payload) {
+	GTEnumerateMergeHeadEntriesPayload *entriesPayload = payload;
+
+	GTRepository *repository = entriesPayload->repository;
+	GTRepositoryEnumerateMergeHeadEntryBlock enumerationBlock = entriesPayload->enumerationBlock;
+
+	GTCommit *commit = [repository lookUpObjectByOID:[GTOID oidWithGitOid:oid] objectType:GTObjectTypeCommit error:NULL];
+
+	BOOL stop = NO;
+
+	enumerationBlock(commit, &stop);
+
+	return (stop == YES ? GIT_EUSER : 0);
+}
+
+- (BOOL)enumerateMergeHeadEntriesWithError:(NSError **)error usingBlock:(void (^)(GTCommit *mergeHeadEntry, BOOL *stop))block {
+	NSParameterAssert(block != nil);
+
+	GTEnumerateMergeHeadEntriesPayload payload = {
+		.repository = self,
+		.enumerationBlock = block,
+	};
+
+	int gitError = git_repository_mergehead_foreach(self.git_repository, GTMergeHeadEntriesCallback, &payload);
+
+	if (gitError != GIT_OK) {
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to get mergehead entries"];
+		return NO;
+	}
+
+	return YES;
+}
+
+- (NSArray *)mergeHeadEntriesWithError:(NSError **)error {
+	NSMutableArray *entries = [NSMutableArray array];
+
+	[self enumerateMergeHeadEntriesWithError:error usingBlock:^(GTCommit *mergeHeadEntry, BOOL *stop) {
+		[entries addObject:mergeHeadEntry];
+
+		*stop = NO;
+	}];
+
+	return entries;
+}
+
+@end

--- a/ObjectiveGit/GTRepository+Merging.m
+++ b/ObjectiveGit/GTRepository+Merging.m
@@ -67,4 +67,32 @@ int GTMergeHeadEntriesCallback(const git_oid *oid, void *payload) {
 	return entries;
 }
 
+- (BOOL)analyzeMerge:(GTMergeAnalysis *)analysis fromBranch:(GTBranch *)fromBranch error:(NSError **)error {
+	NSParameterAssert(analysis != NULL);
+	NSParameterAssert(fromBranch != nil);
+
+	GTCommit *fromCommit = [fromBranch targetCommitWithError:error];
+	if (!fromCommit) {
+		return NO;
+	}
+
+	git_annotated_commit *annotatedCommit;
+	[self annotatedCommit:&annotatedCommit fromCommit:fromCommit error:error];
+
+	// Allow fast-forward or normal merge
+	git_merge_preference_t preference = GIT_MERGE_PREFERENCE_NONE;
+
+	// Merge analysis
+	int gitError = git_merge_analysis((git_merge_analysis_t *)analysis, &preference, self.git_repository, (const git_annotated_commit **) &annotatedCommit, 1);
+	if (gitError != GIT_OK) {
+		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to analyze merge"];
+		return NO;
+	}
+
+	// Cleanup
+	git_annotated_commit_free(annotatedCommit);
+
+	return YES;
+}
+
 @end

--- a/ObjectiveGit/GTRepository+Pull.h
+++ b/ObjectiveGit/GTRepository+Pull.h
@@ -7,22 +7,8 @@
 //
 
 #import "GTRepository.h"
-#import "git2/merge.h"
 
 NS_ASSUME_NONNULL_BEGIN
-
-/// UserInfo key for conflicted files when pulling fails with a merge conflict
-extern NSString * const GTPullMergeConflictedFiles;
-
-/// An enum describing the result of the merge analysis.
-/// See `git_merge_analysis_t`.
-typedef NS_OPTIONS(NSInteger, GTMergeAnalysis) {
-	GTMergeAnalysisNone = GIT_MERGE_ANALYSIS_NONE,
-	GTMergeAnalysisNormal = GIT_MERGE_ANALYSIS_NORMAL,
-	GTMergeAnalysisUpToDate = GIT_MERGE_ANALYSIS_UP_TO_DATE,
-	GTMergeAnalysisUnborn = GIT_MERGE_ANALYSIS_UNBORN,
-	GTMergeAnalysisFastForward = GIT_MERGE_ANALYSIS_FASTFORWARD,
-};
 
 typedef void (^GTRemoteFetchTransferProgressBlock)(const git_transfer_progress *progress, BOOL *stop);
 
@@ -43,16 +29,6 @@ typedef void (^GTRemoteFetchTransferProgressBlock)(const git_transfer_progress *
 /// Returns YES if the pull was successful, NO otherwise (and `error`, if provided,
 /// will point to an error describing what happened).
 - (BOOL)pullBranch:(GTBranch *)branch fromRemote:(GTRemote *)remote withOptions:(nullable NSDictionary *)options error:(NSError **)error progress:(nullable GTRemoteFetchTransferProgressBlock)progressBlock;
-
-/// Analyze which merge to perform.
-///
-/// analysis   - The resulting analysis.
-/// fromBranch - The branch to merge from.
-/// error      - The error if one occurred. Can be NULL.
-///
-/// Returns YES if the analysis was successful, NO otherwise (and `error`, if provided,
-/// will point to an error describing what happened).
-- (BOOL)analyzeMerge:(GTMergeAnalysis *)analysis fromBranch:(GTBranch *)fromBranch error:(NSError **)error;
 
 @end
 

--- a/ObjectiveGit/GTRepository+Pull.m
+++ b/ObjectiveGit/GTRepository+Pull.m
@@ -163,33 +163,6 @@ NSString * const GTPullMergeConflictedFiles = @"GTPullMergeConflictedFiles";
 
 	return YES;
 }
-
-- (BOOL)analyzeMerge:(GTMergeAnalysis *)analysis fromBranch:(GTBranch *)fromBranch error:(NSError **)error {
-	NSParameterAssert(analysis != NULL);
-	NSParameterAssert(fromBranch != nil);
-
-	GTCommit *fromCommit = [fromBranch targetCommitWithError:error];
-	if (!fromCommit) {
-		return NO;
-	}
-
-	git_annotated_commit *annotatedCommit;
-	[self annotatedCommit:&annotatedCommit fromCommit:fromCommit error:error];
-
-	// Allow fast-forward or normal merge
-	git_merge_preference_t preference = GIT_MERGE_PREFERENCE_NONE;
-
-	// Merge analysis
-	int gitError = git_merge_analysis((git_merge_analysis_t *)analysis, &preference, self.git_repository, (const git_annotated_commit **) &annotatedCommit, 1);
-	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to analyze merge"];
-		return NO;
-	}
-
-	// Cleanup
-	git_annotated_commit_free(annotatedCommit);
-
-	return YES;
 }
 
 @end

--- a/ObjectiveGit/GTRepository+Pull.m
+++ b/ObjectiveGit/GTRepository+Pull.m
@@ -112,6 +112,10 @@ NSString * const GTPullMergeConflictedFiles = @"GTPullMergeConflictedFiles";
 			NSMutableArray <NSString *>*files = [NSMutableArray array];
 			[index enumerateConflictedFilesWithError:error usingBlock:^(GTIndexEntry * _Nonnull ancestor, GTIndexEntry * _Nonnull ours, GTIndexEntry * _Nonnull theirs, BOOL * _Nonnull stop) {
 				[files addObject:ours.path];
+
+				GTMergeFileResult *result = [index mergeIndexEntries:ancestor ours:ours theirs:theirs error:error];
+				NSURL *oursFileURL = [self.fileURL URLByAppendingPathComponent:result.path];
+				[result.contents writeToURL:oursFileURL atomically:YES encoding:NSUTF8StringEncoding error:error];
 			}];
 			if (error != NULL) {
 				NSDictionary *userInfo = @{GTPullMergeConflictedFiles: files};

--- a/ObjectiveGit/GTRepository+Pull.m
+++ b/ObjectiveGit/GTRepository+Pull.m
@@ -9,16 +9,10 @@
 #import "GTRepository+Pull.h"
 
 #import "GTCommit.h"
-#import "GTIndex.h"
-#import "GTOID.h"
-#import "GTRemote.h"
-#import "GTReference.h"
-#import "GTRepository+Committing.h"
 #import "GTRepository+RemoteOperations.h"
-#import "GTTree.h"
 #import "NSError+Git.h"
-#import "GTIndexEntry.h"
 #import "git2/errors.h"
+#import "GTRepository+Merging.h"
 
 NSString * const GTPullMergeConflictedFiles = @"GTPullMergeConflictedFiles";
 
@@ -55,114 +49,7 @@ NSString * const GTPullMergeConflictedFiles = @"GTPullMergeConflictedFiles";
 		trackingBranch = branch;
 	}
 
-	// Check if merge is necessary
-	GTBranch *localBranch = [repo currentBranchWithError:error];
-	if (!localBranch) {
-		return NO;
-	}
-
-	GTCommit *localCommit = [localBranch targetCommitWithError:error];
-	if (!localCommit) {
-		return NO;
-	}
-
-	GTCommit *remoteCommit = [trackingBranch targetCommitWithError:error];
-	if (!remoteCommit) {
-		return NO;
-	}
-
-	if ([localCommit.SHA isEqualToString:remoteCommit.SHA]) {
-		// Local and remote tracking branch are already in sync
-		return YES;
-	}
-
-	GTMergeAnalysis analysis = GTMergeAnalysisNone;
-	BOOL success = [self analyzeMerge:&analysis fromBranch:trackingBranch error:error];
-	if (!success) {
-		return NO;
-	}
-
-	if (analysis & GTMergeAnalysisUpToDate) {
-		// Nothing to do
-		return YES;
-	} else if (analysis & GTMergeAnalysisFastForward ||
-			   analysis & GTMergeAnalysisUnborn) {
-		// Fast-forward branch
-		NSString *message = [NSString stringWithFormat:@"merge %@/%@: Fast-forward", remote.name, trackingBranch.name];
-		GTReference *reference = [localBranch.reference referenceByUpdatingTarget:remoteCommit.SHA message:message error:error];
-		BOOL checkoutSuccess = [self checkoutReference:reference strategy:GTCheckoutStrategyForce error:error progressBlock:nil];
-
-		return checkoutSuccess;
-	} else if (analysis & GTMergeAnalysisNormal) {
-		// Do normal merge
-		GTTree *localTree = localCommit.tree;
-		GTTree *remoteTree = remoteCommit.tree;
-
-		// TODO: Find common ancestor
-		GTTree *ancestorTree = nil;
-
-		// Merge
-		GTIndex *index = [localTree merge:remoteTree ancestor:ancestorTree error:error];
-		if (!index) {
-			return NO;
-		}
-
-		// Check for conflict
-		if (index.hasConflicts) {
-			NSMutableArray <NSString *>*files = [NSMutableArray array];
-			[index enumerateConflictedFilesWithError:error usingBlock:^(GTIndexEntry * _Nonnull ancestor, GTIndexEntry * _Nonnull ours, GTIndexEntry * _Nonnull theirs, BOOL * _Nonnull stop) {
-				[files addObject:ours.path];
-			}];
-
-			if (error != NULL) {
-				NSDictionary *userInfo = @{GTPullMergeConflictedFiles: files};
-				*error = [NSError git_errorFor:GIT_ECONFLICT description:@"Merge conflict, Pull aborted." userInfo:userInfo failureReason:nil];
-			}
-
-			// Write conflicts
-			git_merge_options merge_opts = GIT_MERGE_OPTIONS_INIT;
-			git_checkout_options checkout_opts = GIT_CHECKOUT_OPTIONS_INIT;
-			checkout_opts.checkout_strategy = GIT_CHECKOUT_ALLOW_CONFLICTS;
-
-			git_annotated_commit *annotatedCommit;
-			[self annotatedCommit:&annotatedCommit fromCommit:remoteCommit error:error];
-
-			git_merge(repo.git_repository, (const git_annotated_commit **)&annotatedCommit, 1, &merge_opts, &checkout_opts);
-
-			return NO;
-		}
-
-		GTTree *newTree = [index writeTreeToRepository:repo error:error];
-		if (!newTree) {
-			return NO;
-		}
-
-		// Create merge commit
-		NSString *message = [NSString stringWithFormat:@"Merge branch '%@'", localBranch.shortName];
-		NSArray *parents = @[ localCommit, remoteCommit ];
-
-		// FIXME: This is stepping on the local tree
-		GTCommit *mergeCommit = [repo createCommitWithTree:newTree  message:message parents:parents updatingReferenceNamed:localBranch.name error:error];
-		if (!mergeCommit) {
-			return NO;
-		}
-
-		BOOL success = [self checkoutReference:localBranch.reference strategy:GTCheckoutStrategyForce error:error progressBlock:nil];
-		return success;
-	}
-
-	return NO;
-}
-
-- (BOOL)annotatedCommit:(git_annotated_commit **)annotatedCommit fromCommit:(GTCommit *)fromCommit error:(NSError **)error {
-	int gitError = git_annotated_commit_lookup(annotatedCommit, self.git_repository, fromCommit.OID.git_oid);
-	if (gitError != GIT_OK) {
-		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to lookup annotated commit for %@", fromCommit];
-		return NO;
-	}
-
-	return YES;
-}
+	return [repo mergeBranchIntoCurrentBranch:trackingBranch withError:error];
 }
 
 @end

--- a/ObjectiveGit/ObjectiveGit.h
+++ b/ObjectiveGit/ObjectiveGit.h
@@ -41,6 +41,7 @@ FOUNDATION_EXPORT const unsigned char ObjectiveGitVersionString[];
 #import <ObjectiveGit/GTRepository+RemoteOperations.h>
 #import <ObjectiveGit/GTRepository+Reset.h>
 #import <ObjectiveGit/GTRepository+Pull.h>
+#import <ObjectiveGit/GTRepository+Merging.h>
 #import <ObjectiveGit/GTEnumerator.h>
 #import <ObjectiveGit/GTCommit.h>
 #import <ObjectiveGit/GTCredential.h>

--- a/ObjectiveGitFramework.xcodeproj/project.pbxproj
+++ b/ObjectiveGitFramework.xcodeproj/project.pbxproj
@@ -63,6 +63,10 @@
 		23BB67BC1C7DF45300A37A66 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 23BB67BB1C7DF45300A37A66 /* libz.tbd */; };
 		23BB67C11C7DF60300A37A66 /* GTRepository+PullSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = F8EFA0361B405020000FF7D0 /* GTRepository+PullSpec.m */; };
 		23BB67C21C7DF60400A37A66 /* GTRepository+PullSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = F8EFA0361B405020000FF7D0 /* GTRepository+PullSpec.m */; };
+		23F39FAD1C86DB1C00849F3C /* GTRepository+Merging.h in Headers */ = {isa = PBXBuildFile; fileRef = 23F39FAB1C86DB1C00849F3C /* GTRepository+Merging.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		23F39FAE1C86DB1C00849F3C /* GTRepository+Merging.m in Sources */ = {isa = PBXBuildFile; fileRef = 23F39FAC1C86DB1C00849F3C /* GTRepository+Merging.m */; };
+		23F39FAF1C86DD0A00849F3C /* GTRepository+Merging.h in Headers */ = {isa = PBXBuildFile; fileRef = 23F39FAB1C86DB1C00849F3C /* GTRepository+Merging.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		23F39FB01C86E01800849F3C /* GTRepository+Merging.m in Sources */ = {isa = PBXBuildFile; fileRef = 23F39FAC1C86DB1C00849F3C /* GTRepository+Merging.m */; };
 		3011D86B1668E48500CE3409 /* GTDiffFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 3011D8691668E48500CE3409 /* GTDiffFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3011D86D1668E48500CE3409 /* GTDiffFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 3011D86A1668E48500CE3409 /* GTDiffFile.m */; };
 		3011D8711668E78500CE3409 /* GTDiffHunk.h in Headers */ = {isa = PBXBuildFile; fileRef = 3011D86F1668E78500CE3409 /* GTDiffHunk.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -444,6 +448,8 @@
 		20F43DE118A2F667007D3621 /* GTRepository+Blame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GTRepository+Blame.h"; sourceTree = "<group>"; };
 		20F43DE218A2F667007D3621 /* GTRepository+Blame.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "GTRepository+Blame.m"; sourceTree = "<group>"; };
 		23BB67BB1C7DF45300A37A66 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		23F39FAB1C86DB1C00849F3C /* GTRepository+Merging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GTRepository+Merging.h"; sourceTree = "<group>"; };
+		23F39FAC1C86DB1C00849F3C /* GTRepository+Merging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "GTRepository+Merging.m"; sourceTree = "<group>"; };
 		3011D8691668E48500CE3409 /* GTDiffFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GTDiffFile.h; sourceTree = "<group>"; };
 		3011D86A1668E48500CE3409 /* GTDiffFile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GTDiffFile.m; sourceTree = "<group>"; };
 		3011D86F1668E78500CE3409 /* GTDiffHunk.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GTDiffHunk.h; sourceTree = "<group>"; };
@@ -875,6 +881,8 @@
 				4DFFB15A183AA8D600D1565E /* GTRepository+RemoteOperations.m */,
 				88B2131A1B20E785005CF2C5 /* GTRepository+References.h */,
 				88B2131B1B20E785005CF2C5 /* GTRepository+References.m */,
+				23F39FAB1C86DB1C00849F3C /* GTRepository+Merging.h */,
+				23F39FAC1C86DB1C00849F3C /* GTRepository+Merging.m */,
 				BDD8AE6D13131B8800CB5D40 /* GTEnumerator.h */,
 				BDD8AE6E13131B8800CB5D40 /* GTEnumerator.m */,
 				BD6C22A71314625800992935 /* GTObject.h */,
@@ -1072,6 +1080,7 @@
 				79262F8B13C69B1600A4B1EA /* git2.h in Headers */,
 				88EB7E4D14AEBA600046FEA4 /* GTConfiguration.h in Headers */,
 				BDE4C064130EFE2C00851650 /* NSError+Git.h in Headers */,
+				23F39FAD1C86DB1C00849F3C /* GTRepository+Merging.h in Headers */,
 				55C8057D13875C11004DCB0F /* NSData+Git.h in Headers */,
 				D03B57A118BFFF07007124F4 /* GTDiffPatch.h in Headers */,
 				883CD6AB1600EBC600F57354 /* GTRemote.h in Headers */,
@@ -1108,6 +1117,7 @@
 				D01B6F2319F82F8700D411BC /* GTRepository+Reset.h in Headers */,
 				D01B6F2D19F82F8700D411BC /* GTEnumerator.h in Headers */,
 				D01B6F5519F82FA600D411BC /* GTReflog.h in Headers */,
+				23F39FAF1C86DD0A00849F3C /* GTRepository+Merging.h in Headers */,
 				D01B6F3519F82F8700D411BC /* GTBlob.h in Headers */,
 				D01B6F4D19F82F8700D411BC /* GTRemote.h in Headers */,
 				D01B6F1519F82F7B00D411BC /* NSData+Git.h in Headers */,
@@ -1427,6 +1437,7 @@
 				BDD8AE7013131B8800CB5D40 /* GTEnumerator.m in Sources */,
 				BD6C235313146E6600992935 /* GTCommit.m in Sources */,
 				30DCBA5E17B45213009B0EBD /* GTStatusDelta.m in Sources */,
+				23F39FAE1C86DB1C00849F3C /* GTRepository+Merging.m in Sources */,
 				30DCBA6517B45A78009B0EBD /* GTRepository+Status.m in Sources */,
 				BD6C235413146E6A00992935 /* GTObject.m in Sources */,
 				BD6C254613148DD300992935 /* GTSignature.m in Sources */,
@@ -1486,6 +1497,7 @@
 				D01B6F2E19F82F8700D411BC /* GTEnumerator.m in Sources */,
 				D01B6F4C19F82F8700D411BC /* GTConfiguration.m in Sources */,
 				D01B6F6619F82FA600D411BC /* GTRepository+Attributes.m in Sources */,
+				23F39FB01C86E01800849F3C /* GTRepository+Merging.m in Sources */,
 				D019778A19F8307600F523DA /* ObjectiveGit.m in Sources */,
 				D01B6F3219F82F8700D411BC /* GTCommit.m in Sources */,
 				D01B6F3819F82F8700D411BC /* GTTree.m in Sources */,

--- a/ObjectiveGitTests/GTRepository+PullSpec.m
+++ b/ObjectiveGitTests/GTRepository+PullSpec.m
@@ -260,7 +260,7 @@ describe(@"pull", ^{
 			expect(error.domain).to(equal(@"GTGitErrorDomain"));
 			expect(error.userInfo[GTPullMergeConflictedFiles]).to(equal(@[@"test.txt"]));
 			expect(fileContents).notTo(equal(@"TestLocal"));
-			expect([localRepo mergeHeadEntriesWithError:nil]).to(equal(@[remoteCommit]));
+			expect([localRepo mergeHeadEntriesWithError:nil]).to(equal(@[remoteCommit.OID]));
 			expect([localRepo preparedMessageWithError:nil]).to(beginWith(@"Merge commit"));
 			expect(error.localizedDescription).to(equal(@"Merge conflict"));
 			expect(@(transferProgressed)).to(beTruthy());

--- a/ObjectiveGitTests/GTRepository+PullSpec.m
+++ b/ObjectiveGitTests/GTRepository+PullSpec.m
@@ -262,7 +262,7 @@ describe(@"pull", ^{
 			expect(fileContents).notTo(equal(@"TestLocal"));
 			expect([localRepo mergeHeadEntriesWithError:nil]).to(equal(@[remoteCommit]));
 			expect([localRepo preparedMessageWithError:nil]).to(beginWith(@"Merge commit"));
-			expect(error.localizedDescription).to(equal(@"Merge conflict, Pull aborted."));
+			expect(error.localizedDescription).to(equal(@"Merge conflict"));
 			expect(@(transferProgressed)).to(beTruthy());
 		});
 

--- a/ObjectiveGitTests/GTRepository+PullSpec.m
+++ b/ObjectiveGitTests/GTRepository+PullSpec.m
@@ -255,9 +255,13 @@ describe(@"pull", ^{
 			BOOL result = [localRepo pullBranch:masterBranch fromRemote:remote withOptions:nil error:&error progress:^(const git_transfer_progress *progress, BOOL *stop) {
 				transferProgressed = YES;
 			}];
+			NSString *fileContents = [NSString stringWithContentsOfURL:[localRepo.fileURL URLByAppendingPathComponent:@"test.txt"] encoding:NSUTF8StringEncoding error:nil];
 			expect(@(result)).to(beFalsy());
 			expect(error.domain).to(equal(@"GTGitErrorDomain"));
 			expect(error.userInfo[GTPullMergeConflictedFiles]).to(equal(@[@"test.txt"]));
+			expect(fileContents).notTo(equal(@"TestLocal"));
+			expect([localRepo mergeHeadEntriesWithError:nil]).to(equal(@[remoteCommit]));
+			expect([localRepo preparedMessageWithError:nil]).to(beginWith(@"Merge commit"));
 			expect(error.localizedDescription).to(equal(@"Merge conflict, Pull aborted."));
 			expect(@(transferProgressed)).to(beTruthy());
 		});


### PR DESCRIPTION
This mimics the default `git` behaviour and writes the conflicted files down like this:

```
<<<<<HEAD
fksdjfa;lsdkjf;lads;afl
========
<<<<<<<<<4567dvssqw3124323
```

It also writes into `.git/MERGE_HEAD` the remote commit SHA, into `.git/MERGE_MSG` the correct merge message. It can then be pulled in the merge commit via `try repository.preparedMessage()`.

The merge head enumeration was added so the merge commit can pull all merge heads and use them as parent commits.