### PR TITLE
Fix mergeBranchIntoCurrentBranch: for conflicted state conditions

### DIFF
--- a/ObjectiveGit/GTRepository+Merging.m
+++ b/ObjectiveGit/GTRepository+Merging.m
@@ -139,7 +139,7 @@ int GTMergeHeadEntriesCallback(const git_oid *oid, void *payload) {
 			// Write conflicts
 			git_merge_options merge_opts = GIT_MERGE_OPTIONS_INIT;
 			git_checkout_options checkout_opts = GIT_CHECKOUT_OPTIONS_INIT;
-			checkout_opts.checkout_strategy = GIT_CHECKOUT_ALLOW_CONFLICTS;
+			checkout_opts.checkout_strategy = (GIT_CHECKOUT_SAFE | GIT_CHECKOUT_ALLOW_CONFLICTS);
 
 			git_annotated_commit *annotatedCommit;
 			[self annotatedCommit:&annotatedCommit fromCommit:remoteCommit error:error];

--- a/ObjectiveGit/GTRepository+Stashing.h
+++ b/ObjectiveGit/GTRepository+Stashing.h
@@ -35,7 +35,7 @@ typedef NS_ENUM(NSInteger, GTRepositoryStashApplyProgress) {
 	GTRepositoryStashApplyProgressAnalyzeIndex = GIT_STASH_APPLY_PROGRESS_ANALYZE_INDEX,
 	GTRepositoryStashApplyProgressAnalyzeModified = GIT_STASH_APPLY_PROGRESS_ANALYZE_MODIFIED,
 	GTRepositoryStashApplyProgressAnalyzeUntracked = GIT_STASH_APPLY_PROGRESS_ANALYZE_UNTRACKED,
-	GTRepositoryStashApplyProgressGheckoutUntracked = GIT_STASH_APPLY_PROGRESS_CHECKOUT_UNTRACKED,
+	GTRepositoryStashApplyProgressCheckoutUntracked = GIT_STASH_APPLY_PROGRESS_CHECKOUT_UNTRACKED,
 	GTRepositoryStashApplyProgressCheckoutModified = GIT_STASH_APPLY_PROGRESS_CHECKOUT_MODIFIED,
 	GTRepositoryStashApplyProgressDone = GIT_STASH_APPLY_PROGRESS_DONE,
 };


### PR DESCRIPTION
`checkout_opts` passed to libgit2 missed a `GIT_CHECKOUT_SAFE` strategy, causing a dry run and only conflicted files being written out to the tree (losing all other non-conflicted ones).

This is because libgit2 has a safeguard check in `git_merge` call, auto-adding `GIT_CHECKOUT_SAFE` when no `checkout_opts` where specified, but since the Objective-Git code specified `GIT_CHECKOUT_ALLOW_CONFLICTS` flag, it wasn't applied, causing the behaviour outlined above:

`checkout_strategy = given_checkout_opts ?
        given_checkout_opts->checkout_strategy :
        GIT_CHECKOUT_SAFE;`