### PR TITLE
Fix typo in GTRepositoryStashApplyProgress

### DIFF
--- a/ObjectiveGit/GTRepository+Stashing.h
+++ b/ObjectiveGit/GTRepository+Stashing.h
@@ -35,7 +35,7 @@ typedef NS_ENUM(NSInteger, GTRepositoryStashApplyProgress) {
 	GTRepositoryStashApplyProgressAnalyzeIndex = GIT_STASH_APPLY_PROGRESS_ANALYZE_INDEX,
 	GTRepositoryStashApplyProgressAnalyzeModified = GIT_STASH_APPLY_PROGRESS_ANALYZE_MODIFIED,
 	GTRepositoryStashApplyProgressAnalyzeUntracked = GIT_STASH_APPLY_PROGRESS_ANALYZE_UNTRACKED,
-	GTRepositoryStashApplyProgressGheckoutUntracked = GIT_STASH_APPLY_PROGRESS_CHECKOUT_UNTRACKED,
+	GTRepositoryStashApplyProgressCheckoutUntracked = GIT_STASH_APPLY_PROGRESS_CHECKOUT_UNTRACKED,
 	GTRepositoryStashApplyProgressCheckoutModified = GIT_STASH_APPLY_PROGRESS_CHECKOUT_MODIFIED,
 	GTRepositoryStashApplyProgressDone = GIT_STASH_APPLY_PROGRESS_DONE,
 };


### PR DESCRIPTION
Minor one. Fixing a typo in enum name:
`GTRepositoryStashApplyProgressGheckoutUntracked` -> `GTRepositoryStashApplyProgressСheckoutUntracked`