### PR TITLE
Split the OID lookup from the object lookup in GTEnumerator

### DIFF
--- a/ObjectiveGit/Categories/NSError+Git.h
+++ b/ObjectiveGit/Categories/NSError+Git.h
@@ -29,7 +29,11 @@
 
 #import <Foundation/Foundation.h>
 
+/// The error domain used by Objective-Git
 extern NSString * const GTGitErrorDomain;
+
+/// Error userinfo keys
+extern NSString * const GTGitErrorOID;
 
 @interface NSError (Git)
 

--- a/ObjectiveGit/Categories/NSError+Git.m
+++ b/ObjectiveGit/Categories/NSError+Git.m
@@ -31,6 +31,7 @@
 #import "git2/errors.h"
 
 NSString * const GTGitErrorDomain = @"GTGitErrorDomain";
+NSString * const GTGitErrorOID = @"GTOID";
 
 @implementation NSError (Git)
 

--- a/ObjectiveGit/GTEnumerator.h
+++ b/ObjectiveGit/GTEnumerator.h
@@ -117,6 +117,16 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns a (possibly empty) array of GTCommits, or nil if an error occurs.
 - (nullable NSArray<GTCommit *> *)allObjectsWithError:(NSError **)error;
 
+/// Get the next OID.
+///
+/// success - If not NULL, this will be set to whether getting the next object
+///           was successful. This will be YES if the receiver is exhausted, so
+///           it can be used to interpret the meaning of a nil return value.
+/// error   - If not NULL, set to any error that occurs during traversal.
+///
+/// Returns nil if an error occurs or the enumeration is done.
+- (nullable GTOID *)nextOIDWithSuccess:(nullable BOOL *)success error:(NSError **)error;
+
 /// Gets the next commit.
 ///
 /// success - If not NULL, this will be set to whether getting the next object

--- a/ObjectiveGit/GTRepository.m
+++ b/ObjectiveGit/GTRepository.m
@@ -290,7 +290,10 @@ static int remoteCreate(git_remote **remote, git_repository *repo, const char *n
 		if (error != NULL) {
 			char oid_str[GIT_OID_HEXSZ+1];
 			git_oid_tostr(oid_str, sizeof(oid_str), oid);
-			*error = [NSError git_errorFor:gitError description:@"Failed to lookup object %s in repository.", oid_str];
+			*error = [NSError git_errorFor:gitError
+							   description:@"Failed to lookup object"
+								  userInfo:@{GTGitErrorOID: [GTOID oidWithGitOid:oid]}
+							 failureReason:@"The object %s couldn't be found in the repository.", oid_str];
 		}
 		return nil;
 	}

--- a/ObjectiveGit/GTRepository.m
+++ b/ObjectiveGit/GTRepository.m
@@ -290,10 +290,7 @@ static int remoteCreate(git_remote **remote, git_repository *repo, const char *n
 		if (error != NULL) {
 			char oid_str[GIT_OID_HEXSZ+1];
 			git_oid_tostr(oid_str, sizeof(oid_str), oid);
-			*error = [NSError git_errorFor:gitError
-							   description:@"Failed to lookup object"
-								  userInfo:@{GTGitErrorOID: [GTOID oidWithGitOid:oid]}
-							 failureReason:@"The object %s couldn't be found in the repository.", oid_str];
+			*error = [NSError git_errorFor:gitError description:@"Failed to lookup object" userInfo:@{GTGitErrorOID: [GTOID oidWithGitOid:oid]} failureReason:@"The object %s couldn't be found in the repository.", oid_str];
 		}
 		return nil;
 	}


### PR DESCRIPTION
This is a first step toward handling shallow repositories, by separating the lookup done while enumerating.

Also provides the missing OID through the error.

Related to libgit2/libgit2#3058