### PR TITLE
Removed `InfoPlist.strings` from disk, deleted `English.lproj` folder.

### DIFF
--- a/English.lproj/InfoPlist.strings
+++ b/English.lproj/InfoPlist.strings
@@ -1,2 +1,0 @@
-﻿/* Localized versions of Info.plist keys */
-

--- a/ObjectiveGit/GTBlob.m
+++ b/ObjectiveGit/GTBlob.m
@@ -84,7 +84,7 @@
 	NSParameterAssert(repository != nil);
 
 	git_oid oid;
-	int gitError = git_blob_create_frombuffer(&oid, repository.git_repository, [data bytes], data.length);
+	int gitError = git_blob_create_from_buffer(&oid, repository.git_repository, [data bytes], data.length);
 	if(gitError < GIT_OK) {
 		if(error != NULL) {
 			*error = [NSError git_errorFor:gitError description:@"Failed to create blob from NSData"];
@@ -100,7 +100,7 @@
 	NSParameterAssert(repository != nil);
 
 	git_oid oid;
-	int gitError = git_blob_create_fromdisk(&oid, repository.git_repository, [[file path] fileSystemRepresentation]);
+	int gitError = git_blob_create_from_disk(&oid, repository.git_repository, [[file path] fileSystemRepresentation]);
 	if(gitError < GIT_OK) {
 		if(error != NULL) {
 			*error = [NSError git_errorFor:gitError description:@"Failed to create blob from NSURL"];
@@ -137,7 +137,9 @@
 	NSCParameterAssert(path != nil);
 
 	git_buf buffer = GIT_BUF_INIT_CONST(0, NULL);
-	int gitError = git_blob_filtered_content(&buffer, self.git_blob, path.UTF8String, 1);
+
+	git_blob_filter_options opts = GIT_BLOB_FILTER_OPTIONS_INIT;
+	int gitError = git_blob_filter(&buffer, self.git_blob, path.UTF8String, &opts);
 	if (gitError != GIT_OK) {
 		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to apply filters for path %@ to blob", path];
 		return nil;

--- a/ObjectiveGit/GTCredential+Private.h
+++ b/ObjectiveGit/GTCredential+Private.h
@@ -27,4 +27,4 @@ typedef struct {
 	__unsafe_unretained GTCredentialProvider *credProvider;
 } GTCredentialAcquireCallbackInfo;
 
-int GTCredentialAcquireCallback(git_cred **cred, const char *url, const char *username_from_url, unsigned int allowed_types, void *payload);
+int GTCredentialAcquireCallback(git_credential **cred, const char *url, const char *username_from_url, unsigned int allowed_types, void *payload);

--- a/ObjectiveGit/GTCredential.h
+++ b/ObjectiveGit/GTCredential.h
@@ -12,9 +12,9 @@
 /// An enum describing the data needed for authentication.
 /// See `git_credtype_t`.
 typedef NS_ENUM(NSInteger, GTCredentialType) {
-    GTCredentialTypeUserPassPlaintext = GIT_CREDTYPE_USERPASS_PLAINTEXT,
-    GTCredentialTypeSSHKey = GIT_CREDTYPE_SSH_KEY,
-    GTCredentialTypeSSHCustom = GIT_CREDTYPE_SSH_CUSTOM,
+	GTCredentialTypeUserPassPlaintext = GIT_CREDENTIAL_USERPASS_PLAINTEXT,
+	GTCredentialTypeSSHKey = GIT_CREDENTIAL_SSH_KEY,
+	GTCredentialTypeSSHCustom = GIT_CREDENTIAL_SSH_CUSTOM,
 };
 
 NS_ASSUME_NONNULL_BEGIN
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 /// The GTCredential class is used to provide authentication data.
-/// It acts as a wrapper around `git_cred` objects.
+/// It acts as a wrapper around `git_credential` objects.
 @interface GTCredential : NSObject
 
 /// Create a credential object from a username/password pair.
@@ -86,8 +86,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// Return a new GTCredential instance, or nil if an error occurred
 + (instancetype _Nullable)credentialWithUserName:(NSString *)userName publicKeyString:(NSString * _Nullable)publicKeyString privateKeyString:(NSString *)privateKeyString passphrase:(NSString * _Nullable)passphrase error:(NSError **)error;
 
-/// The underlying `git_cred` object.
-- (git_cred *)git_cred __attribute__((objc_returns_inner_pointer));
+/// The underlying `git_credential` object.
+- (git_credential *)git_credential __attribute__((objc_returns_inner_pointer));
 
 @end
 

--- a/ObjectiveGit/GTCredential.m
+++ b/ObjectiveGit/GTCredential.m
@@ -39,14 +39,14 @@ typedef GTCredential *(^GTCredentialProviderBlock)(GTCredentialType allowedTypes
 @end
 
 @interface GTCredential ()
-@property (nonatomic, assign, readonly) git_cred *git_cred;
+@property (nonatomic, assign, readonly) git_credential *git_credential;
 @end
 
 @implementation GTCredential
 
 + (instancetype)credentialWithUserName:(NSString *)userName password:(NSString *)password error:(NSError **)error {
-	git_cred *cred;
-	int gitError = git_cred_userpass_plaintext_new(&cred, userName.UTF8String, password.UTF8String);
+	git_credential *cred;
+	int gitError = git_credential_userpass_plaintext_new(&cred, userName.UTF8String, password.UTF8String);
 	if (gitError != GIT_OK) {
 		if (error) *error = [NSError git_errorFor:gitError description:@"Failed to create credentials object" failureReason:@"There was an error creating a credential object for username %@.", userName];
 		return nil;
@@ -61,8 +61,8 @@ typedef GTCredential *(^GTCredentialProviderBlock)(GTCredentialType allowedTypes
 	NSString *privateKeyPath = privateKeyURL.filePathURL.path;
 	NSAssert(privateKeyPath != nil, @"Invalid file URL passed: %@", privateKeyURL);
 
-	git_cred *cred;
-	int gitError = git_cred_ssh_key_new(&cred, userName.UTF8String, publicKeyPath.fileSystemRepresentation, privateKeyPath.fileSystemRepresentation, passphrase.UTF8String);
+	git_credential *cred;
+	int gitError = git_credential_ssh_key_new(&cred, userName.UTF8String, publicKeyPath.fileSystemRepresentation, privateKeyPath.fileSystemRepresentation, passphrase.UTF8String);
 	if (gitError != GIT_OK) {
 		if (error) *error = [NSError git_errorFor:gitError description:@"Failed to create credentials object" failureReason:@"There was an error creating a credential object for username %@ with the provided public/private key pair.\nPublic key: %@\nPrivate key: %@", userName, publicKeyURL, privateKeyURL];
 		return nil;
@@ -74,8 +74,8 @@ typedef GTCredential *(^GTCredentialProviderBlock)(GTCredentialType allowedTypes
 + (instancetype)credentialWithUserName:(NSString *)userName publicKeyString:(NSString *)publicKeyString privateKeyString:(NSString *)privateKeyString passphrase:(NSString *)passphrase error:(NSError **)error {
 	NSParameterAssert(privateKeyString != nil);
 	
-	git_cred *cred;
-	int gitError = git_cred_ssh_key_memory_new(&cred, userName.UTF8String, publicKeyString.UTF8String, privateKeyString.UTF8String, passphrase.UTF8String);
+	git_credential *cred;
+	int gitError = git_credential_ssh_key_memory_new(&cred, userName.UTF8String, publicKeyString.UTF8String, privateKeyString.UTF8String, passphrase.UTF8String);
 	if (gitError != GIT_OK) {
 		if (error) *error = [NSError git_errorFor:gitError description:@"Failed to create credentials object" failureReason:@"There was an error creating a credential object for username %@ with the provided public/private key pair.\nPublic key: %@", userName, publicKeyString];
 		return nil;
@@ -84,21 +84,21 @@ typedef GTCredential *(^GTCredentialProviderBlock)(GTCredentialType allowedTypes
 	return [[self alloc] initWithGitCred:cred];
 }
 
-- (instancetype)initWithGitCred:(git_cred *)cred {
+- (instancetype)initWithGitCred:(git_credential *)cred {
 	NSParameterAssert(cred != nil);
 	self = [self init];
 
 	if (self == nil) return nil;
 
-	_git_cred = cred;
+	_git_credential = cred;
 
 	return self;
 }
 
 @end
 
-int GTCredentialAcquireCallback(git_cred **git_cred, const char *url, const char *username_from_url, unsigned int allowed_types, void *payload) {
-	NSCParameterAssert(git_cred != NULL);
+int GTCredentialAcquireCallback(git_credential **git_credential, const char *url, const char *username_from_url, unsigned int allowed_types, void *payload) {
+	NSCParameterAssert(git_credential != NULL);
 	NSCParameterAssert(payload != NULL);
 
 	GTCredentialAcquireCallbackInfo *info = payload;
@@ -118,6 +118,6 @@ int GTCredentialAcquireCallback(git_cred **git_cred, const char *url, const char
 		return GIT_ERROR;
 	}
 
-	*git_cred = cred.git_cred;
+	*git_credential = cred.git_credential;
 	return GIT_OK;
 }

--- a/ObjectiveGit/GTIndex.m
+++ b/ObjectiveGit/GTIndex.m
@@ -196,7 +196,7 @@ typedef BOOL (^GTIndexPathspecMatchedBlock)(NSString *matchedPathspec, NSString 
 	entry.path = [path cStringUsingEncoding:NSUTF8StringEncoding];
 	entry.mode = GIT_FILEMODE_BLOB;
 	
-	int status = git_index_add_frombuffer(self.git_index, &entry, [data bytes], [data length]);
+	int status = git_index_add_from_buffer(self.git_index, &entry, [data bytes], [data length]);
 	
 	if (status != GIT_OK) {
 		if (error != NULL) *error = [NSError git_errorFor:status description:@"Failed to add data with name %@ into index.", path];

--- a/ObjectiveGit/GTOID.m
+++ b/ObjectiveGit/GTOID.m
@@ -98,7 +98,7 @@
 }
 
 - (BOOL)isZero {
-	return git_oid_iszero(self.git_oid) != 0;
+	return git_oid_is_zero(self.git_oid) != 0;
 }
 
 #pragma mark NSObject

--- a/ObjectiveGit/GTRepository+Merging.m
+++ b/ObjectiveGit/GTRepository+Merging.m
@@ -20,7 +20,7 @@
 #import "GTOdbObject.h"
 #import "GTObjectDatabase.h"
 
-typedef void (^GTRemoteFetchTransferProgressBlock)(const git_transfer_progress *stats, BOOL *stop);
+typedef void (^GTRemoteFetchTransferProgressBlock)(const git_indexer_progress *stats, BOOL *stop);
 
 @implementation GTRepository (Merging)
 
@@ -181,7 +181,7 @@ int GTMergeHeadEntriesCallback(const git_oid *oid, void *payload) {
 
 	// initialize the ancestor's merge file input
 	git_merge_file_input ancestorInput;
-	int gitError = git_merge_file_init_input(&ancestorInput, GIT_MERGE_FILE_INPUT_VERSION);
+	int gitError = git_merge_file_input_init(&ancestorInput, GIT_MERGE_FILE_INPUT_VERSION);
 	if (gitError != GIT_OK) {
 		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to create merge file input for ancestor"];
 		return nil;
@@ -199,7 +199,7 @@ int GTMergeHeadEntriesCallback(const git_oid *oid, void *payload) {
 
 	// initialize our merge file input
 	git_merge_file_input ourInput;
-	gitError = git_merge_file_init_input(&ourInput, GIT_MERGE_FILE_INPUT_VERSION);
+	gitError = git_merge_file_input_init(&ourInput, GIT_MERGE_FILE_INPUT_VERSION);
 	if (gitError != GIT_OK) {
 		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to create merge file input for our side"];
 		return nil;
@@ -217,7 +217,7 @@ int GTMergeHeadEntriesCallback(const git_oid *oid, void *payload) {
 
 	// initialize their merge file input
 	git_merge_file_input theirInput;
-	gitError = git_merge_file_init_input(&theirInput, GIT_MERGE_FILE_INPUT_VERSION);
+	gitError = git_merge_file_input_init(&theirInput, GIT_MERGE_FILE_INPUT_VERSION);
 	if (gitError != GIT_OK) {
 		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to create merge file input other side"];
 		return nil;

--- a/ObjectiveGit/GTRepository+Pull.h
+++ b/ObjectiveGit/GTRepository+Pull.h
@@ -10,7 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void (^GTRemoteFetchTransferProgressBlock)(const git_transfer_progress *progress, BOOL *stop);
+typedef void (^GTRemoteFetchTransferProgressBlock)(const git_indexer_progress *progress, BOOL *stop);
 
 @interface GTRepository (Pull)
 

--- a/ObjectiveGit/GTRepository+RemoteOperations.h
+++ b/ObjectiveGit/GTRepository+RemoteOperations.h
@@ -51,7 +51,7 @@ typedef NS_ENUM(NSInteger, GTFetchPruneOption) {
 ///
 /// Returns YES if the fetch was successful, NO otherwise (and `error`, if provided,
 /// will point to an error describing what happened).
-- (BOOL)fetchRemote:(GTRemote *)remote withOptions:(NSDictionary * _Nullable)options error:(NSError **)error progress:(void (^ _Nullable)(const git_transfer_progress *stats, BOOL *stop))progressBlock;
+- (BOOL)fetchRemote:(GTRemote *)remote withOptions:(NSDictionary * _Nullable)options error:(NSError **)error progress:(void (^ _Nullable)(const git_indexer_progress *stats, BOOL *stop))progressBlock;
 
 /// Enumerate all available fetch head entries.
 ///

--- a/ObjectiveGit/GTRepository+RemoteOperations.m
+++ b/ObjectiveGit/GTRepository+RemoteOperations.m
@@ -30,7 +30,7 @@ NSString *const GTRepositoryRemoteOptionsFetchPrune = @"GTRepositoryRemoteOption
 NSString *const GTRepositoryRemoteOptionsDownloadTags = @"GTRepositoryRemoteOptionsDownloadTags";
 NSString *const GTRepositoryRemoteOptionsPushNotes = @"GTRepositoryRemoteOptionsPushNotes";
 
-typedef void (^GTRemoteFetchTransferProgressBlock)(const git_transfer_progress *stats, BOOL *stop);
+typedef void (^GTRemoteFetchTransferProgressBlock)(const git_indexer_progress *stats, BOOL *stop);
 typedef void (^GTRemotePushTransferProgressBlock)(unsigned int current, unsigned int total, size_t bytes, BOOL *stop);
 
 @implementation GTRepository (RemoteOperations)
@@ -45,7 +45,7 @@ typedef struct {
 	git_direction direction;
 } GTRemoteConnectionInfo;
 
-int GTRemoteFetchTransferProgressCallback(const git_transfer_progress *stats, void *payload) {
+int GTRemoteFetchTransferProgressCallback(const git_indexer_progress *stats, void *payload) {
 	GTRemoteConnectionInfo *info = payload;
 	BOOL stop = NO;
 
@@ -286,8 +286,7 @@ int GTFetchHeadEntriesCallback(const char *ref_name, const char *remote_url, con
 	};
 
 	git_push_options push_options = GIT_PUSH_OPTIONS_INIT;
-
-	gitError = git_push_init_options(&push_options, GIT_PUSH_OPTIONS_VERSION);
+	gitError = git_push_options_init(&push_options, GIT_PUSH_OPTIONS_VERSION);
 	if (gitError != GIT_OK) {
 		if (error != NULL) *error = [NSError git_errorFor:gitError description:@"Failed to init push options"];
 		return NO;

--- a/ObjectiveGit/GTRepository.h
+++ b/ObjectiveGit/GTRepository.h
@@ -239,7 +239,7 @@ typedef NS_ENUM(NSInteger, GTRepositoryStateType) {
 ///                         May be NULL.
 ///
 /// returns nil (and fills the error parameter) if an error occurred, or a GTRepository object if successful.
-+ (instancetype _Nullable)cloneFromURL:(NSURL *)originURL toWorkingDirectory:(NSURL *)workdirURL options:(NSDictionary * _Nullable)options error:(NSError **)error transferProgressBlock:(void (^ _Nullable)(const git_transfer_progress *, BOOL *stop))transferProgressBlock;
++ (instancetype _Nullable)cloneFromURL:(NSURL *)originURL toWorkingDirectory:(NSURL *)workdirURL options:(NSDictionary * _Nullable)options error:(NSError **)error transferProgressBlock:(void (^ _Nullable)(const git_indexer_progress *, BOOL *stop))transferProgressBlock;
 
 /// Lookup objects in the repo by oid or sha1
 - (id _Nullable)lookUpObjectByOID:(GTOID *)oid objectType:(GTObjectType)type error:(NSError **)error;

--- a/ObjectiveGit/GTRepository.m
+++ b/ObjectiveGit/GTRepository.m
@@ -214,9 +214,9 @@ typedef struct {
 }
 
 
-typedef void(^GTTransferProgressBlock)(const git_transfer_progress *progress, BOOL *stop);
+typedef void(^GTTransferProgressBlock)(const git_indexer_progress *progress, BOOL *stop);
 
-static int transferProgressCallback(const git_transfer_progress *progress, void *payload) {
+static int transferProgressCallback(const git_indexer_progress *progress, void *payload) {
 	if (payload == NULL) return 0;
 	struct GTClonePayload *pld = payload;
 	if (pld->transferProgressBlock == NULL) return 0;
@@ -244,7 +244,7 @@ struct GTRemoteCreatePayload {
 	git_remote_callbacks remoteCallbacks;
 };
 
-+ (instancetype _Nullable)cloneFromURL:(NSURL *)originURL toWorkingDirectory:(NSURL *)workdirURL options:(NSDictionary * _Nullable)options error:(NSError **)error transferProgressBlock:(void (^ _Nullable)(const git_transfer_progress *, BOOL *stop))transferProgressBlock {
++ (instancetype _Nullable)cloneFromURL:(NSURL *)originURL toWorkingDirectory:(NSURL *)workdirURL options:(NSDictionary * _Nullable)options error:(NSError **)error transferProgressBlock:(void (^ _Nullable)(const git_indexer_progress *, BOOL *stop))transferProgressBlock {
 
 	git_clone_options cloneOptions = GIT_CLONE_OPTIONS_INIT;
 

--- a/ObjectiveGitFramework.xcodeproj/project.pbxproj
+++ b/ObjectiveGitFramework.xcodeproj/project.pbxproj
@@ -159,7 +159,6 @@
 		88F6D9FA1320467100CC0BA8 /* GTCommit.h in Headers */ = {isa = PBXBuildFile; fileRef = BD6C22A41314609A00992935 /* GTCommit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		88F6D9FB1320467500CC0BA8 /* GTObject.h in Headers */ = {isa = PBXBuildFile; fileRef = BD6C22A71314625800992935 /* GTObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		88F6D9FC1320467800CC0BA8 /* GTSignature.h in Headers */ = {isa = PBXBuildFile; fileRef = BD6C254313148DC900992935 /* GTSignature.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8DC2EF530486A6940098B216 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C1666FE841158C02AAC07 /* InfoPlist.strings */; };
 		8DC2EF570486A6940098B216 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7B1FEA5585E11CA2CBB /* Cocoa.framework */; };
 		AA046112134F4D2000DF526B /* GTOdbObject.h in Headers */ = {isa = PBXBuildFile; fileRef = AA046110134F4D2000DF526B /* GTOdbObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA046114134F4D2000DF526B /* GTOdbObject.m in Sources */ = {isa = PBXBuildFile; fileRef = AA046111134F4D2000DF526B /* GTOdbObject.m */; };
@@ -452,7 +451,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		089C1667FE841158C02AAC07 /* English */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = English; path = English.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		1058C7B1FEA5585E11CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		200578C418932A82001C06C3 /* GTBlameSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GTBlameSpec.m; sourceTree = "<group>"; };
 		2089E43B17D9A58000F451DA /* GTTagSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GTTagSpec.m; sourceTree = "<group>"; };
@@ -777,7 +775,6 @@
 			isa = PBXGroup;
 			children = (
 				8DC2EF5A0486A6940098B216 /* Info.plist */,
-				089C1666FE841158C02AAC07 /* InfoPlist.strings */,
 			);
 			name = Resources;
 			sourceTree = "<group>";
@@ -1342,7 +1339,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8DC2EF530486A6940098B216 /* InfoPlist.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1679,17 +1675,6 @@
 			targetProxy = F879D83D1B4B7F7D002D5C07 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
-
-/* Begin PBXVariantGroup section */
-		089C1666FE841158C02AAC07 /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				089C1667FE841158C02AAC07 /* English */,
-			);
-			name = InfoPlist.strings;
-			sourceTree = "<group>";
-		};
-/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		1DEB91AE08733DA50010E9CD /* Debug */ = {


### PR DESCRIPTION
`InfoPlist.strings` was empty, so it wasn’t doing anything. Further, it didn’t really have anything it COULD do — there are no user-facing strings in the Info.plist of a framework.

In modern Xcodes (eg, 11+) `English.lproj` has been deprecated (for `en.lproj` or even `Base.lproj` now) so just having this useless strings file was causing a warning to show during builds.

Not a big deal, but I figure this simplifies the code base so why not pull it back.

Yours,
-Wil Shipley