### PR TITLE
Ignore some more directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,11 @@ project.xcworkspace
 *.xccheckout
 *.xcscmblueprint
 
+ObjectiveGitTests/expecta/
 ObjectiveGitTests/fixtures/Fixtures/*
+ObjectiveGitTests/specta/
 
+External/Configuration
 External/ios-openssl/include
 External/ios-openssl/lib
 External/libssh2-ios


### PR DESCRIPTION
Adds the following to the ignore list:
- ObjectiveGitTests/expecta/
- ObjectiveGitTests/specta/
- External/Configuration

These untracked directories are causing objective-git to show as a "dirty" submodule for parent repositories.