### PR TITLE
GTTreeBuilder: don't add blob data lazily

### DIFF
--- a/ObjectiveGitTests/GTTreeBuilderSpec.m
+++ b/ObjectiveGitTests/GTTreeBuilderSpec.m
@@ -103,19 +103,17 @@ describe(@"GTTreeBuilder building", ^{
 		expect(foundEntry.SHA).to(equal(entry.SHA));
 	});
 
-	it(@"should write new blobs when the tree is written", ^{
+	it(@"should be possible to write a blob with data", ^{
 		GTTreeEntry *entry = [builder addEntryWithData:[@"Hello, World!" dataUsingEncoding:NSUTF8StringEncoding] fileName:@"test.txt" fileMode:GTFileModeBlob error:NULL];
 		expect(entry).notTo(beNil());
 
 		GTObjectDatabase *database = [repo objectDatabaseWithError:NULL];
 		expect(database).notTo(beNil());
 
-		expect(@([database containsObjectWithOID:entry.OID])).to(beFalsy());
+		expect(@([database containsObjectWithOID:entry.OID])).to(beTruthy());
 
 		GTTree *tree = [builder writeTree:NULL];
 		expect(tree).notTo(beNil());
-
-		expect(@([database containsObjectWithOID:entry.OID])).to(beTruthy());
 	});
 
 	it(@"should be possible to write a builder to a repository", ^{


### PR DESCRIPTION
Add the blob data to the object database immediately in `[GTTreeBuilder addEntryWithData]`, instead of queueing it up.  This enables strict object validity checking, prevents us from hashing the file twice (once to compute the OID to give to `addEntryWithOID`, and again when adding to the object database) and reduces memory overhead.