### PR TITLE
Add support for pruning and ignoring tags during fetch

### DIFF
--- a/ObjectiveGit/GTRepository+Pull.h
+++ b/ObjectiveGit/GTRepository+Pull.h
@@ -23,6 +23,8 @@ typedef void (^GTRemoteFetchTransferProgressBlock)(const git_transfer_progress *
 /// options       - Options applied to the fetch operation.
 ///                 Recognized options are:
 ///                 `GTRepositoryRemoteOptionsCredentialProvider`
+///                 `GTRepositoryRemoteOptionsFetchPrune`
+///                 `GTRepositoryRemoteOptionsDownloadTags`
 /// error         - The error if one occurred. Can be NULL.
 /// progressBlock - An optional callback for monitoring progress.
 ///

--- a/ObjectiveGit/GTRepository+RemoteOperations.h
+++ b/ObjectiveGit/GTRepository+RemoteOperations.h
@@ -7,6 +7,7 @@
 //
 
 #import "GTRepository.h"
+#import "git2/remote.h"
 
 @class GTFetchHeadEntry;
 
@@ -14,6 +15,20 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// A `GTCredentialProvider`, that will be used to authenticate against the remote.
 extern NSString *const GTRepositoryRemoteOptionsCredentialProvider;
+
+/// A `GTFetchPruneOption`, that will be used to determine if the fetch should prune or not.
+extern NSString *const GTRepositoryRemoteOptionsFetchPrune;
+
+/// A `GTRemoteAutoTagOption`, that will be used to determine how the fetch should handle tags.
+extern NSString *const GTRepositoryRemoteOptionsDownloadTags;
+
+/// An enum describing the data needed for pruning.
+/// See `git_fetch_prune_t`.
+typedef NS_ENUM(NSInteger, GTFetchPruneOption) {
+	GTFetchPruneOptionUnspecified = GIT_FETCH_PRUNE_UNSPECIFIED,
+	GTFetchPruneOptionYes = GIT_FETCH_PRUNE,
+	GTFetchPruneOptionNo = GIT_FETCH_NO_PRUNE,
+};
 
 @interface GTRepository (RemoteOperations)
 
@@ -25,6 +40,8 @@ extern NSString *const GTRepositoryRemoteOptionsCredentialProvider;
 /// options - Options applied to the fetch operation. May be nil.
 ///           Recognized options are :
 ///           `GTRepositoryRemoteOptionsCredentialProvider`
+///           `GTRepositoryRemoteOptionsFetchPrune`
+///           `GTRepositoryRemoteOptionsDownloadTags`
 /// error   - The error if one occurred. Can be NULL.
 /// progressBlock - Optional callback to receive fetch progress stats during the
 ///                 transfer. May be nil.

--- a/ObjectiveGit/GTRepository+RemoteOperations.m
+++ b/ObjectiveGit/GTRepository+RemoteOperations.m
@@ -23,6 +23,8 @@
 #import "git2/remote.h"
 
 NSString *const GTRepositoryRemoteOptionsCredentialProvider = @"GTRepositoryRemoteOptionsCredentialProvider";
+NSString *const GTRepositoryRemoteOptionsFetchPrune = @"GTRepositoryRemoteOptionsFetchPrune";
+NSString *const GTRepositoryRemoteOptionsDownloadTags = @"GTRepositoryRemoteOptionsDownloadTags";
 
 typedef void (^GTRemoteFetchTransferProgressBlock)(const git_transfer_progress *stats, BOOL *stop);
 typedef void (^GTRemotePushTransferProgressBlock)(unsigned int current, unsigned int total, size_t bytes, BOOL *stop);
@@ -80,6 +82,8 @@ int GTRemotePushTransferProgressCallback(unsigned int current, unsigned int tota
 
 	git_fetch_options fetchOptions = GIT_FETCH_OPTIONS_INIT;
 	fetchOptions.callbacks = remote_callbacks;
+	fetchOptions.prune = [options[GTRepositoryRemoteOptionsFetchPrune] unsignedIntValue];
+	fetchOptions.download_tags = [options[GTRepositoryRemoteOptionsDownloadTags] unsignedIntValue];
 
 	__block git_strarray refspecs;
 	int gitError = git_remote_get_fetch_refspecs(&refspecs, remote.git_remote);


### PR DESCRIPTION
This PR adds `GTRepositoryRemoteOptionsFetchPrune` and  `GTRepositoryRemoteOptionsDownloadTags ` to the recognised options during fetch and pull.
It also wraps `git_fetch_prune_t` in `GTFetchPruneOption`.