### PR TITLE
Fixes crash described by #689

### DIFF
--- a/ObjectiveGit/GTRepository.m
+++ b/ObjectiveGit/GTRepository.m
@@ -108,10 +108,10 @@ typedef struct {
 }
 
 - (void)dealloc {
-	if (_git_repository != NULL) {
+	if (_git_repository != NULL && _git_repository.workdir != NULL) {
 		git_repository_free(_git_repository);
-		_git_repository = NULL;
 	}
+	_git_repository = NULL;
 }
 
 #pragma mark API


### PR DESCRIPTION
When the system calls `-[GTRepository dealloc]` and the git_repository is empty, but still exists, the app crashes.

Here is a screenshot  of the debug session:
<img width="1680" alt="Capture d’écran 2019-05-16 à 20 27 09" src="https://user-images.githubusercontent.com/18022260/57853853-683f3880-7819-11e9-9d25-1bd15bb0a0a5.png">

To fix this, the function is simply checking if the `workdir` property of the `git_repository` object isn't empty before cleaning the repo.

This PR fixes #689