### PR TITLE
Don't put the private key in the error message

### DIFF
--- a/ObjectiveGit/GTCredential.m
+++ b/ObjectiveGit/GTCredential.m
@@ -77,7 +77,7 @@ typedef GTCredential *(^GTCredentialProviderBlock)(GTCredentialType allowedTypes
 	git_cred *cred;
 	int gitError = git_cred_ssh_key_memory_new(&cred, userName.UTF8String, publicKeyString.UTF8String, privateKeyString.UTF8String, passphrase.UTF8String);
 	if (gitError != GIT_OK) {
-		if (error) *error = [NSError git_errorFor:gitError description:@"Failed to create credentials object" failureReason:@"There was an error creating a credential object for username %@ with the provided public/private key pair.\nPublic key: %@\nPrivate key: %@", userName, publicKeyString, privateKeyString];
+		if (error) *error = [NSError git_errorFor:gitError description:@"Failed to create credentials object" failureReason:@"There was an error creating a credential object for username %@ with the provided public/private key pair.\nPublic key: %@", userName, publicKeyString];
 		return nil;
 	}
 	


### PR DESCRIPTION
Right now we're formatting the SSH private key as part of an NSError's description. This is **pretty bad**, because it might have been logged to the Console.