### PR TITLE
Automatically package OpenSSL inside the framework

### DIFF
--- a/ObjectiveGitFramework.xcodeproj/project.pbxproj
+++ b/ObjectiveGitFramework.xcodeproj/project.pbxproj
@@ -1225,6 +1225,7 @@
 				79262F0F13C697BE00A4B1EA /* Copy git2 Headers */,
 				BEF7E4DF1A3A47450035BB8E /* Copy git2 Headers again */,
 				8DC2EF500486A6940098B216 /* Headers */,
+				4D751E9D215D765D003CD3CE /* Package external libraries */,
 			);
 			buildRules = (
 			);
@@ -1356,6 +1357,20 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		4D751E9D215D765D003CD3CE /* Package external libraries */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Package external libraries";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "./script/repackage-dylibs.rb";
+		};
 		6A28265317C69CB400C6A948 /* OpenSSL-iOS */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/ObjectiveGitFramework.xcodeproj/project.pbxproj
+++ b/ObjectiveGitFramework.xcodeproj/project.pbxproj
@@ -365,7 +365,6 @@
 		F8D1BDEF1B31FE7C00CDEC90 /* GTRepository+Pull.h in Headers */ = {isa = PBXBuildFile; fileRef = F8D1BDEC1B31FE7C00CDEC90 /* GTRepository+Pull.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F8D1BDF01B31FE7C00CDEC90 /* GTRepository+Pull.m in Sources */ = {isa = PBXBuildFile; fileRef = F8D1BDED1B31FE7C00CDEC90 /* GTRepository+Pull.m */; };
 		F8D1BDF11B31FE7C00CDEC90 /* GTRepository+Pull.m in Sources */ = {isa = PBXBuildFile; fileRef = F8D1BDED1B31FE7C00CDEC90 /* GTRepository+Pull.m */; };
-		F8D6384B207A618D00D1FD32 /* script in Resources */ = {isa = PBXBuildFile; fileRef = F8D6384A207A618D00D1FD32 /* script */; };
 		F8D6385C207AC74A00D1FD32 /* libiconv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = F8D6385B207AC74A00D1FD32 /* libiconv.tbd */; };
 		F8D6385D207AC75100D1FD32 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 23BB67BB1C7DF45300A37A66 /* libz.tbd */; };
 		F8D6385F207ACAE600D1FD32 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = F8D6385E207ACAE600D1FD32 /* libz.tbd */; };
@@ -1343,7 +1342,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				8DC2EF530486A6940098B216 /* InfoPlist.strings in Resources */,
-				F8D6384B207A618D00D1FD32 /* script in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/script/repackage-dylibs.rb
+++ b/script/repackage-dylibs.rb
@@ -1,0 +1,110 @@
+#!/usr/bin/ruby
+
+# This script looks up an executable's list of shared libraries, copies
+# non-standard ones (ie. anything not under /usr or /System/) into the target's
+# bundle and updates the executable install_name to point to the "packaged"
+# version.
+
+# Usage:
+# Add the script as a Run Script build phase in the target using Xcode.
+
+# FIXMEs:
+# - only handles dylibs
+# - only tested against a framework target
+# - doesn't care about codesigning
+
+
+require 'fileutils'
+require 'ostruct'
+
+def err(msg)
+  puts "error: " + msg
+  exit 1
+end
+
+def warn(msg)
+  puts "warning: " + msg
+end
+
+def note(msg)
+  puts "note: " + msg
+end
+
+envvars = %w(
+  TARGET_BUILD_DIR
+  EXECUTABLE_PATH
+  FRAMEWORKS_FOLDER_PATH
+)
+
+envvars.each do |var|
+  raise "Must be run in an Xcode Run Phase" unless ENV[var]
+  Kernel.const_set var, ENV[var]
+end
+
+TARGET_EXECUTABLE_PATH = File.join(TARGET_BUILD_DIR, EXECUTABLE_PATH)
+TARGET_FRAMEWORKS_PATH = File.join(TARGET_BUILD_DIR, FRAMEWORKS_FOLDER_PATH)
+
+def extract_link_dependencies
+  deps = `otool -L #{TARGET_EXECUTABLE_PATH}`
+
+  lines = deps.split("\n").map(&:strip)
+  lines.shift
+  lines.shift
+  lines.map do |dep|
+    path, compat, current = /^(.*) \(compatibility version (.*), current version (.*)\)$/.match(dep)[1..3]
+    err "Failed to parse #{dep}" if path.nil?
+
+    dep = OpenStruct.new
+    dep.install_name = path
+    dep.current_version = current
+    dep.compat_version = compat
+    dep.type = File.extname(path)
+    dep.name = File.basename(path)
+    dep.is_packaged = (dep.install_name =~ /^@rpath/)
+    dep.path = if dep.install_name =~ /^@rpath/
+      File.join(TARGET_FRAMEWORKS_PATH, dep.name)
+    else
+      dep.install_name
+    end
+
+    dep
+  end
+end
+
+def repackage_dependency(dep)
+  return if dep.is_packaged or dep.path =~ /^(\/usr\/lib|\/System\/Library)/
+
+  note "Packaging #{dep.name}…"
+
+  FileUtils.mkdir(TARGET_FRAMEWORKS_PATH) unless Dir.exist?(TARGET_FRAMEWORKS_PATH)
+
+  case dep.type
+  when ".dylib"
+    if File.exist?(File.join(TARGET_FRAMEWORKS_PATH, dep.name))
+      warn "#{dep.path} already in Frameworks directory, removing"
+      FileUtils.rm File.join(TARGET_FRAMEWORKS_PATH, dep.name)
+    end
+
+    note "Copying #{dep[:path]} to TARGET_FRAMEWORKS_PATH"
+    FileUtils.cp dep[:path], TARGET_FRAMEWORKS_PATH
+
+    out = `install_name_tool -change #{dep.path} "@rpath/#{dep.name}" #{TARGET_EXECUTABLE_PATH}`
+    if $? != 0
+      err "install_name_tool failed with error #{$?}:\n#{out}"
+    end
+
+    dep.path = File.join(TARGET_FRAMEWORKS_PATH, dep.name)
+    dep.install_name = "@rpath/#{dep.name}"
+    dep.is_packaged = true
+
+  else
+    warn "Unhandled type #{dep.type} for #{dep.path}, ignoring"
+  end
+end
+
+extract_link_dependencies.each do |dep|
+  repackage_dependency dep
+end
+
+note "Packaging done"
+exit 0

--- a/script/repackage-dylibs.rb
+++ b/script/repackage-dylibs.rb
@@ -79,23 +79,25 @@ def repackage_dependency(dep)
   note "Packaging #{dep.name}…"
 
   FileUtils.mkdir(TARGET_FRAMEWORKS_PATH) unless Dir.exist?(TARGET_FRAMEWORKS_PATH)
+  packaged_path = File.join(TARGET_FRAMEWORKS_PATH, dep.name)
 
   case dep.type
   when ".dylib"
-    if File.exist?(File.join(TARGET_FRAMEWORKS_PATH, dep.name))
+    if File.exist? packaged_path
       warn "#{dep.path} already in Frameworks directory, removing"
-      FileUtils.rm File.join(TARGET_FRAMEWORKS_PATH, dep.name)
+      FileUtils.rm packaged_path
     end
 
     note "Copying #{dep[:path]} to TARGET_FRAMEWORKS_PATH"
     FileUtils.cp dep[:path], TARGET_FRAMEWORKS_PATH
+    FileUtils.chmod "u=rw", packaged_path
 
     out = `install_name_tool -change #{dep.path} "@rpath/#{dep.name}" #{dep.executable}`
     if $? != 0
       err "install_name_tool failed with error #{$?}:\n#{out}"
     end
 
-    dep.path = File.join(TARGET_FRAMEWORKS_PATH, dep.name)
+    dep.path = packaged_path
     dep.install_name = "@rpath/#{dep.name}"
     dep.is_packaged = true
   else


### PR DESCRIPTION
As per the script's documentation :

> This script looks up an executable's list of shared libraries, copies
> non-standard ones (ie. anything not under /usr or /System/) into the target's
> bundle and updates the executable install_name to point to the "packaged"
> version.

In short, it will grab the Homebrew version of OpenSSL dylibs we're using and fixup the ObjectiveGit framework to use a copy of them.

It's 2018, that `install_name` should have been automated by now 😉.

Ref #667.