### PR TITLE
Add some nullables to methods & properties that can return nil

### DIFF
--- a/ObjectiveGit/GTCredential.h
+++ b/ObjectiveGit/GTCredential.h
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// type     - the credential types allowed by the operation.
 /// URL      - the URL the operation is authenticating against.
 /// userName - the user name provided by the operation. Can be nil, and might be ignored.
-- (GTCredential * _Nullable)credentialForType:(GTCredentialType)type URL:(NSString *)URL userName:(nullable NSString *)userName;
+- (GTCredential * _Nullable)credentialForType:(GTCredentialType)type URL:(nullable NSString *)URL userName:(nullable NSString *)userName;
 @end
 
 /// The GTCredential class is used to provide authentication data.

--- a/ObjectiveGit/GTIndex.h
+++ b/ObjectiveGit/GTIndex.h
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// error      - If not NULL, set to any error that occurs.
 ///
 /// Returns the loaded index, or nil if an error occurred.
-+ (instancetype)indexWithFileURL:(NSURL *)fileURL repository:(GTRepository *)repository error:(NSError **)error;
++ (nullable instancetype)indexWithFileURL:(NSURL *)fileURL repository:(GTRepository *)repository error:(NSError **)error;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/ObjectiveGit/GTOID.h
+++ b/ObjectiveGit/GTOID.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface GTOID : NSObject <NSCopying>
 
 /// The SHA pointed to by the OID.
-@property (nonatomic, readonly, copy, nullable) NSString *SHA;
+@property (nonatomic, readonly, copy) NSString *SHA;
 
 /// Is the OID all zero? This usually indicates that the object has not been
 /// inserted into the ODB yet.

--- a/ObjectiveGit/GTOID.h
+++ b/ObjectiveGit/GTOID.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface GTOID : NSObject <NSCopying>
 
 /// The SHA pointed to by the OID.
-@property (nonatomic, readonly, copy) NSString *SHA;
+@property (nonatomic, readonly, copy, nullable) NSString *SHA;
 
 /// Is the OID all zero? This usually indicates that the object has not been
 /// inserted into the ODB yet.

--- a/ObjectiveGit/GTOID.m
+++ b/ObjectiveGit/GTOID.m
@@ -29,8 +29,8 @@
 - (NSString *)SHA {
 	char *SHA = git_oid_tostr_s(self.git_oid);
 	NSString *str = [[NSString alloc] initWithBytes:SHA
-																					 length:GIT_OID_HEXSZ
-																				 encoding:NSUTF8StringEncoding];
+                                             length:GIT_OID_HEXSZ
+                                           encoding:NSUTF8StringEncoding];
 	NSAssert(str != nil, @"Failed to create SHA string");
 	return str;
 }

--- a/ObjectiveGit/GTOID.m
+++ b/ObjectiveGit/GTOID.m
@@ -27,13 +27,11 @@
 }
 
 - (NSString *)SHA {
-	char *SHA = malloc(GIT_OID_HEXSZ);
-	NSAssert(SHA != NULL, @"Failed to malloc SHA string");
-
-	git_oid_fmt(SHA, self.git_oid);
-
-	NSString *str = [[NSString alloc] initWithBytesNoCopy:SHA length:GIT_OID_HEXSZ encoding:NSUTF8StringEncoding freeWhenDone:YES];
-	NSAssert(str != nil, @"Failed to allocate SHA string");
+	char *SHA = git_oid_tostr_s(self.git_oid);
+	NSString *str = [[NSString alloc] initWithBytes:SHA
+																					 length:GIT_OID_HEXSZ
+																				 encoding:NSUTF8StringEncoding];
+	NSAssert(str != nil, @"Failed to create SHA string");
 	return str;
 }
 

--- a/ObjectiveGit/GTOID.m
+++ b/ObjectiveGit/GTOID.m
@@ -28,12 +28,12 @@
 
 - (NSString *)SHA {
 	char *SHA = malloc(GIT_OID_HEXSZ);
-	if (SHA == NULL) return nil;
+	NSAssert(SHA != NULL, @"Failed to malloc SHA string");
 
 	git_oid_fmt(SHA, self.git_oid);
 
 	NSString *str = [[NSString alloc] initWithBytesNoCopy:SHA length:GIT_OID_HEXSZ encoding:NSUTF8StringEncoding freeWhenDone:YES];
-	if (str == nil) free(SHA);
+	NSAssert(str != nil, @"Failed to allocate SHA string");
 	return str;
 }
 

--- a/ObjectiveGit/GTReference.h
+++ b/ObjectiveGit/GTReference.h
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, strong) GTRepository *repository;
 @property (nonatomic, readonly) GTReferenceType referenceType;
 @property (nonatomic, readonly) const git_oid *git_oid;
-@property (nonatomic, strong, readonly) GTOID *OID;
+@property (nonatomic, strong, readonly, nullable) GTOID *OID;
 
 /// Whether this is a remote-tracking branch.
 @property (nonatomic, readonly, getter = isRemote) BOOL remote;
@@ -78,10 +78,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (git_reference *)git_reference __attribute__((objc_returns_inner_pointer));
 
 /// The target (either GTObject or GTReference) to which the reference points.
-@property (nonatomic, readonly, copy) id unresolvedTarget;
+@property (nonatomic, readonly, copy, nullable) id unresolvedTarget;
 
 /// The resolved object to which the reference points.
-@property (nonatomic, readonly, copy) id resolvedTarget;
+@property (nonatomic, readonly, copy, nullable) id resolvedTarget;
 
 /// The last direct reference in a chain
 @property (nonatomic, readonly, copy) GTReference *resolvedReference;

--- a/ObjectiveGit/GTRepository.h
+++ b/ObjectiveGit/GTRepository.h
@@ -167,7 +167,7 @@ typedef NS_ENUM(NSInteger, GTRepositoryStateType) {
 @interface GTRepository : NSObject
 
 /// The file URL for the repository's working directory.
-@property (nonatomic, readonly, strong) NSURL *fileURL;
+@property (nonatomic, readonly, strong, nullable) NSURL *fileURL;
 /// The file URL for the repository's .git directory.
 @property (nonatomic, readonly, strong, nullable) NSURL *gitDirectoryURL;
 

--- a/ObjectiveGit/GTRepository.h
+++ b/ObjectiveGit/GTRepository.h
@@ -167,6 +167,7 @@ typedef NS_ENUM(NSInteger, GTRepositoryStateType) {
 @interface GTRepository : NSObject
 
 /// The file URL for the repository's working directory.
+/// Returns nil for a bare repository.
 @property (nonatomic, readonly, strong, nullable) NSURL *fileURL;
 /// The file URL for the repository's .git directory.
 @property (nonatomic, readonly, strong, nullable) NSURL *gitDirectoryURL;

--- a/ObjectiveGit/GTSignature.h
+++ b/ObjectiveGit/GTSignature.h
@@ -42,10 +42,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, copy, nullable) NSString *email;
 
 /// The time when the action happened.
-@property (nonatomic, readonly, strong) NSDate *time;
+@property (nonatomic, readonly, strong, nullable) NSDate *time;
 
 /// The time zone that `time` should be interpreted relative to.
-@property (nonatomic, readonly, copy) NSTimeZone *timeZone;
+@property (nonatomic, readonly, copy, nullable) NSTimeZone *timeZone;
 
 /// Initializes the receiver with the given signature.
 ///


### PR DESCRIPTION
Xcode 8 now complains about methods and properties that return nil but are not declared `nullable`. This fixes all of those analyzer warnings.
