### PR TITLE
-[GTNote target] -> -[GTNote targetOID]

### DIFF
--- a/ObjectiveGit/GTNote.h
+++ b/ObjectiveGit/GTNote.h
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Content of the note.
 @property (nonatomic, readonly, strong) NSString *note;
 
-@property (nonatomic, readonly, strong) GTObject *target;
+@property (nonatomic, readonly, strong) GTOID *targetOID;
 
 /// The underlying `git_note` object.
 - (git_note *)git_note __attribute__((objc_returns_inner_pointer));


### PR DESCRIPTION
Apparently messed this one up initially: the GTNote class itself defines a read-only accessor to `targetOID`, while public header defines a `target` property. Fixing the public header so it gets proper access to `targetOID`.