### PR TITLE
Add checkout strategy to stash apply/pop methods

### DIFF
--- a/ObjectiveGit/GTRepository+Stashing.h
+++ b/ObjectiveGit/GTRepository+Stashing.h
@@ -62,22 +62,22 @@ NS_ASSUME_NONNULL_BEGIN
 ///         will cause enumeration to stop after the block returns. Must not be nil.
 - (void)enumerateStashesUsingBlock:(void (^)(NSUInteger index, NSString * __nullable message, GTOID * __nullable oid, BOOL *stop))block;
 
-/// Apply stashed changes (with a default checkout strategy).
+/// Apply stashed changes.
 ///
 /// index         - The index of the stash to apply. 0 is the latest one.
 /// flags         - The flags to use when applying the stash.
-/// options       - The options to use when checking out.
+/// options       - The options to use when checking out (if nil, use the defaults provided by libgit2).
 /// error         - If not NULL, set to any error that occurred.
 /// progressBlock - A block that will be executed on each step of the stash application.
 ///
 /// Returns YES if the requested stash was successfully applied, NO otherwise.
 - (BOOL)applyStashAtIndex:(NSUInteger)index flags:(GTRepositoryStashApplyFlag)flags checkoutOptions:(nullable GTCheckoutOptions *)options error:(NSError **)error progressBlock:(nullable void (^)(GTRepositoryStashApplyProgress progress, BOOL *stop))progressBlock;
 
-/// Pop stashed changes (with a default checkout strategy).
+/// Pop stashed changes.
 ///
 /// index         - The index of the stash to apply. 0 is the most recent stash.
 /// flags         - The flags to use when applying the stash.
-/// options       - The options to use when checking out.
+/// options       - The options to use when checking out (if nil, use the defaults provided by libgit2).
 /// error         - If not NULL, set to any error that occurred.
 /// progressBlock - A block that will be executed on each step of the stash application.
 ///

--- a/ObjectiveGit/GTRepository+Stashing.h
+++ b/ObjectiveGit/GTRepository+Stashing.h
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///         will cause enumeration to stop after the block returns. Must not be nil.
 - (void)enumerateStashesUsingBlock:(void (^)(NSUInteger index, NSString * __nullable message, GTOID * __nullable oid, BOOL *stop))block;
 
-/// Apply stashed changes.
+/// Apply stashed changes (with a default checkout strategy).
 ///
 /// index - The index of the stash to apply. 0 is the latest one.
 /// flags - The flags to use when applying the stash.
@@ -71,7 +71,17 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns YES if the requested stash was successfully applied, NO otherwise.
 - (BOOL)applyStashAtIndex:(NSUInteger)index flags:(GTRepositoryStashApplyFlag)flags error:(NSError **)error progressBlock:(nullable void (^)(GTRepositoryStashApplyProgress progress, BOOL *stop))progressBlock;
 
-/// Pop stashed changes.
+/// Apply stashed changes with a set checkout strategy.
+///
+/// index       - The index of the stash to apply. 0 is the latest one.
+/// flags	    - The flags to use when applying the stash.
+/// strategy    - The checkout strategy to use when applying the stash.
+/// error       - If not NULL, set to any error that occurred.
+///
+/// Returns YES if the requested stash was successfully applied, NO otherwise.
+- (BOOL)applyStashAtIndex:(NSUInteger)index flags:(GTRepositoryStashApplyFlag)flags strategy:(GTCheckoutStrategyType)strategy error:(NSError **)error progressBlock:(nullable void (^)(GTRepositoryStashApplyProgress progress, BOOL *stop))progressBlock;
+
+/// Pop stashed changes (with a default checkout strategy).
 ///
 /// index - The index of the stash to apply. 0 is the most recent stash.
 /// flags - The flags to use when applying the stash.
@@ -79,6 +89,16 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// Returns YES if the requested stash was successfully applied, NO otherwise.
 - (BOOL)popStashAtIndex:(NSUInteger)index flags:(GTRepositoryStashApplyFlag)flags error:(NSError **)error progressBlock:(nullable void (^)(GTRepositoryStashApplyProgress progress, BOOL *stop))progressBlock;
+
+/// Pop stashed changes with a set checkout strategy.
+///
+/// index       - The index of the stash to apply. 0 is the most recent stash.
+/// flags       - The flags to use when applying the stash.
+/// strategy    - The checkout strategy to use when applying the stash.
+/// error       - If not NULL, set to any error that occurred.
+///
+/// Returns YES if the requested stash was successfully applied, NO otherwise.
+- (BOOL)popStashAtIndex:(NSUInteger)index flags:(GTRepositoryStashApplyFlag)flags strategy:(GTCheckoutStrategyType)strategy error:(NSError **)error progressBlock:(nullable void (^)(GTRepositoryStashApplyProgress progress, BOOL *stop))progressBlock;
 
 /// Drop a stash from the repository's list of stashes.
 ///

--- a/ObjectiveGit/GTRepository+Stashing.m
+++ b/ObjectiveGit/GTRepository+Stashing.m
@@ -60,9 +60,16 @@ static int stashApplyProgressCallback(git_stash_apply_progress_t progress, void 
 }
 
 - (BOOL)applyStashAtIndex:(NSUInteger)index flags:(GTRepositoryStashApplyFlag)flags error:(NSError **)error progressBlock:(nullable void (^)(GTRepositoryStashApplyProgress progress, BOOL *stop))progressBlock {
+	// GTCheckoutStrategyNone may sound odd at first, but this is what was passed in before (de-facto), and libgit2 has a sanity check to set it to GIT_CHECKOUT_SAFE if it's 0.
+	return [self applyStashAtIndex:index flags:flags strategy:GTCheckoutStrategyNone error:error progressBlock:progressBlock];
+}
+
+- (BOOL)applyStashAtIndex:(NSUInteger)index flags:(GTRepositoryStashApplyFlag)flags strategy:(GTCheckoutStrategyType)strategy error:(NSError **)error progressBlock:(nullable void (^)(GTRepositoryStashApplyProgress progress, BOOL *stop))progressBlock {
 	git_stash_apply_options stash_options = GIT_STASH_APPLY_OPTIONS_INIT;
 
 	stash_options.flags = (git_stash_apply_flags)flags;
+	stash_options.checkout_options.checkout_strategy = strategy;
+	
 	if (progressBlock != nil) {
 		stash_options.progress_cb = stashApplyProgressCallback;
 		stash_options.progress_payload = (__bridge void *)progressBlock;
@@ -77,9 +84,15 @@ static int stashApplyProgressCallback(git_stash_apply_progress_t progress, void 
 }
 
 - (BOOL)popStashAtIndex:(NSUInteger)index flags:(GTRepositoryStashApplyFlag)flags error:(NSError **)error progressBlock:(nullable void (^)(GTRepositoryStashApplyProgress progress, BOOL *stop))progressBlock {
+	// GTCheckoutStrategyNone may sound odd at first, but this is what was passed in before (de-facto), and libgit2 has a sanity check to set it to GIT_CHECKOUT_SAFE if it's 0.
+	return [self popStashAtIndex:index flags:flags strategy:GTCheckoutStrategyNone error:error progressBlock:progressBlock];
+}
+
+- (BOOL)popStashAtIndex:(NSUInteger)index flags:(GTRepositoryStashApplyFlag)flags strategy:(GTCheckoutStrategyType)strategy error:(NSError **)error progressBlock:(nullable void (^)(GTRepositoryStashApplyProgress progress, BOOL *stop))progressBlock {
 	git_stash_apply_options stash_options = GIT_STASH_APPLY_OPTIONS_INIT;
 
 	stash_options.flags = (git_stash_apply_flags)flags;
+	stash_options.checkout_options.checkout_strategy = strategy;
 	if (progressBlock != nil) {
 		stash_options.progress_cb = stashApplyProgressCallback;
 		stash_options.progress_payload = (__bridge void *)progressBlock;


### PR DESCRIPTION
For a finer control over the unstash process, propogate checkout strategy to Objective-Git from the underlying libgit2 stash methods by adding an extra `strategy` argument to `-[GTRepository applyStashAtIndex:…]` and  `-[GTRepository popStashAtIndex:…]`