### PR TITLE
Update libgit2 to 0.24.0

### DIFF
--- a/ObjectiveGit/GTRepository+RemoteOperations.m
+++ b/ObjectiveGit/GTRepository+RemoteOperations.m
@@ -226,7 +226,7 @@ int GTFetchHeadEntriesCallback(const char *ref_name, const char *remote_url, con
 	remote_callbacks.push_transfer_progress = GTRemotePushTransferProgressCallback;
 	remote_callbacks.payload = &connectionInfo,
 
-	gitError = git_remote_connect(remote.git_remote, GIT_DIRECTION_PUSH, &remote_callbacks);
+	gitError = git_remote_connect(remote.git_remote, GIT_DIRECTION_PUSH, &remote_callbacks, NULL);
 	if (gitError != GIT_OK) {
 		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to connect remote"];
 		return NO;


### PR DESCRIPTION
This updates `libgit2` to the latest release `v0.24.0`:

~~I had to disable `GIT_OPT_ENABLE_STRICT_OBJECT_CREATION` in these tests.~~

* ~~`[GTRemotePushSpec pushing__to_remote__can_push_one_commit]`~~
* ~~`[GTRemoteSpec network_operations____GTRepository_fetchRemote_withOptions_error_progress____brings_in_new_commits]`~~
* ~~`[GTRepositoryCommitting can_create_commits]`~~
* ~~`[GTRepositoryPullSpec pull__from_remote__fails_to_merge_when_there_is_a_conflict]`~~
* ~~`[GTTreeBuilderSpec GTTreeBuilder_building__should_write_new_blobs_when_the_tree_is_written]`~~

~~Now I am unsure if I should stick to [permanently disabling this](https://github.com/libgit2/objective-git/commit/c51e7387c4d53a1cc6dd44ad36338c9b98e8c1c3) or [just silence it for the tests](https://github.com/libgit2/objective-git/commit/cfe733ba32eb1df96eaedf822d1b63b160c1567d).~~