### PR TITLE
Fix mergeBranchIntoCurrentBranch for conflicted state

### DIFF
--- a/ObjectiveGit/GTRepository+Merging.m
+++ b/ObjectiveGit/GTRepository+Merging.m
@@ -139,7 +139,7 @@ int GTMergeHeadEntriesCallback(const git_oid *oid, void *payload) {
 			// Write conflicts
 			git_merge_options merge_opts = GIT_MERGE_OPTIONS_INIT;
 			git_checkout_options checkout_opts = GIT_CHECKOUT_OPTIONS_INIT;
-			checkout_opts.checkout_strategy = GIT_CHECKOUT_ALLOW_CONFLICTS;
+			checkout_opts.checkout_strategy = (GIT_CHECKOUT_SAFE | GIT_CHECKOUT_ALLOW_CONFLICTS);
 
 			git_annotated_commit *annotatedCommit;
 			[self annotatedCommit:&annotatedCommit fromCommit:remoteCommit error:error];


### PR DESCRIPTION
`checkout_opts` passed to libgit2 missed a `GIT_CHECKOUT_SAFE` strategy, causing a dry run and only conflicted files being written out to the tree (losing all other non-conflicted ones).

This is because libgit2 has a safeguard check in `git_merge` call, auto-adding `GIT_CHECKOUT_SAFE` when no `checkout_opts` where specified, but since the Objective-Git code specified `GIT_CHECKOUT_ALLOW_CONFLICTS` flag, it wasn't applied, causing the behaviour outlined above:

`checkout_strategy = given_checkout_opts ?
        given_checkout_opts->checkout_strategy :
        GIT_CHECKOUT_SAFE;`