### PR TITLE
Add clean_externals script

### DIFF
--- a/script/clean_externals
+++ b/script/clean_externals
@@ -1,0 +1,22 @@
+#!/bin/bash -ex
+
+#
+# clean_externals
+# ObjectiveGit
+#
+# Removes the outputs from the various static library targets.
+# Necessary when switching platforms/architectures as Xcode does not clean
+# these for you.
+#
+
+# A list of external static libraries included in the SwiftGit2 framework
+libraries=(
+    External/libgit2.a
+    External/libgit2-ios/libgit2-ios.a
+    External/libssh2-ios/lib/libssh2-ios.a
+    External/ios-openssl/lib/libssl.a
+    External/ios-openssl/lib/libcrypto.a
+    External/ios-openssl/include
+)
+
+rm -vrf "${libraries[@]}"


### PR DESCRIPTION
Little script to run by hand when changing the build process or updating external dependencies.