### PR TITLE
Fix bug in isValidRemoteName

### DIFF
--- a/ObjectiveGit/GTRemote.m
+++ b/ObjectiveGit/GTRemote.m
@@ -104,7 +104,7 @@ NSString * const GTRemoteRenameProblematicRefSpecs = @"GTRemoteRenameProblematic
 + (BOOL)isValidRemoteName:(NSString *)name {
 	NSParameterAssert(name != nil);
 
-	return git_remote_is_valid_name(name.UTF8String) == GIT_OK;
+	return (git_remote_is_valid_name(name.UTF8String) == 1 ? YES : NO);
 }
 
 #pragma mark Properties


### PR DESCRIPTION
According to the docs git_remote_is_valid_name returns either 1 (success) or 0.