### PR TITLE
Exposing line info from git_diff_hunk in GTDiffHunk.

### DIFF
--- a/ObjectiveGit/GTDiffHunk.h
+++ b/ObjectiveGit/GTDiffHunk.h
@@ -22,6 +22,18 @@ NS_ASSUME_NONNULL_BEGIN
 /// The number of lines represented in the hunk.
 @property (nonatomic, readonly) NSUInteger lineCount;
 
+/// The starting line number in the old file
+@property (nonatomic, readonly) NSUInteger oldStart;
+
+/// The number of lines in the old file
+@property (nonatomic, readonly) NSUInteger oldLines;
+
+/// The starting line number in the new file
+@property (nonatomic, readonly) NSUInteger newStart;
+
+/// The number of lines in the new file
+@property (nonatomic, readonly) NSUInteger newLines;
+
 - (instancetype)init NS_UNAVAILABLE;
 
 /// Designated initialiser.

--- a/ObjectiveGit/GTDiffHunk.m
+++ b/ObjectiveGit/GTDiffHunk.m
@@ -40,6 +40,10 @@
 	int result = git_patch_get_hunk(&_git_hunk, &gitLineCount, patch.git_patch, hunkIndex);
 	if (result != GIT_OK) return nil;
 	_lineCount = gitLineCount;
+	_oldStart = self.git_hunk->old_start;
+	_oldLines = self.git_hunk->old_lines;
+	_newStart = self.git_hunk->new_start;
+	_newLines = self.git_hunk->new_lines;
 
 	_patch = patch;
 	_hunkIndex = hunkIndex;

--- a/ObjectiveGitTests/GTDiffSpec.m
+++ b/ObjectiveGitTests/GTDiffSpec.m
@@ -112,6 +112,10 @@ describe(@"GTDiff diffing", ^{
 			[patch enumerateHunksUsingBlock:^(GTDiffHunk *hunk, BOOL *stop) {
 				expect(hunk.header).to(equal(@"@@ -4,7 +4,7 @@"));
 				expect(@(hunk.lineCount)).to(equal(@8));
+				expect(@(hunk.oldStart)).to(equal(@4));
+				expect(@(hunk.oldLines)).to(equal(@7));
+				expect(@(hunk.newStart)).to(equal(@4));
+				expect(@(hunk.newLines)).to(equal(@7));
 
 				NSArray *expectedLines = @[ @"//",
 				@"//  Created by Joe Ricioppo on 9/29/10.",


### PR DESCRIPTION
I didn't see how to get at [these fields](https://github.com/libgit2/libgit2/blob/77394a27af283b366fa8bb444d29670131bfa104/include/git2/diff.h#L502-L505) in the underlying `git_diff_hunk`, so I copied them into obj-c properties on `GTDiffhunk`. I'm not really sure if that's the right way to do it–if you'd prefer I pass through to the `git_diff_hunk` or if there's some other way that I'm missing.

I updated the hunk-related spec in `GTDiffSpec.m` because I didn't see any test files dedicated specifically to `GTDiffHunk`. 