### PR TITLE
⬆️ Nimble (7.1.0)

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,4 +1,4 @@
 github "jspahrsummers/xcconfigs" "master"
 github "Quick/Quick" ~> 1.2.0
-github "Quick/Nimble" ~> 7.0.3
+github "Quick/Nimble" ~> 7.1.0
 github "ZipArchive/ZipArchive" ~> 2.1.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "Quick/Nimble" "v7.0.3"
+github "Quick/Nimble" "v7.1.0"
 github "Quick/Quick" "v1.2.0"
 github "ZipArchive/ZipArchive" "v2.1.2"
 github "jspahrsummers/xcconfigs" "bb795558a76e5daf3688500055bbcfe243bffa8d"


### PR DESCRIPTION
Nimble ([7.1.0](https://github.com/Quick/Nimble/releases/tag/v7.1.0)) came out just hours after I updated it in #651.