### PR TITLE
Add updatePushURLString:error: to GTRemote

### DIFF
--- a/ObjectiveGit/GTRemote.h
+++ b/ObjectiveGit/GTRemote.h
@@ -119,6 +119,16 @@ typedef enum {
 /// if updating or saving the remote failed.
 - (BOOL)updateURLString:(NSString *)URLString error:(NSError **)error;
 
+/// Updates the push URL string for this remote.
+///
+/// URLString - The URLString to update to. May not be nil.
+/// error     - If not NULL, this will be set to any error that occurs when
+///             updating the URLString or saving the remote.
+///
+/// Returns YES if the push URLString was successfully updated, NO and an error
+/// if updating or saving the remote failed.
+- (BOOL)updatePushURLString:(NSString *)URLString error:(NSError **)error;
+
 /// Adds a fetch refspec to this remote.
 ///
 /// fetchRefspec - The fetch refspec string to add. May not be nil.

--- a/ObjectiveGit/GTRemote.m
+++ b/ObjectiveGit/GTRemote.m
@@ -204,6 +204,21 @@ NSString * const GTRemoteRenameProblematicRefSpecs = @"GTRemoteRenameProblematic
 	return YES;
 }
 
+- (BOOL)updatePushURLString:(NSString *)URLString error:(NSError **)error {
+	NSParameterAssert(URLString != nil);
+	
+	if ([self.pushURLString isEqualToString:URLString]) return YES;
+	
+	int gitError = git_remote_set_pushurl(self.repository.git_repository, self.name.UTF8String, URLString.UTF8String);
+	if (gitError != GIT_OK) {
+		if (error != NULL) {
+			*error = [NSError git_errorFor:gitError description:@"Failed to update remote push URL string."];
+		}
+		return NO;
+	}
+	return YES;
+}
+
 - (BOOL)addFetchRefspec:(NSString *)fetchRefspec error:(NSError **)error {
 	NSParameterAssert(fetchRefspec != nil);
 

--- a/ObjectiveGitTests/GTRemoteSpec.m
+++ b/ObjectiveGitTests/GTRemoteSpec.m
@@ -62,7 +62,7 @@ describe(@"updating", ^{
 	});
 
 	it(@"push URL string", ^{
-		expect(remote.pushURLString).to(equal(@"git@github.com:github/Test_App.git"));
+		expect(remote.pushURLString).to(beNil());
 		
 		NSString *newURLString = @"https://github.com/github/Test_App.git";
 		

--- a/ObjectiveGitTests/GTRemoteSpec.m
+++ b/ObjectiveGitTests/GTRemoteSpec.m
@@ -61,6 +61,21 @@ describe(@"updating", ^{
 		expect(remote.URLString).to(equal(newURLString));
 	});
 
+	it(@"push URL string", ^{
+		expect(remote.pushURLString).to(equal(@"git@github.com:github/Test_App.git"));
+		
+		NSString *newURLString = @"https://github.com/github/Test_App.git";
+		
+		__block NSError *error = nil;
+		expect(@([remote updatePushURLString:newURLString error:&error])).to(beTruthy());
+		expect(error).to(beNil());
+		
+		// Reload remote from disk to pick up the change
+		remote = configuration.remotes[0];
+		
+		expect(remote.pushURLString).to(equal(newURLString));
+	});
+
 	it(@"fetch refspecs", ^{
 		expect(remote.fetchRefspecs).to(equal(@[ fetchRefspec ]));
 


### PR DESCRIPTION
This is to match `updateURLString:error:`. There is a a `setPushURLString:` but it ignores errors.

At the moment I'm not able to run the tests (see #584) so I'm counting on Travis...