### PR TITLE
Fix nullability warnings introduced in Xcode 10

### DIFF
--- a/ObjectiveGit/GTBlameHunk.m
+++ b/ObjectiveGit/GTBlameHunk.m
@@ -39,7 +39,9 @@
 }
 
 - (NSString *)originalPath {
-	return @(self.git_blame_hunk.orig_path);
+	NSString *path = @(self.git_blame_hunk.orig_path);
+	NSAssert(path, @"string was nil");
+	return path;
 }
 
 - (BOOL)isBoundary {

--- a/ObjectiveGit/GTConfiguration.m
+++ b/ObjectiveGit/GTConfiguration.m
@@ -112,7 +112,10 @@
 static int configCallback(const git_config_entry *entry, void *payload) {
 	NSMutableArray *configurationKeysArray = (__bridge NSMutableArray *)payload;
 
-	[configurationKeysArray addObject:@(entry->name)];
+	NSString *name = @(entry->name);
+	NSCAssert(name, @"string was nil");
+
+	[configurationKeysArray addObject:name];
 
 	return 0;
 }

--- a/ObjectiveGit/GTDiffFile.m
+++ b/ObjectiveGit/GTDiffFile.m
@@ -22,8 +22,9 @@
 	self = [super init];
 	if (self == nil) return nil;
 
-	_path = @(file.path);
-	if (_path == nil) return nil;
+	NSString *path = @(file.path);
+	if (path == nil) return nil;
+	_path = path;
 
 	_git_diff_file = file;
 	_size = (NSUInteger)file.size;

--- a/ObjectiveGit/GTFilterSource.m
+++ b/ObjectiveGit/GTFilterSource.m
@@ -27,10 +27,13 @@
 	self = [super init];
 	if (self == nil) return nil;
 
-	const char *path = git_repository_workdir(git_filter_source_repo(source));
-	_repositoryURL = [NSURL fileURLWithPath:@(path)];
-	
-	_path = @(git_filter_source_path(source));
+	NSString *path = @(git_repository_workdir(git_filter_source_repo(source)));
+	NSAssert(path, @"workdir was nil");
+	_repositoryURL = [NSURL fileURLWithPath:path];
+
+	path = @(git_filter_source_path(source));
+	NSAssert(path, @"path was nil");
+	_path = path;
 
 	const git_oid *gitOid = git_filter_source_id(source);
 	if (gitOid != NULL) _OID = [[GTOID alloc] initWithGitOid:gitOid];

--- a/ObjectiveGit/GTIndexEntry.m
+++ b/ObjectiveGit/GTIndexEntry.m
@@ -74,7 +74,9 @@
 #pragma mark Properties
 
 - (NSString *)path {
-	return @(self.git_index_entry->path);
+	NSString *path = @(self.git_index_entry->path);
+	NSAssert(path, @"path is nil");
+	return path;
 }
 
 - (int)flags {

--- a/ObjectiveGit/GTNote.m
+++ b/ObjectiveGit/GTNote.m
@@ -42,7 +42,9 @@
 }
 
 - (NSString *)note {
-	return @(git_note_message(self.git_note));
+	NSString *message = @(git_note_message(self.git_note));
+	NSAssert(message, @"message is nil");
+	return message;
 }
 
 - (GTSignature *)author {

--- a/ObjectiveGit/GTReference.m
+++ b/ObjectiveGit/GTReference.m
@@ -118,10 +118,12 @@ static NSString *referenceTypeToString(GTReferenceType type) {
 }
 
 - (NSString *)name {
-	const char *refName = git_reference_name(self.git_reference);
-	NSAssert(refName != nil, @"Unexpected nil name");
+	const char *cRefName = git_reference_name(self.git_reference);
+	NSAssert(cRefName != nil, @"Unexpected nil name");
 
-	return @(refName);
+	NSString *refName = @(cRefName);
+	NSAssert(refName, @"refname is nil");
+	return refName;
 }
 
 - (GTReference *)referenceByRenaming:(NSString *)newName error:(NSError **)error {

--- a/ObjectiveGit/GTRepository+RemoteOperations.m
+++ b/ObjectiveGit/GTRepository+RemoteOperations.m
@@ -126,9 +126,15 @@ int GTFetchHeadEntriesCallback(const char *ref_name, const char *remote_url, con
 	GTRepository *repository = entriesPayload->repository;
 	GTRemoteEnumerateFetchHeadEntryBlock enumerationBlock = entriesPayload->enumerationBlock;
 
-	GTReference *reference = [repository lookUpReferenceWithName:@(ref_name) error:NULL];
+	NSString *refName = @(ref_name);
+	NSCAssert(refName, @"refName is nil");
 
-	GTFetchHeadEntry *entry = [[GTFetchHeadEntry alloc] initWithReference:reference remoteURLString:@(remote_url) targetOID:[GTOID oidWithGitOid:oid] isMerge:(BOOL)is_merge];
+	NSString *remoteURL = @(remote_url);
+	NSCAssert(remote_url, @"remoteURL is nil");
+
+	GTReference *reference = [repository lookUpReferenceWithName:refName error:NULL];
+
+	GTFetchHeadEntry *entry = [[GTFetchHeadEntry alloc] initWithReference:reference remoteURLString:remoteURL targetOID:[GTOID oidWithGitOid:oid] isMerge:(BOOL)is_merge];
 
 	BOOL stop = NO;
 

--- a/ObjectiveGit/GTRepository.m
+++ b/ObjectiveGit/GTRepository.m
@@ -637,18 +637,22 @@ static int GTRepositoryForeachTagCallback(const char *name, git_oid *oid, void *
 }
 
 - (NSURL *)fileURL {
-	const char *path = git_repository_workdir(self.git_repository);
+	const char *cPath = git_repository_workdir(self.git_repository);
 	// bare repository, you may be looking for gitDirectoryURL
-	if (path == NULL) return nil;
+	if (cPath == NULL) return nil;
 
-	return [NSURL fileURLWithPath:@(path) isDirectory:YES];
+	NSString *path = @(cPath);
+	NSAssert(path, @"workdir is nil");
+	return [NSURL fileURLWithPath:path isDirectory:YES];
 }
 
 - (NSURL *)gitDirectoryURL {
-	const char *path = git_repository_path(self.git_repository);
-	if (path == NULL) return nil;
+	const char *cPath = git_repository_path(self.git_repository);
+	if (cPath == NULL) return nil;
 
-	return [NSURL fileURLWithPath:@(path) isDirectory:YES];
+	NSString *path = @(cPath);
+	NSAssert(path, @"gitdirectory is nil");
+	return [NSURL fileURLWithPath:path isDirectory:YES];
 }
 
 - (BOOL)isBare {
@@ -737,7 +741,9 @@ static int submoduleEnumerationCallback(git_submodule *git_submodule, const char
 
 	NSError *error;
 	// Use -submoduleWithName:error: so that we get a git_submodule that we own.
-	GTSubmodule *submodule = [info->parentRepository submoduleWithName:@(name) error:&error];
+	NSString *submoduleName = @(name);
+	NSCAssert(submoduleName, @"submodule name is nil");
+	GTSubmodule *submodule = [info->parentRepository submoduleWithName:submoduleName error:&error];
 
 	BOOL stop = NO;
 	info->block(submodule, error, &stop);

--- a/ObjectiveGit/GTSubmodule.m
+++ b/ObjectiveGit/GTSubmodule.m
@@ -62,21 +62,30 @@
 	const char *cName = git_submodule_name(self.git_submodule);
 	NSAssert(cName != NULL, @"Unexpected nil submodule name");
 
-	return @(cName);
+	NSString *name = @(cName);
+	NSAssert(name, @"name is nil");
+
+	return name;
 }
 
 - (NSString *)path {
 	const char *cPath = git_submodule_path(self.git_submodule);
 	NSAssert(cPath != NULL, @"Unexpected nil submodule path");
 
-	return @(cPath);
+	NSString *path = @(cPath);
+	NSAssert(path, @"message is nil");
+
+	return path;
 }
 
 - (NSString *)URLString {
 	const char *cURL = git_submodule_url(self.git_submodule);
 	NSAssert(cURL != NULL, @"Unexpected nil submodule URL");
 
-	return @(cURL);
+	NSString *URL = @(cURL);
+	NSAssert(URL, @"URL is nil");
+
+	return URL;
 }
 
 #pragma mark Lifecycle

--- a/ObjectiveGit/GTTag.m
+++ b/ObjectiveGit/GTTag.m
@@ -47,11 +47,15 @@
 #pragma mark API
 
 - (NSString *)message {
-	return @(git_tag_message(self.git_tag));
+	NSString *message = @(git_tag_message(self.git_tag));
+	NSAssert(message, @"message is nil");
+	return message;
 }
 
 - (NSString *)name {
-	return @(git_tag_name(self.git_tag));
+	NSString *name = @(git_tag_name(self.git_tag));
+	NSAssert(name, @"message is nil");
+	return name;
 }
 
 - (GTObject *)target {

--- a/ObjectiveGit/GTTreeEntry.m
+++ b/ObjectiveGit/GTTreeEntry.m
@@ -94,7 +94,9 @@
 }
 
 - (NSString *)name {
-	return @(git_tree_entry_name(self.git_tree_entry));
+	NSString *name = @(git_tree_entry_name(self.git_tree_entry));
+	NSAssert(name, @"name was nil");
+	return name;
 }
 
 - (NSInteger)attributes {


### PR DESCRIPTION
This fixes a slew (37) of warnings caused by the analyzer noticing that `@()` can fail.