### PR TITLE
Revert to "default enabled" behavior of checking out when cloning

### DIFF
--- a/ObjectiveGit/GTRepository.h
+++ b/ObjectiveGit/GTRepository.h
@@ -71,10 +71,10 @@ extern NSString * const GTRepositoryCloneOptionsBare;
 
 /// An `NSNumber` wrapped `BOOL`, if NO, don't checkout the remote HEAD.
 /// Default value is `YES`.
-extern NSString * const GTRepositoryCloneOptionsCheckout;
+extern NSString * const GTRepositoryCloneOptionsPerformCheckout;
 
 /// A `GTCheckoutOptions` object describing how to perform the checkout.
-extern NSString * const GTRepositoryCloneCheckoutOptions;
+extern NSString * const GTRepositoryCloneOptionsCheckoutOptions;
 
 /// A `GTCredentialProvider`, that will be used to authenticate against the
 /// remote.

--- a/ObjectiveGit/GTRepository.h
+++ b/ObjectiveGit/GTRepository.h
@@ -228,15 +228,14 @@ typedef NS_ENUM(NSInteger, GTRepositoryStateType) {
 /// options               - A dictionary consisting of the options:
 ///                         `GTRepositoryCloneOptionsTransportFlags`,
 ///                         `GTRepositoryCloneOptionsBare`,
-///                         `GTRepositoryCloneCheckoutOptions`,
+///                         `GTRepositoryCloneOptionsPerformCheckout`,
+///                         `GTRepositoryCloneOptionsCheckoutOptions`,
 ///                         `GTRepositoryCloneOptionsCredentialProvider`,
 ///                         `GTRepositoryCloneOptionsCloneLocal`,
 ///                         `GTRepositoryCloneOptionsServerCertificateURL`
 /// error                 - A pointer to fill in case of trouble.
 /// transferProgressBlock - This block is called with network transfer updates.
 ///                         May be NULL.
-/// checkoutProgressBlock - This block is called with checkout updates
-///                         (if `GTRepositoryCloneOptionsCheckout` is YES).
 ///                         May be NULL.
 ///
 /// returns nil (and fills the error parameter) if an error occurred, or a GTRepository object if successful.

--- a/ObjectiveGit/GTRepository.m
+++ b/ObjectiveGit/GTRepository.m
@@ -60,7 +60,8 @@
 #import "git2.h"
 
 NSString * const GTRepositoryCloneOptionsBare = @"GTRepositoryCloneOptionsBare";
-NSString * const GTRepositoryCloneCheckoutOptions = @"GTRepositoryCloneCheckoutOptions";
+NSString * const GTRepositoryCloneOptionsPerformCheckout = @"GTRepositoryCloneOptionsPerformCheckout";
+NSString * const GTRepositoryCloneOptionsCheckoutOptions = @"GTRepositoryCloneOptionsCheckoutOptions";
 NSString * const GTRepositoryCloneOptionsTransportFlags = @"GTRepositoryCloneOptionsTransportFlags";
 NSString * const GTRepositoryCloneOptionsCredentialProvider = @"GTRepositoryCloneOptionsCredentialProvider";
 NSString * const GTRepositoryCloneOptionsCloneLocal = @"GTRepositoryCloneOptionsCloneLocal";
@@ -248,7 +249,14 @@ struct GTRemoteCreatePayload {
 	NSNumber *bare = options[GTRepositoryCloneOptionsBare];
 	cloneOptions.bare = (bare == nil ? 0 : bare.boolValue);
 
-	GTCheckoutOptions *checkoutOptions = options[GTRepositoryCloneCheckoutOptions];
+	NSNumber *checkout = options[GTRepositoryCloneOptionsPerformCheckout];
+	BOOL doCheckout = (checkout != nil ? [checkout boolValue] : YES);
+
+	GTCheckoutOptions *checkoutOptions = options[GTRepositoryCloneOptionsCheckoutOptions];
+	if (checkoutOptions == nil && doCheckout) {
+		checkoutOptions = [GTCheckoutOptions checkoutOptionsWithStrategy:GTCheckoutStrategySafe];
+	}
+
 	if (checkoutOptions != nil) {
 		cloneOptions.checkout_opts = *(checkoutOptions.git_checkoutOptions);
 	}

--- a/ObjectiveGitTests/GTRepositorySpec.m
+++ b/ObjectiveGitTests/GTRepositorySpec.m
@@ -100,7 +100,7 @@ describe(@"+cloneFromURL:toWorkingDirectory:options:error:transferProgressBlock:
 
 			NSDictionary *cloneOptions = @{
 										   GTRepositoryCloneOptionsCloneLocal: @YES,
-										   GTRepositoryCloneCheckoutOptions: checkoutOptions,
+										   GTRepositoryCloneOptionsCheckoutOptions: checkoutOptions,
 										   };
 			repository = [GTRepository cloneFromURL:originURL toWorkingDirectory:workdirURL options:cloneOptions error:&error transferProgressBlock:transferProgressBlock];
 			expect(repository).notTo(beNil());
@@ -125,7 +125,7 @@ describe(@"+cloneFromURL:toWorkingDirectory:options:error:transferProgressBlock:
 			NSDictionary *options = @{
 									  GTRepositoryCloneOptionsBare: @YES,
 									  GTRepositoryCloneOptionsCloneLocal: @YES,
-									  GTRepositoryCloneCheckoutOptions: checkoutOptions,
+									  GTRepositoryCloneOptionsCheckoutOptions: checkoutOptions,
 									  };
 			repository = [GTRepository cloneFromURL:originURL toWorkingDirectory:workdirURL options:options error:&error transferProgressBlock:transferProgressBlock];
 			expect(repository).notTo(beNil());
@@ -147,7 +147,7 @@ describe(@"+cloneFromURL:toWorkingDirectory:options:error:transferProgressBlock:
 			GTCheckoutOptions *checkoutOptions = [GTCheckoutOptions checkoutOptionsWithStrategy:GTCheckoutStrategySafe];
 			checkoutOptions.progressBlock = checkoutProgressBlock;
 
-			repository = [GTRepository cloneFromURL:originURL toWorkingDirectory:workdirURL options:@{ GTRepositoryCloneCheckoutOptions: checkoutOptions } error:&error transferProgressBlock:transferProgressBlock];
+			repository = [GTRepository cloneFromURL:originURL toWorkingDirectory:workdirURL options:@{ GTRepositoryCloneOptionsCheckoutOptions: checkoutOptions } error:&error transferProgressBlock:transferProgressBlock];
 			expect(repository).notTo(beNil());
 			expect(error).to(beNil());
 
@@ -188,7 +188,7 @@ describe(@"+cloneFromURL:toWorkingDirectory:options:error:transferProgressBlock:
 				checkoutOptions.progressBlock = checkoutProgressBlock;
 				NSDictionary *cloneOptions = @{
 											   GTRepositoryCloneOptionsCredentialProvider: provider,
-											   GTRepositoryCloneCheckoutOptions: checkoutOptions,
+											   GTRepositoryCloneOptionsCheckoutOptions: checkoutOptions,
 											   };
 
 				repository = [GTRepository cloneFromURL:originURL toWorkingDirectory:workdirURL options:cloneOptions error:&error transferProgressBlock:transferProgressBlock];


### PR DESCRIPTION
This adds back a renamed version of the old BOOL options and sets a GTCheckoutOptions with sane defaults.

Fixes #618