### PR TITLE
Make GTCredential from GTCredentialProviderBlock optional

### DIFF
--- a/ObjectiveGit/GTCredential.h
+++ b/ObjectiveGit/GTCredential.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// credentialBlock - a block that will be called when credentials are requested.
 ///                   Must not be nil.
-+ (instancetype)providerWithBlock:(GTCredential *(^)(GTCredentialType type, NSString *URL, NSString *userName))credentialBlock;
++ (instancetype)providerWithBlock:(GTCredential * _Nullable(^)(GTCredentialType type, NSString *URL, NSString *userName))credentialBlock;
 
 /// Default credential provider method.
 ///
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// type     - the credential types allowed by the operation.
 /// URL      - the URL the operation is authenticating against.
 /// userName - the user name provided by the operation. Can be nil, and might be ignored.
-- (GTCredential *)credentialForType:(GTCredentialType)type URL:(NSString *)URL userName:(nullable NSString *)userName;
+- (GTCredential * _Nullable)credentialForType:(GTCredentialType)type URL:(NSString *)URL userName:(nullable NSString *)userName;
 @end
 
 /// The GTCredential class is used to provide authentication data.

--- a/ObjectiveGit/GTCredential.m
+++ b/ObjectiveGit/GTCredential.m
@@ -12,7 +12,7 @@
 
 #import "git2/errors.h"
 
-typedef GTCredential * _Nullable (^GTCredentialProviderBlock)(GTCredentialType allowedTypes, NSString *URL, NSString *userName);
+typedef GTCredential *(^GTCredentialProviderBlock)(GTCredentialType allowedTypes, NSString *URL, NSString *userName);
 
 @interface GTCredentialProvider ()
 @property (nonatomic, readonly, copy) GTCredentialProviderBlock credBlock;
@@ -30,7 +30,7 @@ typedef GTCredential * _Nullable (^GTCredentialProviderBlock)(GTCredentialType a
 	return provider;
 }
 
-- (GTCredential * _Nullable)credentialForType:(GTCredentialType)type URL:(NSString *)URL userName:(NSString *)userName {
+- (GTCredential *)credentialForType:(GTCredentialType)type URL:(NSString *)URL userName:(NSString *)userName {
 	NSAssert(self.credBlock != nil, @"Provider asked for credentials without block being set.");
 
 	return self.credBlock(type, URL, userName);

--- a/ObjectiveGit/GTCredential.m
+++ b/ObjectiveGit/GTCredential.m
@@ -12,7 +12,7 @@
 
 #import "git2/errors.h"
 
-typedef GTCredential *(^GTCredentialProviderBlock)(GTCredentialType allowedTypes, NSString *URL, NSString *userName);
+typedef GTCredential * _Nullable (^GTCredentialProviderBlock)(GTCredentialType allowedTypes, NSString *URL, NSString *userName);
 
 @interface GTCredentialProvider ()
 @property (nonatomic, readonly, copy) GTCredentialProviderBlock credBlock;
@@ -30,7 +30,7 @@ typedef GTCredential *(^GTCredentialProviderBlock)(GTCredentialType allowedTypes
 	return provider;
 }
 
-- (GTCredential *)credentialForType:(GTCredentialType)type URL:(NSString *)URL userName:(NSString *)userName {
+- (GTCredential * _Nullable)credentialForType:(GTCredentialType)type URL:(NSString *)URL userName:(NSString *)userName {
 	NSAssert(self.credBlock != nil, @"Provider asked for credentials without block being set.");
 
 	return self.credBlock(type, URL, userName);


### PR DESCRIPTION
Currently the credential is enforced as non-optional by the swift compiler.
This means that there is no way for the user to abort a remote operation that demands a credential.